### PR TITLE
Trait specification refinement

### DIFF
--- a/prusti-interface/src/specifications.rs
+++ b/prusti-interface/src/specifications.rs
@@ -196,7 +196,7 @@ pub enum AssertionKind<ET, AT> {
     /// Conjunction &&.
     And(Vec<Assertion<ET, AT>>),
     /// Implication ==>
-    Implies(Expression<ET>, Assertion<ET, AT>),
+    Implies(Assertion<ET, AT>, Assertion<ET, AT>),
     /// TODO < Even > ==> x % 2 == 0
     TypeCond(ForAllVars<AT>, Assertion<ET, AT>),
     /// Quantifier (forall vars :: {triggers} filter ==> body)
@@ -289,7 +289,7 @@ impl TypedAssertion {
                     })
             }
             AssertionKind::Implies(ref lhs, ref rhs) => {
-                let mut spans = vec![lhs.expr.span.clone()];
+                let mut spans = lhs.get_spans();
                 spans.extend(rhs.get_spans());
                 spans
             }

--- a/prusti-viper/src/encoder/borrows.rs
+++ b/prusti-viper/src/encoder/borrows.rs
@@ -88,7 +88,7 @@ where
     /// TODO: Implement support for `blocked_lifetimes` via nested magic wands.
     pub borrow_infos: Vec<BorrowInfo<P>>,
     /// The functional specification: precondition and postcondition
-    specification: TypedSpecificationSet,
+    pub specification: TypedSpecificationSet,
 }
 
 impl<L: fmt::Debug, P: fmt::Debug> ProcedureContractGeneric<L, P> {

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -808,6 +808,7 @@ impl<'v, 'r, 'a, 'tcx> Encoder<'v, 'r, 'a, 'tcx> {
         encoded_return: Option<&vir::Expr>,
         targets_are_values: bool,
         stop_at_bbi: Option<mir::BasicBlock>,
+        error: ErrorCtxt,
     ) -> vir::Expr {
         let spec_encoder = SpecEncoder::new(
             self,
@@ -820,7 +821,7 @@ impl<'v, 'r, 'a, 'tcx> Encoder<'v, 'r, 'a, 'tcx> {
         );
         spec_encoder.encode_assertion(assertion).set_default_pos(
             self.error_manager()
-                .register(assertion.get_spans(), ErrorCtxt::GenericExpression),
+                .register(assertion.get_spans(), error),
         )
     }
 

--- a/prusti-viper/src/encoder/error_manager/mod.rs
+++ b/prusti-viper/src/encoder/error_manager/mod.rs
@@ -79,6 +79,12 @@ pub enum ErrorCtxt {
     DivergingCallInPureFunction,
     /// A Viper pure function call with `false` precondition that encodes a Rust panic in a pure function
     PanicInPureFunction(PanicCause),
+    /// A Viper `assert e1 ==> e2` that encodes a weakening of the precondition
+    /// of a method implementation of a trait
+    AssertMethodPreconditionWeakening,
+    /// A Viper `assert e1 ==> e2` that encodes a strengthening of the precondition
+    /// of a method implementation of a trait
+    AssertMethodPostconditionStrengthening,
 }
 
 /// The Rust error that will be reported from the compiler
@@ -446,6 +452,18 @@ impl<'tcx> ErrorManager<'tcx> {
                     format!("implicit type invariants might not hold at the end of the method."),
                     error_span
                 ).set_failing_assertion(opt_cause_span)
+            }
+
+            ("assert.failed:assertion.false", ErrorCtxt::AssertMethodPreconditionWeakening) => {
+                CompilerError::new(format!("precondition may not be a valid weakening."), error_span)
+                    .set_failing_assertion(opt_cause_span)
+                    .set_help("The trait's preconditions must imply (==>) the implemented method's preconditions.")
+            }
+
+            ("assert.failed:assertion.false", ErrorCtxt::AssertMethodPostconditionStrengthening) => {
+                CompilerError::new(format!("postcondition may not be a valid strengthening."), error_span)
+                    .set_failing_assertion(opt_cause_span)
+                    .set_help("The implemented method's postcondition must imply (==>) the trait's postcondition.")
             }
 
             (full_err_id, ErrorCtxt::Unexpected) => {

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2302,7 +2302,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
             self.cfg_method
                 .add_stmt(
                     start_cfg_block,
-                    vir::Stmt::Assert(weakening_spec, FoldingBehaviour::None, pos)
+                    vir::Stmt::Assert(weakening_spec, FoldingBehaviour::Expr, pos)
                 );
         }
         self.cfg_method
@@ -2923,7 +2923,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
             self.cfg_method
                 .add_stmt(
                     return_cfg_block,
-                    vir::Stmt::Assert(patched_strengthening_spec, FoldingBehaviour::None, pos)
+                    vir::Stmt::Assert(patched_strengthening_spec, FoldingBehaviour::Expr, pos)
                 );
         }
         // Assert functional specification of postcondition

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2242,6 +2242,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                 None,
                 false,
                 None,
