### PR TITLE
Report nice errors when impure functions are used

### DIFF
--- a/prusti-viper/src/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mod.rs
@@ -20,6 +20,7 @@ mod places;
 mod procedure_encoder;
 mod pure_function_encoder;
 mod spec_encoder;
+mod stub_function_encoder;
 mod type_encoder;
 mod utils;
 

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1618,7 +1618,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                         let is_pure_function =
                             self.encoder.env().has_attribute_name(def_id, "pure");
                         if is_pure_function {
-                            let function_name = self.encoder.encode_pure_function_use(def_id);
+                            let (function_name, return_type) = self.encoder.encode_pure_function_use(term.source_info.span, def_id);
                             debug!("Encoding pure function call '{}'", function_name);
                             assert!(destination.is_some());
 
@@ -1628,7 +1628,6 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                                 arg_exprs.push(arg_expr);
                             }
 
-                            let return_type = self.encoder.encode_pure_function_return_type(def_id);
                             let formal_args: Vec<vir::LocalVar> = args
                                 .iter()
                                 .enumerate()

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -633,10 +633,11 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> BackwardMirInterpreter<'tcx>
 
                         // generic function call
                         _ => {
-                            let function_name = self.encoder.encode_pure_function_use(def_id);
+                            let (function_name, return_type) = self
+                                .encoder
+                                .encode_pure_function_use(term.source_info.span, def_id);
                             trace!("Encoding pure function call '{}'", function_name);
 
-                            let return_type = self.encoder.encode_pure_function_return_type(def_id);
                             let formal_args: Vec<vir::LocalVar> = args
                                 .iter()
                                 .enumerate()

--- a/prusti-viper/src/encoder/stub_function_encoder.rs
+++ b/prusti-viper/src/encoder/stub_function_encoder.rs
@@ -1,0 +1,94 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use encoder::mir_encoder::MirEncoder;
+use encoder::foldunfold;
+use encoder::vir;
+use encoder::Encoder;
+use rustc::hir::def_id::DefId;
+use rustc::mir;
+
+pub struct StubFunctionEncoder<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> {
+    encoder: &'p Encoder<'v, 'r, 'a, 'tcx>,
+    mir: &'p mir::Mir<'tcx>,
+    mir_encoder: MirEncoder<'p, 'v, 'r, 'a, 'tcx>,
+    proc_def_id: DefId,
+}
+
+impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> StubFunctionEncoder<'p, 'v, 'r, 'a, 'tcx> {
+    pub fn new(
+        encoder: &'p Encoder<'v, 'r, 'a, 'tcx>,
+        proc_def_id: DefId,
+        mir: &'p mir::Mir<'tcx>,
+    ) -> Self {
+        trace!("StubFunctionEncoder constructor: {:?}", proc_def_id);
+        StubFunctionEncoder {
+            encoder,
+            mir,
+            mir_encoder: MirEncoder::new_with_namespace(
+                encoder,
+                mir,
+                proc_def_id,
+                "_stub".to_string(),
+            ),
+            proc_def_id,
+        }
+    }
+
+    pub fn encode_function(&self) -> vir::Function {
+        let function_name = self.encode_function_name();
+        debug!("Encode stub function {}", function_name);
+        let subst_strings = self.encoder.type_substitution_strings();
+
+        let precondition = vir::Expr::Const(vir::Const::Bool(false), vir::Position::default());
+        let postcondition = vir::Expr::Const(vir::Const::Bool(false), vir::Position::default());
+
+        let formal_args: Vec<_> = self
+            .mir
+            .args_iter()
+            .map(|local| {
+                let var_name = self.mir_encoder.encode_local_var_name(local);
+                let mir_type = self.mir_encoder.get_local_ty(local);
+                let var_type = self
+                    .encoder
+                    .encode_value_type(self.encoder.resolve_typaram(mir_type));
+                let var_type = var_type.patch(&subst_strings);
+                vir::LocalVar::new(var_name, var_type)
+            })
+            .collect();
+
+        let return_type = self.encode_function_return_type();
+
+        let function = vir::Function {
+            name: function_name,
+            formal_args,
+            return_type,
+            pres: vec![precondition],
+            posts: vec![postcondition],
+            body: None,
+        };
+
+        self.encoder
+            .log_vir_program_before_foldunfold(function.to_string());
+
+        foldunfold::add_folding_unfolding_to_function(
+            function,
+            self.encoder.get_used_viper_predicates_map(),
+        )
+    }
+
+    pub fn encode_function_name(&self) -> String {
+        let mut base_name = self.encoder.encode_item_name(self.proc_def_id);
+        base_name.push_str("_stub");
+
+        base_name
+    }
+
+    pub fn encode_function_return_type(&self) -> vir::Type {
+        let ty = self.encoder.resolve_typaram(self.mir.return_ty());
+        self.encoder.encode_value_type(ty)
+    }
+}

--- a/prusti-viper/src/verifier.rs
+++ b/prusti-viper/src/verifier.rs
@@ -195,6 +195,10 @@ impl<'v, 'r, 'a, 'tcx> Verifier<'v, 'r, 'a, 'tcx> {
         }
         self.encoder.process_encoding_queue();
 
+        if self.env.has_errors() {
+            return VerificationResult::Failure;
+        }
+
         let duration = start.elapsed();
         info!(
             "Encoding to Viper successful ({}.{} seconds)",

--- a/prusti-viper/src/verifier.rs
+++ b/prusti-viper/src/verifier.rs
@@ -195,10 +195,6 @@ impl<'v, 'r, 'a, 'tcx> Verifier<'v, 'r, 'a, 'tcx> {
         }
         self.encoder.process_encoding_queue();
 
-        if self.env.has_errors() {
-            return VerificationResult::Failure;
-        }
-
         let duration = start.elapsed();
         info!(
             "Encoding to Viper successful ({}.{} seconds)",

--- a/prusti/tests/verify/ui/non-pure-function.rs
+++ b/prusti/tests/verify/ui/non-pure-function.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code)]
+extern crate prusti_contracts;
+
+mod foo {
+    pub fn get_false() -> bool {
+        false
+    }
+}
+
+fn get_true() -> bool {
+    true
+}
+
+#[requires="get_true() && !foo::get_false()"]
+fn main() {
+}

--- a/prusti/tests/verify/ui/non-pure-function.stderr
+++ b/prusti/tests/verify/ui/non-pure-function.stderr
@@ -1,0 +1,14 @@
+error: Use of impure function "get_true" in assertion
+  --> $DIR/non-pure-function.rs:14:13
+   |
+14 | #[requires="get_true() && !foo::get_false()"]
+   |             ^^^^^^^^^^
+
+error: Use of impure function "foo::get_false" in assertion
+  --> $DIR/non-pure-function.rs:14:28
+   |
+14 | #[requires="get_true() && !foo::get_false()"]
+   |                            ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/prusti/tests/verify/ui/non-pure-function.stderr
+++ b/prusti/tests/verify/ui/non-pure-function.stderr
@@ -10,5 +10,11 @@ error: Use of impure function "foo::get_false" in assertion
 14 | #[requires="get_true() && !foo::get_false()"]
    |                            ^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: [Prusti] precondition of pure function call might not hold.
+  --> $DIR/non-pure-function.rs:14:13
+   |
+14 | #[requires="get_true() && !foo::get_false()"]
+   |             ^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes #11.

This approach allows lowering to continue, despite it generating invalid VIR. However, we never pass that code to Viper since we exit the verifier early if any errors are reported during the lowering process.