### PR TITLE
Support "if" statement in foldunfold/semantics.rs.

### DIFF
--- a/prusti-viper/src/encoder/foldunfold/log.rs
+++ b/prusti-viper/src/encoder/foldunfold/log.rs
@@ -15,6 +15,7 @@ use prusti_common::vir;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::RwLock;
 
 // Note: Now every PathCtxt has its own EventLog, because a Borrow no longer unique
 // (e.g. we duplicate the evaluation of the loop condition in the encoding of loops).
@@ -25,7 +26,7 @@ pub(super) struct EventLog {
     /// Actions performed by the fold-unfold algorithm before the join. We can use a single
     /// CfgBlockIndex because fold-unfold algorithms generates a new basic block for dropped
     /// permissions.
-    prejoin_actions: HashMap<vir::CfgBlockIndex, Rc<Vec<Action>>>,
+    prejoin_actions: HashMap<vir::CfgBlockIndex, Rc<RwLock<Vec<Action>>>>,
 
     /// A list of accessibility predicates for which we inhaled `Read`
     /// permission when creating a borrow and original places from which
@@ -69,13 +70,10 @@ impl EventLog {
         let entry_rc = self
             .prejoin_actions
             .entry(block_index)
-            .or_insert(Rc::new(Vec::new()));
-        if let Some(entry) = Rc::get_mut(entry_rc) {
-            entry.push(action);
-            trace!("[exit] log_prejoin_action {}", entry.iter().to_string());
-        } else {
-            panic!("Could not modify a shared Rc<_> entry of EventLog::prejoin_actions");
-        }
+            .or_insert(Rc::new(RwLock::new(Vec::new())));
+        let mut entry = entry_rc.write().unwrap();
+        entry.push(action);
+        trace!("[exit] log_prejoin_action {}", entry.iter().to_string());
     }
 
     pub fn collect_dropped_permissions(
@@ -88,7 +86,7 @@ impl EventLog {
         let mut dropped_permissions = Vec::new();
         for curr_block_index in relevant_path {
             if let Some(actions) = self.prejoin_actions.get(curr_block_index) {
-                for action in actions.iter() {
+                for action in actions.read().unwrap().iter() {
                     if let Action::Drop(perm, missing_perm) = action {
                         if dag.in_borrowed_places(missing_perm.get_place()) {
                             dropped_permissions.push(perm.clone());

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -974,7 +974,38 @@ impl<'p, 'v: 'p, 'r: 'v, 'a: 'r, 'tcx: 'a> vir::CfgReplacer<PathCtxt<'p>, Action
 
         // 5. Apply effect of statement on state
         debug!("[step.5] replace_stmt: {}", stmt);
-        pctxt.apply_stmt(&stmt);
+        stmt = match stmt {
+            vir::Stmt::If(cond, then_stmts, else_stmts) => {
+                let mut then_pctxt = pctxt.clone();
+                let mut then_stmts = then_stmts.into_iter()
+                    .map(|stmt| self.replace_stmt(
+                        stmt_index, &stmt, false, &mut then_pctxt, curr_block_index, new_cfg, None
+                    ))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter().flatten()
+                    .collect::<Vec<_>>();
+                let mut else_pctxt = pctxt.clone();
+                let mut else_stmts = else_stmts.into_iter()
+                    .map(|stmt| self.replace_stmt(
+                        stmt_index, &stmt, false, &mut else_pctxt, curr_block_index, new_cfg, None
+                    ))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter().flatten()
+                    .collect::<Vec<_>>();
+                let (mut join_actions, mut joined_pctxt) = self.prepend_join(
+                    vec![&then_pctxt, &else_pctxt])?;
+                else_stmts.extend(self.perform_prejoin_action(
+                    &mut joined_pctxt, curr_block_index, join_actions.remove(1))?);
+                then_stmts.extend(self.perform_prejoin_action(
+                    &mut joined_pctxt, curr_block_index, join_actions.remove(0))?);
+                *pctxt = joined_pctxt;
+                vir::Stmt::If(cond, then_stmts, else_stmts)
+            },
+            _ => {
+                pctxt.apply_stmt(&stmt);
+                stmt
+            }
+        };
         stmts.push(stmt.clone());
 
         // 6. Recombine permissions into full if read was carved out during fold.


### PR DESCRIPTION
This PR extends the support for "if" statements further. Now, I define the semantics of if statements w.r.t. the fold/unfold algorithm. The basic idea is that applying an if statement `if (e) { b1 } else { b2 }` in a fold/unfold state `s` can result in one of two possible states:
- First, we could end up in the state `s1` that is the result of applying `b1` in the state `s` (this happens when `e` evaluates to true).
- Second, we could end up in the state `s2` that is the result of applying `b2` in the state `s` (this happens when `e` evaluates to false).

Because we don't know statically what `e` will evaluate to, the result `s'` of applying the whole if statement in state `s` is the greatest lower bound of `s1` and `s2`. Concretely, this means the access permissions we hold for a place `p` in `s'` is the minimum of what we hold in `s1` and of what we hold in `s2`. The predicate permissions for `s'` are computed analogously. The places that are considered moved permanently in `s'` are the places that are moved permanently in `s1` or `s2` (i.e., the set union).

The properties `framing_stack` and `dropped` are reset to their default empty values. I'm not sure if this is the right thing to do.

In general I do not know if my changes are actually doing the right thing, though my current understanding of the fold/unfold algorithm makes me think they do. If the changes seem sensible I would be happy if they are merged now, otherwise we can postpone merging until I can confirm that they actually work correctly. But it will take some time until I can confirm this, because there are other issues I have to work on first in order to be able to test it.