### PR TITLE
Add basic docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:buster
+
+
+RUN apt-get update && apt-get install -y wget && \
+    wget -q -O - https://pmserver.inf.ethz.ch/viper/debs/xenial/key.asc | apt-key add - && \
+    echo 'deb http://pmserver.inf.ethz.ch/viper/debs/xenial /' | tee /etc/apt/sources.list.d/viper.list && \
+    apt-get update && \
+    apt-get install -y viper build-essential pkg-config gcc libssl-dev
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+COPY . .
+
+RUN make build
+


### PR DESCRIPTION
Hi,

I tried building this on my Mac and encountered a bunch of errors related to Scala and other things so I gave up and made a basic docker build instead. I've just confirmed that `make test` works on my computer.

The `Dockerfile` is very bare-bones but successfully installs viper and builds prusti.