### PR TITLE
Drop obsolete proc-macro-hack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,12 +1640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
-
-[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,7 +1713,6 @@ dependencies = [
 name = "prusti-contracts-internal"
 version = "0.1.0"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2 1.0.19",
  "prusti-specs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,6 @@ dependencies = [
 name = "prusti-contracts"
 version = "0.1.0"
 dependencies = [
- "proc-macro-hack",
  "prusti-contracts-impl",
  "prusti-contracts-internal",
  "trybuild",
@@ -1712,7 +1711,6 @@ dependencies = [
 name = "prusti-contracts-impl"
 version = "0.1.0"
 dependencies = [
- "proc-macro-hack",
  "prusti-specs",
  "quote 1.0.7",
 ]

--- a/prusti-contracts-impl/Cargo.toml
+++ b/prusti-contracts-impl/Cargo.toml
@@ -9,5 +9,4 @@ proc-macro = true
 
 [dependencies]
 prusti-specs = { path = "../prusti-specs" }
-proc-macro-hack = "0.5"
 quote = "1.0"

--- a/prusti-contracts-impl/src/lib.rs
+++ b/prusti-contracts-impl/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 
 #[proc_macro_attribute]
@@ -34,7 +33,7 @@ pub fn trusted(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
     tokens
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn invariant(_tokens: TokenStream) -> TokenStream {
     (quote! { () }).into()
 }

--- a/prusti-contracts-internal/Cargo.toml
+++ b/prusti-contracts-internal/Cargo.toml
@@ -10,4 +10,3 @@ proc-macro = true
 [dependencies]
 prusti-specs = { path = "../prusti-specs" }
 proc-macro2 = "1.0.13"
-proc-macro-hack = "0.5.15"

--- a/prusti-contracts-internal/src/lib.rs
+++ b/prusti-contracts-internal/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use proc_macro_hack::proc_macro_hack;
 
 #[proc_macro_attribute]
 pub fn requires(attr: TokenStream, tokens: TokenStream) -> TokenStream {
@@ -33,7 +32,7 @@ pub fn trusted(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     prusti_specs::trusted(attr.into(), tokens.into()).into()
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn invariant(tokens: TokenStream) -> TokenStream {
     prusti_specs::invariant(tokens.into()).into()
 }

--- a/prusti-contracts/Cargo.toml
+++ b/prusti-contracts/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 prusti-contracts-impl = { path = "../prusti-contracts-impl" }
 prusti-contracts-internal = { path = "../prusti-contracts-internal", optional = true }
-proc-macro-hack = "0.5.15"
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/src/lib.rs
@@ -2,8 +2,6 @@ extern crate proc_macro;
 
 #[cfg(not(feature = "prusti"))]
 mod private {
-    use proc_macro_hack::proc_macro_hack;
-
     /// A macro for writing a precondition on a function.
     pub use prusti_contracts_impl::requires;
 
@@ -23,14 +21,11 @@ mod private {
     pub use prusti_contracts_impl::trusted;
 
     /// A macro for writing a loop invariant.
-    #[proc_macro_hack]
     pub use prusti_contracts_impl::invariant;
 }
 
 #[cfg(feature = "prusti")]
 mod private {
-    use proc_macro_hack::proc_macro_hack;
-
     /// A macro for writing a precondition on a function.
     pub use prusti_contracts_internal::requires;
 
@@ -50,7 +45,6 @@ mod private {
     pub use prusti_contracts_internal::trusted;
 
     /// A macro for writing a loop invariant.
-    #[proc_macro_hack]
     pub use prusti_contracts_internal::invariant;
 }
 

--- a/prusti/tests/pass/parse/collect.stdout
+++ b/prusti/tests/pass/parse/collect.stdout
@@ -40,49 +40,24 @@ fn test2() { }
 fn test3() {
     let mut curr = 0;
     while curr < 2 {
-
-
-        {
-            #[allow(dead_code)]
-            enum ProcMacroHack { Value = ("true", 0).1, }
-            macro_rules! proc_macro_call {
-                () =>
+        if false {
+            #[prusti::spec_only]
+            #[prusti::spec_id = "$(NUM_UUID)"]
+            #[prusti::assertion =
+              "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
+            let _prusti_loop_invariant =
                 {
-                    if false
-                    {
-                        #[prusti :: spec_only]
-                        #[prusti :: spec_id =
-                          "$(NUM_UUID)"]
-                        #[prusti :: assertion =
-                          "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
-                        let _prusti_loop_invariant =
-                        {
-                            #[prusti :: spec_only]
-                            #[prusti :: expr_id =
-                              "$(NUM_UUID)_101"] || ->
-                            bool { true } ;
-                        } ;
-                    }
-                }
-            }
-            if false {
-                #[prusti::spec_only]
-                #[prusti::spec_id = "$(NUM_UUID)"]
-                #[prusti::assertion =
-                  "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
-                let _prusti_loop_invariant =
-                    {
 
-                        #[prusti::spec_only]
-                        #[prusti::expr_id =
-                          "$(NUM_UUID)_101"]
-                        || -> bool { true };
-                    };
-            }
+                    #[prusti::spec_only]
+                    #[prusti::expr_id =
+                      "$(NUM_UUID)_101"]
+                    || -> bool { true };
+                };
         };
         curr += 1;
     }
 }
+
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -108,47 +83,24 @@ fn prusti_post_item_test4_$(NUM_UUID)(result: ()) {
 fn test4() {
     let mut curr = 0;
     while curr < 2 {
-        {
-            #[allow(dead_code)]
-            enum ProcMacroHack { Value = ("true", 0).1, }
-            macro_rules! proc_macro_call {
-                () =>
+        if false {
+            #[prusti::spec_only]
+            #[prusti::spec_id = "$(NUM_UUID)"]
+            #[prusti::assertion =
+              "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
+            let _prusti_loop_invariant =
                 {
-                    if false
-                    {
-                        #[prusti :: spec_only]
-                        #[prusti :: spec_id =
-                          "$(NUM_UUID)"]
-                        #[prusti :: assertion =
-                          "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
-                        let _prusti_loop_invariant =
-                        {
-                            #[prusti :: spec_only]
-                            #[prusti :: expr_id =
-                              "$(NUM_UUID)_101"] || ->
-                            bool { true } ;
-                        } ;
-                    }
-                }
-            }
-            if false {
-                #[prusti::spec_only]
-                #[prusti::spec_id = "$(NUM_UUID)"]
-                #[prusti::assertion =
-                  "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
-                let _prusti_loop_invariant =
-                    {
 
-                        #[prusti::spec_only]
-                        #[prusti::expr_id =
-                          "$(NUM_UUID)_101"]
-                        || -> bool { true };
-                    };
-            }
+                    #[prusti::spec_only]
+                    #[prusti::expr_id =
+                      "$(NUM_UUID)_101"]
+                    || -> bool { true };
+                };
         };
         curr += 1;
     }
 }
+
 fn main() { }
 Collected verification items 5:
 procedure: collect::test3[0] at $DIR/collect.rs:16:1: 22:2 (#0)

--- a/prusti/tests/pass/parse/parse_err.stderr
+++ b/prusti/tests/pass/parse/parse_err.stderr
@@ -15,12 +15,8 @@ error: expected expression
    |
 14 |         invariant!(true ++ 1)
    |                          ^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression
   --> $DIR/parse_err.rs:27:17

--- a/prusti/tests/pass/parse/true.stdout
+++ b/prusti/tests/pass/parse/true.stdout
@@ -39,48 +39,23 @@ fn test2() { }
 
 fn test3() {
     for _ in 0..2 {
-
-
-        {
-            #[allow(dead_code)]
-            enum ProcMacroHack { Value = ("true", 0).1, }
-            macro_rules! proc_macro_call {
-                () =>
+        if false {
+            #[prusti::spec_only]
+            #[prusti::spec_id = "$(NUM_UUID)"]
+            #[prusti::assertion =
+              "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
+            let _prusti_loop_invariant =
                 {
-                    if false
-                    {
-                        #[prusti :: spec_only]
-                        #[prusti :: spec_id =
-                          "$(NUM_UUID)"]
-                        #[prusti :: assertion =
-                          "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
-                        let _prusti_loop_invariant =
-                        {
-                            #[prusti :: spec_only]
-                            #[prusti :: expr_id =
-                              "$(NUM_UUID)_101"] || ->
-                            bool { true } ;
-                        } ;
-                    }
-                }
-            }
-            if false {
-                #[prusti::spec_only]
-                #[prusti::spec_id = "$(NUM_UUID)"]
-                #[prusti::assertion =
-                  "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
-                let _prusti_loop_invariant =
-                    {
 
-                        #[prusti::spec_only]
-                        #[prusti::expr_id =
-                          "$(NUM_UUID)_101"]
-                        || -> bool { true };
-                    };
-            }
+                    #[prusti::spec_only]
+                    #[prusti::expr_id =
+                      "$(NUM_UUID)_101"]
+                    || -> bool { true };
+                };
         }
     }
 }
