### PR TITLE
Update package sources as part of setup.

### DIFF
--- a/x.py
+++ b/x.py
@@ -101,6 +101,7 @@ def setup_ubuntu(rustup_only):
     """Install the dependencies on Ubuntu."""
     if not rustup_only:
         # Install dependencies.
+        shell('sudo apt-get update')
         shell('sudo apt-get install -y '
               'build-essential pkg-config '
               'wget gcc libssl-dev openjdk-8-jdk')


### PR DESCRIPTION
The CI builds just failed because `apt-get` couldn't download some packages (404 Not Found). This change makes sure that we always update the package sources before attempting to install packages.