### PR TITLE
Add support for writing specifications as attribute macros

### DIFF
--- a/prusti/tests/parse/pass/attribute_macros.rs
+++ b/prusti/tests/parse/pass/attribute_macros.rs
@@ -1,0 +1,19 @@
+#![feature(attr_literals)]
+
+extern crate prusti_contracts;
+
+// Extend Prusti to allow writing specifications in functional style
+#[requires("x > 0 && y > 0")]
+#[ensures("result >= x && result >= y")]
+#[ensures("result == x || result == y")]
+pub fn loop_max(x: u32, y: u32) -> u32 {
+    let mut r = x;
+    #[invariant("r >= x")]
+    #[invariant("r == x || r <= y")]
+    while r < y {
+        r += 1
+    }
+    r
+}
+
+fn main() {}

--- a/prusti/tests/parse/ui/attribute_macros.rs
+++ b/prusti/tests/parse/ui/attribute_macros.rs
@@ -1,0 +1,21 @@
+#![feature(attr_literals)]
+
+extern crate prusti_contracts;
+
+// no args
+#[ensures()]
+fn no_args() {}
+
+#[requires("too", "many", "args")]
+fn too_many_args() {}
+
+#[requires("true")]
+fn wrong_token() {
+    let mut i=0u32;
+    #[invariant["true"]]
+    while i<10 {
+        i += 1
+    }
+}
+
+fn main() {}

--- a/prusti/tests/parse/ui/attribute_macros.stderr
+++ b/prusti/tests/parse/ui/attribute_macros.stderr
@@ -1,0 +1,20 @@
+error: malformed specification (expected single argument)
+ --> $DIR/attribute_macros.rs:6:1
+  |
+6 | #[ensures()]
+  | ^^^^^^^^^^^^
+
+error: malformed specification (expected single argument)
+ --> $DIR/attribute_macros.rs:9:1
+  |
+9 | #[requires("too", "many", "args")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: malformed specification (expected token)
+  --> $DIR/attribute_macros.rs:15:5
+   |
+15 |     #[invariant["true"]]
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/prusti/tests/verify/pass/generic/linear_search.rs
+++ b/prusti/tests/verify/pass/generic/linear_search.rs
@@ -1,0 +1,74 @@
+extern crate prusti_contracts;
+
+pub struct VecWrapper<T> {
+    v: Vec<T>,
+}
+
+impl<T: Eq> VecWrapper<T> {
+    #[trusted]
+    #[pure]
+    pub fn len(&self) -> usize {
+        self.v.len()
+    }
+
+    #[trusted]
+    #[pure]
+    #[requires("0 <= index && index < self.len()")]
+    pub fn present(&self, index: usize, value: &T) -> bool {
+        self.v[index] == *value
+    }
+}
+
+pub enum UsizeOption {
+    Some(usize),
+    None,
+}
+
+impl UsizeOption {
+    #[pure]
+    pub fn is_some(&self) -> bool {
+        match self {
+            UsizeOption::Some(_) => true,
+            UsizeOption::None => false,
+        }
+    }
+    #[pure]
+    pub fn is_none(&self) -> bool {
+        match self {
+            UsizeOption::Some(_) => false,
+            UsizeOption::None => true,
+        }
+    }
+}
+
+#[ensures("result.is_none() ==>
+            (forall k: usize :: (0 <= k && k < arr.len()) ==> !arr.present(k, elem))")]
+#[ensures("match result {
+                UsizeOption::Some(index) => (
+                    0 <= index && index < arr.len() && arr.present(index, elem)
+                ),
+                UsizeOption::None => true,
+            }")]
+fn linear_search<T: Eq>(arr: &VecWrapper<T>, elem: &T) -> UsizeOption {
+    let mut i = 0;
+    let mut done = false;
+
+    #[invariant("i <= arr.len()")]
+    #[invariant("forall k: usize :: (0 <= k && k < i) ==> !arr.present(k, elem)")]
+    #[invariant("done ==> (i < arr.len() && arr.present(i, elem))")]
+    while i < arr.len() && !done {
+        if arr.present(i, elem) {
+            done = true;
+        } else {
+            i += 1;
+        }
+    }
+
+    if done {
+        UsizeOption::Some(i)
+    } else {
+        UsizeOption::None
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Allow writing specifications as attribute procedural macros.  This allows the same code to be compiled by rustc.

Also added example showing how Prusti verifies a generic Linear Search.