### PR TITLE
Fix order of branches

### DIFF
--- a/prusti-common/src/vir/ast/expr.rs
+++ b/prusti-common/src/vir/ast/expr.rs
@@ -884,6 +884,14 @@ impl Expr {
         }
     }
 
+    pub fn negate(self) -> Self {
+        if let Expr::UnaryOp(UnaryOpKind::Not, box inner_expr, _pos) = self {
+            inner_expr
+        } else {
+            Expr::not(self)
+        }
+    }
+
     pub fn map_labels<F>(self, f: F) -> Self
     where
         F: Fn(String) -> Option<String>,

--- a/prusti-viper/src/encoder/errors/error_manager.rs
+++ b/prusti-viper/src/encoder/errors/error_manager.rs
@@ -283,14 +283,14 @@ impl<'tcx> ErrorManager<'tcx> {
 
             ("assert.failed:assertion.false", ErrorCtxt::ExhaleLoopInvariantAfterIteration) => {
                 PrustiError::verification(
-                    "loop invariant might not hold after a loop iteration.",
+                    "loop invariant might not hold after a loop iteration that preserves the loop condition.",
                     error_span
                 ).push_primary_span(opt_cause_span)
             }
 
             ("assert.failed:assertion.false", ErrorCtxt::AssertLoopInvariantAfterIteration) => {
                 PrustiError::verification(
-                    "loop invariant might not hold after a loop iteration.",
+                    "loop invariant might not hold after a loop iteration that preserves the loop condition.",
                     error_span
                 ).push_primary_span(opt_cause_span)
             }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -23,7 +23,7 @@ use prusti_common::vir::fixes::fix_ghost_vars;
 use prusti_common::vir::optimisations::methods::{
     remove_empty_if, remove_trivial_assertions, remove_unused_vars,
 };
-use prusti_common::vir::{self, CfgBlockIndex, Successor, collect_assigned_vars, Expr, Type, UnaryOpKind};
+use prusti_common::vir::{self, CfgBlockIndex, Successor, collect_assigned_vars, Expr, Type};
 use prusti_common::vir::{ExprIterator, FoldingBehaviour};
 use prusti_common::config;
 use prusti_interface::data::ProcedureDefId;
@@ -1685,8 +1685,8 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                         if target_span > default_target_span {
                             let guard_pos = target_guard.pos().clone();
                             cfg_targets = vec![(
-                                Expr::UnaryOp(UnaryOpKind::Not, box target_guard, guard_pos),
-                                default_target
+                                target_guard.negate().set_pos(guard_pos),
+                                default_target,
                             )];
                             default_target = target;
                         } else {

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -23,7 +23,7 @@ use prusti_common::vir::fixes::fix_ghost_vars;
 use prusti_common::vir::optimisations::methods::{
     remove_empty_if, remove_trivial_assertions, remove_unused_vars,
 };
-use prusti_common::vir::{self, CfgBlockIndex, Successor, collect_assigned_vars, Expr, Type};
+use prusti_common::vir::{self, CfgBlockIndex, Successor, collect_assigned_vars, Expr, Type, UnaryOpKind};
 use prusti_common::vir::{ExprIterator, FoldingBehaviour};
 use prusti_common::config;
 use prusti_interface::data::ProcedureDefId;
@@ -1614,6 +1614,11 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                     vir::AssignKind::Copy,
                 ));
 
+                let guard_is_bool = match switch_ty.sty {
+                    ty::TypeVariants::TyBool => true,
+                    _ => false
+                };
+
                 for (i, &value) in values.iter().enumerate() {
                     let target = targets[i as usize];
                     // Convert int to bool, if required
@@ -1639,7 +1644,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                     };
                     cfg_targets.push((viper_guard, target))
                 }
-                let default_target = targets[values.len()];
+                let mut default_target = targets[values.len()];
                 let mut kill_default_target = false;
 
                 // Is the target an unreachable block?