+
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -105,50 +80,27 @@ fn prusti_post_item_test4_$(NUM_UUID)(result: ()) {
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test4() {
     for _ in 0..2 {
-        {
-            #[allow(dead_code)]
-            enum ProcMacroHack { Value = ("true", 0).1, }
-            macro_rules! proc_macro_call {
-                () =>
+        if false {
+            #[prusti::spec_only]
+            #[prusti::spec_id = "$(NUM_UUID)"]
+            #[prusti::assertion =
+              "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
+            let _prusti_loop_invariant =
                 {
-                    if false
-                    {
-                        #[prusti :: spec_only]
-                        #[prusti :: spec_id =
-                          "$(NUM_UUID)"]
-                        #[prusti :: assertion =
-                          "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
-                        let _prusti_loop_invariant =
-                        {
-                            #[prusti :: spec_only]
-                            #[prusti :: expr_id =
-                              "$(NUM_UUID)_101"] || ->
-                            bool { true } ;
-                        } ;
-                    }
-                }
-            }
-            if false {
-                #[prusti::spec_only]
-                #[prusti::spec_id = "$(NUM_UUID)"]
-                #[prusti::assertion =
-                  "{/"kind/":{/"Expr/":{/"spec_id/":/"$(UUID)/",/"expr_id/":101}}}"]
-                let _prusti_loop_invariant =
-                    {
 
-                        #[prusti::spec_only]
-                        #[prusti::expr_id =
-                          "$(NUM_UUID)_101"]
-                        || -> bool { true };
-                    };
-            }
+                    #[prusti::spec_only]
+                    #[prusti::expr_id =
+                      "$(NUM_UUID)_101"]
+                    || -> bool { true };
+                };
         }
     }
 }
