### PR TITLE
Fix inherent impl blocks on trait refinement for unsafe traits

### DIFF
--- a/prusti-interface/src/parser.rs
+++ b/prusti-interface/src/parser.rs
@@ -1994,7 +1994,7 @@ impl<'tcx> Folder for SpecParser<'tcx> {
                     if !new_spec_items.is_empty() {
                         new_items.push(ptr::P(ast::Item {
                             node: ast::ItemKind::Impl(
-                                unsafety,
+                                ast::Unsafety::Normal,
                                 polarity,
                                 defaultness,
                                 generics.clone(),

--- a/prusti/tests/verify/pass/unsafe-traits/unsafe-trait-refinement.rs
+++ b/prusti/tests/verify/pass/unsafe-traits/unsafe-trait-refinement.rs
@@ -1,0 +1,24 @@
+extern crate prusti_contracts;
+
+unsafe trait Foo {
+    #[ensures="result > 42"]
+    fn foo(&self) -> i32;
+}
+
+struct Dummy {
+    inner: i32,
+}
+
+unsafe impl Foo for Dummy {
+    #[ensures="result > 84"]
+    fn foo(&self) -> i32 {
+        if self.inner > 84 {
+            self.inner
+        } else {
+            102
+        }
+    }
+}
+
+fn main() {}
+


### PR DESCRIPTION
Trying to verify code such as:

```rust
unsafe trait Foo {
    #[ensures="result > 42"]
    fn foo(&self) -> i32;
}

struct Dummy {
    inner: i32,
}

unsafe impl Foo for Dummy {
    #[ensures="result > 84"]
    fn foo(&self) -> i32 {
        if self.inner > 84 {
            self.inner
        } else {
            102
        }
    }
}
```

Creates an `unsafe` inherent implementation block on `Dummy` during parsing. This is illegal Rust.

For some reason, this breaks existing tests due to verification failures because of overflow. I don't really see how this is related to the unsafety issue. Needs investigation.

Eg:

```
error: [Prusti] assertion might fail with "attempt to add with overflow"
   --> tests/verify/pass-overflow/rosetta/Knights_tour_generic.rs:313:9
    |
313 |         step += 1;
    |         ^^^^^^^^^

error: aborting due to previous error

```

CC: @fpoli 