+                ErrorCtxt::GenericExpression,
             );
             //warn!("after:  {:?}", &value);
             func_spec.push(value);
@@ -2255,6 +2256,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                 None,
                 false,
                 None,
+                ErrorCtxt::AssertMethodPreconditionWeakening
             ));
         (
             type_spec.into_iter().conjoin(),
@@ -2385,6 +2387,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                     Some(&encoded_return),
                     false,
                     None,
+                    ErrorCtxt::GenericExpression,
                 );
                 let mut assertion_rhs = self.encoder.encode_assertion(
                     &body_rhs,
@@ -2394,6 +2397,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                     Some(&encoded_return),
                     false,
                     None,
+                    ErrorCtxt::GenericExpression,
                 );
                 assertion_lhs =
                     self.wrap_arguments_into_old(assertion_lhs, pre_label, contract, &encoded_args);
@@ -2568,6 +2572,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                 Some(&encoded_return),
                 false,
                 None,
+                ErrorCtxt::GenericExpression,
             );
             func_spec_spans.extend(item.assertion.get_spans());
             assertion = self.wrap_arguments_into_old(assertion, pre_label, contract, &encoded_args);
@@ -2586,6 +2591,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                     Some(&encoded_return),
                     false,
                     None,
+                    ErrorCtxt::AssertMethodPostconditionStrengthening
                 );
                 self.wrap_arguments_into_old(assertion, pre_label, contract, &encoded_args)
             });
@@ -3257,6 +3263,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                                 None,
                                 false,
                                 Some(loop_head),
+                                ErrorCtxt::GenericExpression,
                             );
                             let spec_spans = spec.assertion.get_spans();
                             let spec_pos = self.encoder.error_manager().register_span(

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -269,6 +269,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> PureFunctionEncoder<'p, 'v, 'r, 'a, '
                 None,
                 true,
                 None,
+                ErrorCtxt::GenericExpression,
             ));
         }
 
@@ -300,6 +301,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> PureFunctionEncoder<'p, 'v, 'r, 'a, '
                 Some(&encoded_return.clone().into()),
                 true,
                 None,
+                ErrorCtxt::GenericExpression,
             );
             debug_assert!(!encoded_postcond.pos().is_default());
             func_spec.push(encoded_postcond);

--- a/prusti-viper/src/encoder/spec_encoder.rs
+++ b/prusti-viper/src/encoder/spec_encoder.rs
@@ -352,7 +352,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> SpecEncoder<'p, 'v, 'r, 'a, 'tcx> {
                 .into_iter()
                 .conjoin(),
             box AssertionKind::Implies(ref lhs, ref rhs) => {
-                vir::Expr::implies(self.encode_expression(lhs), self.encode_assertion(rhs))
+                vir::Expr::implies(self.encode_assertion(lhs), self.encode_assertion(rhs))
             }
             box AssertionKind::TypeCond(ref vars, ref assertion) => {
                 let enc = |hir_id: hir::HirId| -> vir::Expr {

--- a/prusti/src/typeck.rs
+++ b/prusti/src/typeck.rs
@@ -85,12 +85,9 @@ fn type_assertion(
                         })
                         .collect(),
                 ),
