### PR TITLE
Split test CI action in quick/full test.

### DIFF
--- a/.github/workflows/prepare-environment.sh
+++ b/.github/workflows/prepare-environment.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+sudo apt-get install -y build-essential pkg-config gcc libssl-dev openjdk-8-jdk
+
+echo "::set-env name=LD_LIBRARY_PATH::"$(dirname "$(find "$JAVA_HOME" -name "libjvm.so")")""
+
+wget -q "http://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip"
+unzip ViperToolsNightlyLinux.zip -d viper_tools
+rm ViperToolsNightlyLinux.zip
+echo "::set-env name=VIPER_HOME::$(pwd)/viper_tools/backends/"
+echo "::set-env name=Z3_EXE::$(pwd)/viper_tools/z3/bin/z3"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,36 +8,34 @@ on:
 
 env:
   RUST_BACKTRACE: 1
+  RUST_TEST_THREADS: 1
+  PRUSTI_ASSERT_TIMEOUT: 60000
 
 jobs:
-  build:
+
+  quick-test:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
       uses: actions/checkout@v2
-    - name: Setup Java JDK
-      uses: actions/setup-java@v1.3.0
-      with:
-        java-version: 1.8
-    - name: Add Java JDK to the library path
-      run: echo "::set-env name=LD_LIBRARY_PATH::"$(dirname "$(find "$JAVA_HOME" -name "libjvm.so")")""
-    - name: Setup Viper
-      working-directory: ./..
-      run: |
-        wget -q 'http://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip'
-        unzip ViperToolsNightlyLinux.zip -d viper_tools
-        rm ViperToolsNightlyLinux.zip
-        echo "::set-env name=VIPER_HOME::$(pwd)/viper_tools/backends/"
-        echo "::set-env name=Z3_EXE::$(pwd)/viper_tools/z3/bin/z3"
-    - name: Install system dependencies for Prusti
-      run: sudo apt-get install -y build-essential pkg-config gcc libssl-dev
+    - name: Prepare environment
+      run: .github/workflows/prepare-environment.sh
     - name: Build with cargo
       run: cargo build --all --verbose
     - name: Run cargo tests
-      run: cargo test --all --verbose
+      run: cargo test -p prusti --verbose
       env:
-        RUST_TEST_THREADS: 1
-        PRUSTI_ASSERT_TIMEOUT: 60000
+        TESTNAME: quick/
+
+  full-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+    - name: Prepare environment
+      run: .github/workflows/prepare-environment.sh
+    - name: Run cargo tests
+      run: cargo test --all --verbose
     - name: Run tests with prusti-rustc
       run: |
         ./target/debug/prusti-rustc prusti/tests/verify/pass/no-annotations/assert-true.rs

--- a/prusti/tests/verify/pass/quick/mut-borrows.rs
+++ b/prusti/tests/verify/pass/quick/mut-borrows.rs
@@ -1,0 +1,1 @@
+../mut-borrows/basic.rs


### PR DESCRIPTION
This would split the test action into two jobs. One is only testing the examples from `prusti/tests/verify/pass/quick/`, the other one is running the full test suite (Including the examples from `prusti/tests/verify/pass/quick/`, they should probably be excluded). How useful this is depends on how representative the quick tests can be, i.e., how confident we are that the changes are correct after the quick tests pass.

Another option would be to do the split the other way round, i.e., keep the test suite mostly as it is today and move the tests that take too long to a separate job for long-running tests.

Still another way would be to split the tests into multiple categories, for example

- hand rolled test that test specific aspects of the encoding, meaning the ones from `prusti/tests/verify/pass/expiring-loans`, `prusti/tests/verify/pass/equality`, and so on.
- RustHorn tests
- Rosetta tests
- Crate tests
- ...

This way we actually get faster results because the different categories run in parallel (and we see results from categories that finish quickly early).

Building Prusti once and reusing the result for all test jobs is possible, but not trivial. The issue is that two jobs don't share the filesystem. The only way to share files is via the `upload-artifact` and `download-artifact` actions. Just uploading/downloading the whole `target/` folder is not viable, because it is way too big. We'd have to only upload/download the individual test binaries.