### PR TITLE
Jakob/marker trait contract refinement

### DIFF
--- a/prusti-interface/src/lib.rs
+++ b/prusti-interface/src/lib.rs
@@ -20,6 +20,7 @@
 #![feature(try_from)]
 #![feature(crate_in_paths)]
 #![feature(map_get_key_value)]
+#![feature(iterator_flatten)]
 
 extern crate csv;
 extern crate datafrog;

--- a/prusti-interface/src/parser.rs
+++ b/prusti-interface/src/parser.rs
@@ -1366,11 +1366,11 @@ impl<'tcx> SpecParser<'tcx> {
         let preconditions: Vec<_> = specs
             .clone()
             .into_iter()
-            .filter(|spec| spec.typ == SpecType::Precondition)
+            .filter(|spec| spec.typ.is_precondition())
             .collect();
         let postconditions: Vec<_> = specs
             .into_iter()
-            .filter(|spec| spec.typ == SpecType::Postcondition)
+            .filter(|spec| spec.typ.is_postcondition())
             .collect();
         let spec_set = SpecificationSet::Procedure(preconditions.clone(), postconditions.clone());
 
@@ -1473,7 +1473,7 @@ impl<'tcx> SpecParser<'tcx> {
                 let spec_trees: Vec<TokenTree> = token_stream.trees().collect();
                 if spec_trees.len() == 1 {
                     spec_trees[0].clone()
-                } else if spec_trees.len() == 5 && attribute.path.to_string().starts_with("refines_") {
+                } else if spec_trees.len() == 5 && attribute.path.to_string().starts_with("refine_") {
                     let trait_symbol = if let TokenTree::Token(_, token::Token::Ident(ref ident, _)) = spec_trees[0] {
                         ident.name.clone()
                     } else {

--- a/prusti-interface/src/parser.rs
+++ b/prusti-interface/src/parser.rs
@@ -1473,7 +1473,7 @@ impl<'tcx> SpecParser<'tcx> {
                 let spec_trees: Vec<TokenTree> = token_stream.trees().collect();
                 if spec_trees.len() == 1 {
                     spec_trees[0].clone()
-                } else {
+                } else if spec_trees.len() == 5 && attribute.path.to_string().starts_with("refines_") {
                     let trait_symbol = if let TokenTree::Token(_, token::Token::Ident(ref ident, _)) = spec_trees[0] {
                         ident.name.clone()
                     } else {
@@ -1508,6 +1508,12 @@ impl<'tcx> SpecParser<'tcx> {
                     }
                     function_ref = Some((trait_symbol, func_symbol));
                     spec_trees[4].clone()
+                } else {
+                    self.report_error(
+                        attribute.span,
+                        "malformed specification (expected single argument)"
+                    );
+                    return None;
                 }
             }
             _ => {

--- a/prusti-interface/src/parser.rs
+++ b/prusti-interface/src/parser.rs
@@ -2270,7 +2270,7 @@ impl<'tcx> Folder for SpecParser<'tcx> {
                         if !trait_symbols.contains(&symbol) {
                             self.report_error(
                                 item.span,
-                                &format!("'{}' does not refer to a method in a super trait", symbol));
+                                &format!("no method '{}' in super trait", symbol));
                         }
                     }
 

--- a/prusti-interface/src/specifications.rs
+++ b/prusti-interface/src/specifications.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::string::ToString;
 use syntax::codemap::Span;
+use syntax::symbol::Symbol;
 use syntax::{ast, ptr};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -22,10 +23,37 @@ use syntax::{ast, ptr};
 pub enum SpecType {
     /// Precondition of a procedure.
     Precondition,
+    /// Refine a precondition of a procedure.
+    RefinePrecondition(Option<(Symbol,Symbol)>),
     /// Postcondition of a procedure.
     Postcondition,
+    /// Refine a postcondition of a procedure.
+    RefinePostcondition(Option<(Symbol,Symbol)>),
     /// Loop invariant or struct invariant
     Invariant,
+}
+
+impl SpecType {
+    pub fn is_refines(&self) -> bool {
+        match self {
+            SpecType::RefinePostcondition(_) | SpecType::RefinePrecondition(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_refine_ensures(&self) -> bool {
+        match self {
+            SpecType::RefinePostcondition(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_refine_requires(&self) -> bool {
+        match self {
+            SpecType::RefinePrecondition(_) => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -44,6 +72,8 @@ impl<'a> TryFrom<&'a str> for SpecType {
             "requires" => Ok(SpecType::Precondition),
             "ensures" => Ok(SpecType::Postcondition),
             "invariant" => Ok(SpecType::Invariant),
+            "refine_requires" => Ok(SpecType::RefinePrecondition(None)),
+            "refine_ensures" => Ok(SpecType::RefinePostcondition(None)),
             _ => Err(TryFromStringError::UnknownSpecificationType),
         }
     }

--- a/prusti-interface/src/specifications.rs
+++ b/prusti-interface/src/specifications.rs
@@ -54,6 +54,15 @@ impl SpecType {
             _ => false,
         }
     }
+
+    pub fn get_function_ref(&self) -> Option<(Symbol, Symbol)> {
+        match self {
+            SpecType::RefinePrecondition(ref_opt) | SpecType::RefinePostcondition(ref_opt) => {
+                ref_opt.clone()
+            },
+            _ => None
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/prusti-interface/src/specifications.rs
+++ b/prusti-interface/src/specifications.rs
@@ -41,6 +41,20 @@ impl SpecType {
         }
     }
 
+    pub fn is_postcondition(&self) -> bool {
+        match self {
+            SpecType::Postcondition | SpecType::RefinePostcondition(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_precondition(&self) -> bool {
+        match self {
+            SpecType::Precondition | SpecType::RefinePrecondition(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_refine_ensures(&self) -> bool {
         match self {
             SpecType::RefinePostcondition(_) => true,

--- a/prusti-interface/src/trait_register.rs
+++ b/prusti-interface/src/trait_register.rs
@@ -9,6 +9,7 @@ use std::hash::{Hash,Hasher};
 use std::iter::Iterator;
 use syntax::ast;
 use syntax::ext::quote::rt::Span;
+use syntax::symbol::Symbol;
 use syntax_pos::DUMMY_SP;
 use specifications::SpecID;
 
@@ -33,6 +34,7 @@ pub struct TraitRegister {
 }
 
 type TraitInfo = (RegisterID, Option<SpecID>, ast::Item, Vec<ast::Attribute>);
+pub type FunctionRef = (Symbol, Symbol);
 
 impl TraitRegister {
     pub fn new() -> Self {

--- a/prusti/tests/verify/fail/trait-contracts-refinement/wrong-reference-trait.rs
+++ b/prusti/tests/verify/fail/trait-contracts-refinement/wrong-reference-trait.rs
@@ -1,10 +1,10 @@
 extern crate prusti_contracts;
 
-trait Foo {  //~ ERROR no method 'bar' in super trait
+trait Foo {
     fn foo(&self, arg: i32) -> bool;
 }
 
-#[refine_requires(Foo::bar = "arg > 0")]
+#[refine_requires(Bar::foo = "arg > 0")] //~ ERROR does not refer to super trait
 trait Sub: Foo {}
 
 struct Dummy { }
@@ -22,3 +22,4 @@ fn test_foo(d: &Dummy) {
 }
 
 fn main() {}
+

--- a/prusti/tests/verify/fail/trait-contracts-refinement/wrong-reference.rs
+++ b/prusti/tests/verify/fail/trait-contracts-refinement/wrong-reference.rs
@@ -1,0 +1,24 @@
+extern crate prusti_contracts;
+
+trait Foo {  //~ ERROR 'bar' does not refer to a method in a super trait
+    fn foo(&self, arg: i32) -> bool;
+}
+
+#[refine_requires(Foo::bar = "arg > 0")]
+trait Sub: Foo {}
+
+struct Dummy { }
+
+impl Foo for Dummy {
+    fn foo(&self, arg: i32) -> bool {
+        arg > 5
+    }
+}
+
+impl Sub for Dummy { }
+
+fn test_foo(d: &Dummy) {
+    assert!(d.foo(6));
+}
+
+fn main() {}

--- a/prusti/tests/verify/pass/trait-contracts-refinement/marker-trait-refinement.rs
+++ b/prusti/tests/verify/pass/trait-contracts-refinement/marker-trait-refinement.rs
@@ -1,0 +1,26 @@
+extern crate prusti_contracts;
+
+trait Foo {
+    #[ensures="result > 42"]
+    fn foo(&self) -> i32;
+}
+
+#[refine_ensures(Foo::foo = "result < 442")]
+trait Sub: Foo {}
+
+struct Dummy { }
+
+impl Foo for Dummy {
+    fn foo(&self) -> i32 {
+        84
+    }
+}
+
+impl Sub for Dummy { }
+
+fn test_foo(d: &Dummy) {
+    assert!(d.foo() > 0);
+    assert!(d.foo() < 1000);
+}
+
+fn main() {}

--- a/prusti/tests/verify/pass/trait-contracts-refinement/marker-trait-two-contracts.rs
+++ b/prusti/tests/verify/pass/trait-contracts-refinement/marker-trait-two-contracts.rs
@@ -1,0 +1,38 @@
+extern crate prusti_contracts;
+
+trait Foo {
+    fn foo(&self, arg: i32) -> bool;
+}
+
+trait Bar {
+    fn bar(&self, arg: i32) -> bool;
+}
+
+#[refine_requires(Foo::foo = "arg > 0")]
+#[refine_ensures(Foo::foo = "result == (arg > 5)")]
+#[refine_requires(Bar::bar = "arg < 0")]
+#[refine_ensures(Bar::bar = "result == (arg < -42)")]
+trait Sub: Foo + Bar {}
+
+struct Dummy { }
+
+impl Foo for Dummy {
+    fn foo(&self, arg: i32) -> bool {
+        arg > 5
+    }
+}
+
+impl Bar for Dummy {
+    fn bar(&self, arg: i32) -> bool {
+        arg < -42
+    }
+}
+
+impl Sub for Dummy { }
+
+fn test_foo(d: &Dummy) {
+    assert!(d.foo(6));
+    assert!(d.bar(-55));
+}
+
+fn main() {}

--- a/prusti/tests/verify/pass/trait-contracts-refinement/marker-trait.rs
+++ b/prusti/tests/verify/pass/trait-contracts-refinement/marker-trait.rs
@@ -1,0 +1,24 @@
+extern crate prusti_contracts;
+
+trait Foo {
+    fn foo(&self) -> bool;
+}
+
+#[refine_ensures(Foo::foo = "result")]
+trait Sub: Foo {}
+
+struct Dummy { }
+
+impl Foo for Dummy {
+    fn foo(&self) -> bool {
+        true
+    }
+}
+
+impl Sub for Dummy { }
+
+fn test_foo(d: &Dummy) {
+    assert!(d.foo());
+}
+
+fn main() {}


### PR DESCRIPTION
## Trait Contract Refinement

In some cases, marker traits simply modify the behavior of methods in their super-traits. For instance consider the `PartialEq<T>` and `Eq` traits. In order to consider this additional behavior for verification, traits support contract refinement on trait level:

```rust
pub trait PartialEq<Rhs: ?Sized = Self> {
    #[ensures="<partial equivalence formulas>"]
    fn eq(&self, other: &Rhs) -> bool;
}

#[refine_ensures(PartialEq::eq="self.eq(&self)")]
pub trait Eq: PartialEq<Self> {}
```

Thus, any client implementing `Eq` on a custom type can take advantage of the additional semantics of the total equivalence. Similarly `#[refine_requires]` can be used to refine the precondition of a super-trait.

> Such trait refinement is not scoped. Therefore, considering the previous example, implementing `Eq` on a type implies that the total equivalence contract is always considered on the type, irrespective of whether `Eq` is in scope or not.