+
 fn main() { }
-Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:17 ~ true[317d]::test3[0]::{{closure}}[0]) }) })
-Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:28 ~ true[317d]::test4[0]::{{closure}}[0]) }) })
+Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:12 ~ true[317d]::test3[0]::{{closure}}[0]) }) })
+Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:18 ~ true[317d]::test4[0]::{{closure}}[0]) }) })
 Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:7 ~ true[317d]::prusti_pre_item_test1_$(NUM_UUID)[0]::{{closure}}[0]) }) })
-Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:19 ~ true[317d]::prusti_pre_item_test4_$(NUM_UUID)[0]::{{closure}}[0]) }) })
+Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:14 ~ true[317d]::prusti_pre_item_test4_$(NUM_UUID)[0]::{{closure}}[0]) }) })
 Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:10 ~ true[317d]::prusti_post_item_test2_$(NUM_UUID)[0]::{{closure}}[0]) }) })
-Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:21 ~ true[317d]::prusti_post_item_test4_$(NUM_UUID)[0]::{{closure}}[0]) }) })
+Assertion(Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:16 ~ true[317d]::prusti_post_item_test4_$(NUM_UUID)[0]::{{closure}}[0]) }) })


### PR DESCRIPTION
The [documentation](https://docs.rs/proc-macro-hack/0.5.18/proc_macro_hack/) for the `proc_macro_hack` crate tells us that this "hack" is obsolete since we've upgraded to the newer compiler version. I therefore suggest to drop it, because that would make the generated "desugared" (what `-Zprint-desugared-specs` prints) Rust code cleaner and easier to read.

However, there is one remaining weird test case failure (`prusti/tests/pass/parse/collect.rs`): "Weird" because it *reliably* passes if I call it individually
```
cargo test collect
```
and *reliably* fails when I call just `cargo test`:
```
[...]
------------------------------------------
stderr:
------------------------------------------
Verification of 5 items...
thread 'rustc' panicked at 'no entry found for key', prusti-interface/src/environment/borrowck/facts.rs:255:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.47.0-nightly (6c8927b0c 2020-07-26) running on x86_64-unknown-linux-gnu

note: compiler flags: -Z print-desugared-specs -Z print-collected-verification-items -Z hide-uuids -C prefer-dynamic


------------------------------------------

test [ui] parse/collect.rs ... FAILED
[...]
```
Backtrace:
```
[...]
------------------------------------------
stderr:
------------------------------------------
Verification of 5 items...
thread 'rustc' panicked at 'index out of bounds: the len is 1 but the index is 4', prusti-interface/src/environment/polonius_info.rs:1830:9
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1117
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1508
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:217
  10: rustc_driver::report_ice
  11: <alloc::boxed::Box<F> as core::ops::function::Fn<A>>::call
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/liballoc/boxed.rs:1088
  12: proc_macro::bridge::client::<impl proc_macro::bridge::Bridge>::enter::{{closure}}::{{closure}}
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libproc_macro/bridge/client.rs:318
  13: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:530
  14: rust_begin_unwind
             at src/libstd/panicking.rs:437
  15: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  16: core::panicking::panic_bounds_check
             at src/libcore/panicking.rs:62
  17: <usize as core::slice::SliceIndex<[T]>>::index
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/slice/mod.rs:3116
  18: core::slice::<impl core::ops::index::Index<I> for [T]>::index
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/slice/mod.rs:2959
  19: <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/liballoc/vec.rs:1973
  20: <rustc_index::vec::IndexVec<I,T> as core::ops::index::Index<I>>::index
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/librustc_index/vec.rs:717
  21: <rustc_middle::mir::Body as core::ops::index::Index<rustc_middle::mir::BasicBlock>>::index
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/librustc_middle/mir/mod.rs:432
  22: prusti_interface::environment::polonius_info::is_call
             at prusti-interface/src/environment/polonius_info.rs:1830
  23: prusti_interface::environment::polonius_info::add_fake_facts
             at prusti-interface/src/environment/polonius_info.rs:529
  24: prusti_interface::environment::polonius_info::PoloniusInfo::new
             at prusti-interface/src/environment/polonius_info.rs:725
  25: prusti_viper::encoder::procedure_encoder::ProcedureEncoder::encode
             at prusti-viper/src/encoder/procedure_encoder.rs:351
  26: prusti_viper::encoder::encoder::Encoder::encode_procedure
             at prusti-viper/src/encoder/encoder.rs:1010
  27: prusti_viper::encoder::encoder::Encoder::process_encoding_queue
             at prusti-viper/src/encoder/encoder.rs:1675
  28: prusti_viper::verifier::Verifier::verify
             at prusti-viper/src/verifier.rs:241
  29: prusti::verifier::verify
             at prusti/src/verifier.rs:51
  30: <prusti::PrustiCompilerCalls as rustc_driver::Callbacks>::after_analysis::{{closure}}
             at prusti/src/lib.rs:100
  31: rustc_middle::ty::context::tls::enter_global::{{closure}}
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/librustc_middle/ty/context.rs:1744
  32: rustc_middle::ty::context::tls::enter_context::{{closure}}
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/librustc_middle/ty/context.rs:1721
  33: rustc_middle::ty::context::tls::set_tlv
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/librustc_middle/ty/context.rs:1705
  34: rustc_middle::ty::context::tls::enter_context
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/librustc_middle/ty/context.rs:1721
  35: rustc_middle::ty::context::tls::enter_global
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/librustc_middle/ty/context.rs:1744
  36: rustc_interface::passes::QueryContext::enter
             at /home/[...]/.rustup/toolchains/nightly-2020-07-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/librustc_interface/passes.rs:755
  37: <prusti::PrustiCompilerCalls as rustc_driver::Callbacks>::after_analysis
             at prusti/src/lib.rs:70
  38: rustc_interface::queries::<impl rustc_interface::interface::Compiler>::enter
  39: rustc_span::with_source_map
  40: rustc_interface::interface::create_compiler_and_run
  41: scoped_tls::ScopedKey<T>::set
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.47.0-nightly (6c8927b0c 2020-07-26) running on x86_64-unknown-linux-gnu

note: compiler flags: -Z print-desugared-specs -Z print-collected-verification-items -Z hide-uuids -C prefer-dynamic

query stack during panic:
end of query stack

------------------------------------------

test [ui] parse/collect.rs ... FAILED
[...]
```
Any ideas?