### PR TITLE
Add else branch to Viper if statements.

### DIFF
--- a/prusti-common/src/vir/ast/stmt.rs
+++ b/prusti-common/src/vir/ast/stmt.rs
@@ -50,7 +50,7 @@ pub enum Stmt {
     /// Expire borrows given in the reborrowing DAG.
     ExpireBorrows(ReborrowingDAG),
     /// An `if` statement: the guard and the 'then' branch.
-    If(Expr, Vec<Stmt>),
+    If(Expr, Vec<Stmt>, Vec<Stmt>),
 }
 
 /// What folding behaviour should be used?
@@ -181,15 +181,24 @@ impl fmt::Display for Stmt {
 
             Stmt::ExpireBorrows(dag) => writeln!(f, "expire_borrows {:?}", dag),
 
-            Stmt::If(ref guard, ref then_stmts) => {
-                write!(f, "if {} {{", guard)?;
-                if !then_stmts.is_empty() {
-                    write!(f, "\n")?;
+            Stmt::If(ref guard, ref then_stmts, ref else_stmts) => {
+                fn write_stmt(f: &mut fmt::Formatter, stmt: &Stmt) -> fmt::Result {
+                    writeln!(f, "    {}", stmt.to_string().replace("\n", "\n    "))
                 }
-                for stmt in then_stmts.iter() {
-                    writeln!(f, "    {}", stmt.to_string().replace("\n", "\n    "))?;
+                fn write_block(f: &mut fmt::Formatter, stmts: &[Stmt]) -> fmt::Result {
+                    write!(f, "{{")?;
+                    if !stmts.is_empty() {
+                        write!(f, "\n")?;
+                    }
+                    for stmt in stmts.iter() {
+                        write_stmt(f, stmt)?;
+                    }
+                    write!(f, "}}")
                 }
-                write!(f, "}}")
+                write!(f, "if {} ", guard)?;
+                write_block(f, then_stmts)?;
+                write!(f, " else ")?;
+                write_block(f, else_stmts)
             }
 
             ref x => unimplemented!("{:?}", x),
@@ -280,7 +289,7 @@ pub trait StmtFolder {
             Stmt::PackageMagicWand(w, s, l, v, p) => self.fold_package_magic_wand(w, s, l, v, p),
             Stmt::ApplyMagicWand(w, p) => self.fold_apply_magic_wand(w, p),
             Stmt::ExpireBorrows(d) => self.fold_expire_borrows(d),
-            Stmt::If(g, t) => self.fold_if(g, t),
+            Stmt::If(g, t, e) => self.fold_if(g, t, e),
         }
     }
 
@@ -394,10 +403,11 @@ pub trait StmtFolder {
         Stmt::ExpireBorrows(dag)
     }
 
-    fn fold_if(&mut self, g: Expr, t: Vec<Stmt>) -> Stmt {
+    fn fold_if(&mut self, g: Expr, t: Vec<Stmt>, e: Vec<Stmt>) -> Stmt {
         Stmt::If(
             self.fold_expr(g),
             t.into_iter().map(|x| self.fold(x)).collect(),
+            e.into_iter().map(|x| self.fold(x)).collect(),
         )
     }
 }
@@ -427,7 +437,7 @@ pub trait FallibleStmtFolder {
             }
             Stmt::ApplyMagicWand(w, p) => self.fallible_fold_apply_magic_wand(w, p),
             Stmt::ExpireBorrows(d) => self.fallible_fold_expire_borrows(d),
-            Stmt::If(g, t) => self.fallible_fold_if(g, t),
+            Stmt::If(g, t, e) => self.fallible_fold_if(g, t, e),
         }
     }
 
@@ -576,10 +586,14 @@ pub trait FallibleStmtFolder {
         Ok(Stmt::ExpireBorrows(dag))
     }
 
-    fn fallible_fold_if(&mut self, g: Expr, t: Vec<Stmt>) -> Result<Stmt, Self::Error> {
+    fn fallible_fold_if(&mut self,
+        g: Expr, t: Vec<Stmt>,
+        e: Vec<Stmt>
+    ) -> Result<Stmt, Self::Error> {
         Ok(Stmt::If(
             self.fallible_fold_expr(g)?,
             t.into_iter().map(|x| self.fallible_fold(x)).collect::<Result<_, _>>()?,
+            e.into_iter().map(|x| self.fallible_fold(x)).collect::<Result<_, _>>()?,
         ))
     }
 }
@@ -603,7 +617,7 @@ pub trait StmtWalker {
             Stmt::PackageMagicWand(w, s, l, v, p) => self.walk_package_magic_wand(w, s, l, v, p),
             Stmt::ApplyMagicWand(w, p) => self.walk_apply_magic_wand(w, p),
             Stmt::ExpireBorrows(d) => self.walk_expire_borrows(d),
-            Stmt::If(g, t) => self.walk_if(g, t),
+            Stmt::If(g, t, e) => self.walk_if(g, t, e),
         }
     }
 