-                AssertionKind::Implies(expression, assertion) => AssertionKind::Implies(
-                    Expression {
-                        id: expression.id,
-                        expr: typed_expressions[&expression.id].clone(),
-                    },
-                    type_assertion(assertion, typed_expressions, typed_forallargs),
+                AssertionKind::Implies(lhs_assertion, rhs_assertion) => AssertionKind::Implies(
+                    type_assertion(lhs_assertion, typed_expressions, typed_forallargs),
+                    type_assertion(rhs_assertion, typed_expressions, typed_forallargs),
                 ),
                 AssertionKind::TypeCond(vars, assertion) => AssertionKind::TypeCond(
                     ForAllVars {

--- a/prusti/tests/verify/fail/trait-contracts-refinement/post.rs
+++ b/prusti/tests/verify/fail/trait-contracts-refinement/post.rs
@@ -1,0 +1,37 @@
+extern crate prusti_contracts;
+
+trait Foo {
+    #[requires="-5 <= a && a <= 10"]
+    #[requires="-25 <= b && b <= 30"]
+    #[ensures="result.0 >= a"]
+    #[ensures="result.1 >= b"]
+    fn foo(&mut self, a: isize, b: isize) -> (isize, isize);
+}
+
+struct Dummy {
+    d1: isize,
+    d2: isize,
+}
+
+#[pure]
+#[requires="a > std::isize::MIN"]
+fn abs(a: isize) -> isize {
+    if a < 0 { -a } else { a }
+}
+
+impl Foo for Dummy {
+    #[ensures="result.0 < a"]
+    #[ensures="result.1 == 3"]
+    #[ensures="self.d1 == a"]
+    #[ensures="self.d2 == b"]
+    fn foo(&mut self, a: isize, b: isize) -> (isize, isize) {
+        let a = abs(a);
+        let b = abs(b);
+        self.d1 = a;
+        self.d2 = b;
+        (a - 1, 3)
+    }
+}
+
+
+fn main() {}

--- a/prusti/tests/verify/fail/trait-contracts-refinement/post.rs
+++ b/prusti/tests/verify/fail/trait-contracts-refinement/post.rs
@@ -20,7 +20,8 @@ fn abs(a: isize) -> isize {
 }
 
 impl Foo for Dummy {
-    #[ensures="result.0 < a"]
+    // TODO: why is this the only error that gets reported on the test suite?
+    #[ensures="result.0 < a"] //~ ERROR
     #[ensures="result.1 == 3"]
     #[ensures="self.d1 == a"]
     #[ensures="self.d2 == b"]

--- a/prusti/tests/verify/fail/trait-contracts-refinement/pre.rs
+++ b/prusti/tests/verify/fail/trait-contracts-refinement/pre.rs
@@ -1,7 +1,8 @@
 extern crate prusti_contracts;
 
 trait Foo {
-    #[requires="-5 <= a && a <= 10"]
+    // TODO: why is this the only error that gets reported on the test suite?
+    #[requires="-5 <= a && a <= 10"] //~ ERROR
     #[requires="-25 <= b && b <= 30"]
     #[ensures="result.0 >= a"]
     #[ensures="result.1 >= b"]

--- a/prusti/tests/verify/fail/trait-contracts-refinement/pre.rs
+++ b/prusti/tests/verify/fail/trait-contracts-refinement/pre.rs
@@ -1,0 +1,35 @@
+extern crate prusti_contracts;
+
+trait Foo {
+    #[requires="-5 <= a && a <= 10"]
+    #[requires="-25 <= b && b <= 30"]
+    #[ensures="result.0 >= a"]
+    #[ensures="result.1 >= b"]
+    fn foo(&mut self, a: isize, b: isize) -> (isize, isize);
+}
+
+struct Dummy {
+    d1: isize,
+    d2: isize,
+}
+
+#[pure]
+#[requires="a > std::isize::MIN"]
+fn abs(a: isize) -> isize {
+    if a < 0 { -a } else { a }
+}
+
+impl Foo for Dummy {
+    #[requires="-1 <= a && a <= 1"]
+    #[requires="b == 0"]
+    fn foo(&mut self, a: isize, b: isize) -> (isize, isize) {
+        let a = abs(a);
+        let b = abs(b);
+        self.d1 = a;
+        self.d2 = b;
+        (a, b)
+    }
+}
+
+
+fn main() {}

--- a/prusti/tests/verify/pass/trait-contracts-refinement/basic.rs
+++ b/prusti/tests/verify/pass/trait-contracts-refinement/basic.rs
@@ -1,0 +1,44 @@
+extern crate prusti_contracts;
+
+trait Foo {
+    #[requires="-5 <= a && a <= 10"]
+    #[requires="-25 <= b && b <= 30"]
+    #[ensures="result.0 >= a"]
+    #[ensures="result.1 >= b"]
+    fn foo(&mut self, a: isize, b: isize) -> (isize, isize);
+}
+
+struct Dummy {
+    d1: isize,
+    d2: isize,
+}
+
+#[pure]
+#[requires="a > std::isize::MIN"]
+fn abs(a: isize) -> isize {
+    if a < 0 { -a } else { a }
+}
+
+impl Foo for Dummy {
+    #[requires="-150 <= a && a <= 100"]
+    #[requires="b > std::isize::MIN"]
+    #[ensures="result.0 == abs(a)"]
+    #[ensures="result.1 == abs(b)"]
+    #[ensures="self.d1 == result.0"]
+    #[ensures="self.d2 == result.1"]
+    fn foo(&mut self, a: isize, b: isize) -> (isize, isize) {
+        let a = abs(a);
+        let b = abs(b);
+        self.d1 = a;
+        self.d2 = b;
+        (a, b)
+    }
+}
+
+impl Foo for () {
+    fn foo(&mut self, a: isize, b: isize) -> (isize, isize) {
+        (abs(a), abs(b))
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Hello,
This little PR should allow users to refine the trait specification (the refinement is obviously checked for soundness).
It is not much since one can easily emulate refinement by using Rust's shadowing system, but hey, at least it's a start :)