### PR TITLE
Fix the indentation of the first item in the path context state.

### DIFF
--- a/prusti-viper/src/encoder/foldunfold/state.rs
+++ b/prusti-viper/src/encoder/foldunfold/state.rs
@@ -641,10 +641,10 @@ impl State {
 impl fmt::Display for State {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "acc: {{")?;
-        writeln!(f, "  {}", self.display_acc())?;
+        writeln!(f, "{}", self.display_acc())?;
         writeln!(f, "}}")?;
         writeln!(f, "pred: {{")?;
-        writeln!(f, "  {}", self.display_pred())?;
+        writeln!(f, "{}", self.display_pred())?;
         writeln!(f, "}}")
     }
 }


### PR DESCRIPTION
It's a tiny change ;)

Before, it looked like this:

    acc: {
        _0.tuple_0.val_ref: write,
      _0.tuple_0: write,
      _0.tuple_1.val_ref: write,
      _0.tuple_1: write,
    }
    pred: {
    
    }

Now, it looks like this:

    acc: {
      _0.tuple_0.val_ref: write,
      _0.tuple_0: write,
      _0.tuple_1.val_ref: write,
      _0.tuple_1: write,
    }
    pred: {
    
    }