@@ -710,9 +724,12 @@ pub trait StmtWalker {
 
     fn walk_nested_cfg(&mut self, _entry: &CfgBlockIndex, _exit: &CfgBlockIndex) {}
 
-    fn walk_if(&mut self, g: &Expr, t: &Vec<Stmt>) {
+    fn walk_if(&mut self, g: &Expr, t: &Vec<Stmt>, e: &Vec<Stmt>) {
         self.walk_expr(g);
         for s in t {
+            self.walk(s);
+        }
+        for s in e {
             self.walk(s);
         }
     }

--- a/prusti-common/src/vir/optimizations/methods/empty_if_remover.rs
+++ b/prusti-common/src/vir/optimizations/methods/empty_if_remover.rs
@@ -6,6 +6,8 @@
 
 //! Optimization that removes unused if statements.
 
+use std::slice;
+
 use vir::cfg;
 use vir::Stmt;
 
@@ -16,18 +18,19 @@ use vir::Stmt;
 pub fn remove_empty_if(mut method: cfg::CfgMethod) -> cfg::CfgMethod {
     method.retain_stmts(|stmt| {
         match stmt {
-            Stmt::If(_, ref stmts) => !is_empty_body(stmts),
+            Stmt::If(_, _, _) => !is_empty_body(slice::from_ref(stmt)),
             _ => true, // Keep the rest
         }
     });
     method
 }
 
-fn is_empty_body(stmts: &Vec<Stmt>) -> bool {
+fn is_empty_body(stmts: &[Stmt]) -> bool {
     stmts.iter().all(|stmt| match stmt {
         Stmt::Comment(_) |
         Stmt::TransferPerm(..) => true,
-        Stmt::If(_, ref stmts) => is_empty_body(stmts),
+        Stmt::If(_, ref then_stmts, ref else_stmts) =>
+            is_empty_body(then_stmts) && is_empty_body(else_stmts),
         _ => false
     })
 }

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -213,15 +213,17 @@ impl<'v> ToViper<'v, viper::Stmt<'v>> for Stmt {
                             ));
                             ast.seqn(stmts.as_slice(), &[])
                         }
-                        &Stmt::If(ref guard, ref then_stmts) => {
-                            let stmts: Vec<_> = then_stmts
-                                .iter()
+                        &Stmt::If(ref guard, ref then_stmts, ref else_stmts) => {
+                            let then_stmts: Vec<_> = then_stmts.iter()
+                                .map(|stmt| stmt_to_viper_in_packge(stmt, ast))
+                                .collect();
+                            let else_stmts: Vec<_> = else_stmts.iter()
                                 .map(|stmt| stmt_to_viper_in_packge(stmt, ast))
                                 .collect();
                             ast.if_stmt(
                                 guard.to_viper(ast),
-                                ast.seqn(&stmts, &[]),
-                                ast.seqn(&[], &[]),
+                                ast.seqn(&then_stmts, &[]),
+                                ast.seqn(&else_stmts, &[]),
                             )
                         }
                         _ => stmt.to_viper(ast),
@@ -263,10 +265,10 @@ impl<'v> ToViper<'v, viper::Stmt<'v>> for Stmt {
                 // Skip
                 ast.comment(&self.to_string())
             }
-            &Stmt::If(ref guard, ref then_stmts) => ast.if_stmt(
+            &Stmt::If(ref guard, ref then_stmts, ref else_stmts) => ast.if_stmt(
                 guard.to_viper(ast),
                 ast.seqn(&then_stmts.to_viper(ast), &[]),
-                ast.seqn(&[], &[]),
+                ast.seqn(&else_stmts.to_viper(ast), &[]),
             ),
         }
     }

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -553,6 +553,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> FoldUnfold<'p, 'v, 'r, 'a, 'tcx> {
             stmts.push(vir::Stmt::If(
                 block.guard.clone(),
                 self.patch_places(&block.statements, label),
+                vec![]
             ));
             for ((from, to), statements) in &cfg.edges {
                 if *from == i {
@@ -563,6 +564,7 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> FoldUnfold<'p, 'v, 'r, 'a, 'tcx> {
                     stmts.push(vir::Stmt::If(
                         condition,
                         self.patch_places(statements, label),
+                        vec![]
                     ));
                 }
             }


### PR DESCRIPTION
This adds the option to have else branches in the `vir::If` AST nodes, which will be very useful for my work. The problem is that I don't know to what extent this affects other parts of the code, especially the fold/unfold algorithm. The tests are green, but this is not too surprising because it is not used anywhere right now.

Let me know if you think this change is useful.

P.S.: A related change that would also be useful is to have else-if branches, i.e., `if (e1) { ... } elseif (e2) { ... } else { ... }`.