### PR TITLE
cleanup structural equality at call sites

### DIFF
--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -231,7 +231,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     }
 
     pub fn get_used_viper_domains(&self) -> Vec<vir::Domain> {
-        let mirrors = self
+        let mirrors: Vec<_> = self
             .snap_mirror_funcs
             .borrow()
             .values()
@@ -245,12 +245,14 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             .into_iter()
             .filter_map(|s| s.get_domain())
             .collect();
-        domains.push(vir::Domain {
-            name: SNAPSHOT_MIRROR_DOMAIN.to_string(),
-            functions: mirrors,
-            axioms: vec![],
-            type_vars: vec![],
-        });
+        if !mirrors.is_empty() {
+            domains.push(vir::Domain {
+                name: SNAPSHOT_MIRROR_DOMAIN.to_string(),
+                functions: mirrors,
+                axioms: vec![],
+                type_vars: vec![],
+            });
+        }
         domains.sort_by_key(|d| d.get_identifier());
         domains
     }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1944,7 +1944,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
                     "std::cmp::PartialEq::ne" |
                     "core::cmp::PartialEq::ne" => {
-                        debug_assert!(args.len() == 2);m
+                        debug_assert!(args.len() == 2);
                         debug!("Encoding call of PartialEq::ne");
 
                         stmts.extend(

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -369,11 +369,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let ty = self.encoder.resolve_typaram(self.mir.return_ty());
         self.encoder.encode_value_type(ty)
     }
-
-    pub fn encode_function_ref_return_type(&self) -> vir::Type {
-        let ty = self.encoder.resolve_typaram(self.mir.return_ty());
-        self.encoder.encode_value_or_ref_type(ty)
-    }
 }
 
 pub(super) struct PureFunctionBackwardInterpreter<'p, 'v: 'p, 'tcx: 'v> {


### PR DESCRIPTION
Changes have been tested with the 2018 compiler version; PR is mainly intended to stay in sync with the remaining upgrade.