@@ -1672,6 +1677,23 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> ProcedureEncoder<'p, 'v, 'r, 'a, 'tcx
                     let last_target = cfg_targets.pop().unwrap();
                     (stmts, MirSuccessor::GotoSwitch(cfg_targets, last_target.1))
                 } else {
+                    // Reorder the targets such that Silicon explores branches in the order that we want
+                    if guard_is_bool && cfg_targets.len() == 1 {
+                        let (target_guard, target) = cfg_targets.pop().unwrap();
+                        let target_span = self.mir_encoder.get_span_of_basic_block(target);
+                        let default_target_span = self.mir_encoder.get_span_of_basic_block(default_target);
+                        if target_span > default_target_span {
+                            let guard_pos = target_guard.pos().clone();
+                            cfg_targets = vec![(
+                                Expr::UnaryOp(UnaryOpKind::Not, box target_guard, guard_pos),
+                                default_target
+                            )];
+                            default_target = target;
+                        } else {
+                            // Undo the pop
+                            cfg_targets.push((target_guard, target));
+                        }
+                    }
                     (stmts, MirSuccessor::GotoSwitch(cfg_targets, default_target))
                 }
             }

--- a/prusti/tests/verify/fail/erdinm/typestates-basic-1-3.rs
+++ b/prusti/tests/verify/fail/erdinm/typestates-basic-1-3.rs
@@ -13,8 +13,8 @@ struct Number<S> {
 impl<X> Number<X> {
     #[requires="X == Neg ~~> self.i < 0"]
     #[requires="X == Pos ~~> self.i > 0"]
-    #[ensures="X == Neg ~~> self.i < 0"]
-    #[ensures="X == Pos ~~> self.i > 0"] //~ ERROR postcondition might not hold
+    #[ensures="X == Neg ~~> self.i < 0"] //~ ERROR postcondition might not hold
+    #[ensures="X == Pos ~~> self.i > 0"]
     #[ensures="self.i >= -1 && self.i <= 1"]
     fn to_sign(&mut self) {
         if self.i <= -1 {

--- a/prusti/tests/verify/fail/with-spec/order-of-branches.rs
+++ b/prusti/tests/verify/fail/with-spec/order-of-branches.rs
@@ -1,0 +1,82 @@
+#![allow(dead_code)]
+extern crate prusti_contracts;
+
+/// Test that we report errors for the `then` branch before later branches
+/// See also issue https://github.com/viperproject/silicon/issues/501
+
+fn test_if_1(b: bool) {
+    if b {
+        assert!(false); //~ ERROR
+    } else {
+        assert!(false);
+    }
+}
+
+#[requires="!b"]
+fn test_if_2(b: bool) {
+    if b {
+        assert!(false);
+    } else {
+        assert!(false); //~ ERROR
+    }
+}
+
+fn test_bool_match(b: bool) {
+    match b {
+        true => assert!(false), //~ ERROR
+        false => assert!(false),
+    }
+}
+
+fn test_repeated_match(v: u32) {
+    match v {
+        0 => assert!(false), //~ ERROR
+        x if x < 5 => assert!(false),
+        _ => assert!(false),
+    }
+}
+
+fn test_match_1(v: u32) {
+    match v {
+        0 => assert!(false), //~ ERROR
+        1 => assert!(false),
+        _ => assert!(false),
+    }
+}
+
+#[requires="v >= 1"]
+fn test_match_2(v: u32) {
+    match v {
+        0 => assert!(false),
+        1 => assert!(false), //~ ERROR
+        _ => assert!(false),
+    }
+}
+
+#[requires="v >= 2"]
+fn test_match_3(v: u32) {
+    match v {
+        0 => assert!(false),
+        1 => assert!(false),
+        _ => assert!(false), //~ ERROR
+    }
+}
+
+fn test_loop_1(b: bool) {
+    while b {
+        assert!(false); //~ ERROR
+    }
+    assert!(false);
+}
+
+fn test_loop_2(b: bool) {
+    let mut g = true;
+    #[invariant="g"] //~ ERROR
+    while b {
+        g = false;
+    }
+    assert!(false);
+}
+
+#[trusted]
+fn main() {}

--- a/prusti/tests/verify/pass/loop-invs/negate_loop_condition.rs
+++ b/prusti/tests/verify/pass/loop-invs/negate_loop_condition.rs
@@ -1,0 +1,12 @@
+extern crate prusti_contracts;
+
+fn test_loop(b: bool) {
+    let mut g = b;
+    #[invariant="g"] // Ok, as the loop invariant is not reached after `g = false`
+    while g {
+        g = false;
+    }
+}
+
+#[trusted]
+fn main() {}


### PR DESCRIPTION
Make sure that Prusti checks the `then` branch before later branches.

See also viperproject/silicon#501.