### PR TITLE
Fix $SHELL Makefile variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 RUST_LOG ?= prusti=info
 RUST_TEST_THREADS ?= 1
 JAVA_HOME ?= /usr/lib/jvm/default-java


### PR DESCRIPTION
This is just a small nit to help the build system work on niche Linux setups (like mine).

On some Unix's (specifically NixOS), bash is not in `/bin/bash` (which is actually _not_ a standard POSIX requirement), so use the standard `/usr/bin/env bash` instead.