### PR TITLE
Loop body invariant

### DIFF
--- a/prusti-contracts-impl/src/lib.rs
+++ b/prusti-contracts-impl/src/lib.rs
@@ -34,6 +34,6 @@ pub fn trusted(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-pub fn invariant(_tokens: TokenStream) -> TokenStream {
+pub fn body_invariant(_tokens: TokenStream) -> TokenStream {
     (quote! { () }).into()
 }

--- a/prusti-contracts-internal/src/lib.rs
+++ b/prusti-contracts-internal/src/lib.rs
@@ -33,6 +33,6 @@ pub fn trusted(attr: TokenStream, tokens: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-pub fn invariant(tokens: TokenStream) -> TokenStream {
-    prusti_specs::invariant(tokens.into()).into()
+pub fn body_invariant(tokens: TokenStream) -> TokenStream {
+    prusti_specs::body_invariant(tokens.into()).into()
 }

--- a/prusti-contracts-test/Cargo.lock
+++ b/prusti-contracts-test/Cargo.lock
@@ -36,12 +36,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,7 +48,6 @@ dependencies = [
 name = "prusti-contracts"
 version = "0.1.0"
 dependencies = [
- "proc-macro-hack",
  "prusti-contracts-impl",
 ]
 
@@ -62,7 +55,6 @@ dependencies = [
 name = "prusti-contracts-impl"
 version = "0.1.0"
 dependencies = [
- "proc-macro-hack",
  "prusti-specs",
  "quote",
 ]

--- a/prusti-contracts-test/src/lib.rs
+++ b/prusti-contracts-test/src/lib.rs
@@ -8,7 +8,7 @@ pub fn test2() {}
 
 pub fn test3() {
     for _ in 0..2 {
-        invariant!(true)
+        body_invariant!(true)
     }
 }
 
@@ -16,6 +16,6 @@ pub fn test3() {
 #[ensures(true)]
 pub fn test4() {
     for _ in 0..2 {
-        invariant!(true)
+        body_invariant!(true)
     }
 }

--- a/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/src/lib.rs
@@ -20,8 +20,8 @@ mod private {
     /// A macro for marking a function as trusted.
     pub use prusti_contracts_impl::trusted;
 
-    /// A macro for writing a loop invariant.
-    pub use prusti_contracts_impl::invariant;
+    /// A macro for writing a loop body invariant.
+    pub use prusti_contracts_impl::body_invariant;
 }
 
 #[cfg(feature = "prusti")]
@@ -44,8 +44,8 @@ mod private {
     /// A macro for marking a function as trusted.
     pub use prusti_contracts_internal::trusted;
 
-    /// A macro for writing a loop invariant.
-    pub use prusti_contracts_internal::invariant;
+    /// A macro for writing a loop body invariant.
+    pub use prusti_contracts_internal::body_invariant;
 }
 
 

--- a/prusti-contracts/tests/pass/true.rs
+++ b/prusti-contracts/tests/pass/true.rs
@@ -11,7 +11,7 @@ fn test2() {}
 
 fn test3() {
     for _ in 0..2 {
-        invariant!(true);
+        body_invariant!(true);
     }
 }
 
@@ -19,7 +19,7 @@ fn test3() {
 #[ensures(true)]
 fn test4() {
     for _ in 0..2 {
-        invariant!(true);
+        body_invariant!(true);
     }
 }
 

--- a/prusti-specs/src/lib.rs
+++ b/prusti-specs/src/lib.rs
@@ -117,7 +117,7 @@ pub fn trusted(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
     }
 }
 
-pub fn invariant(tokens: TokenStream) -> TokenStream {
+pub fn body_invariant(tokens: TokenStream) -> TokenStream {
     let mut rewriter = rewriter::AstRewriter::new();
     let spec_id = rewriter.generate_spec_id();
     let invariant = handle_result!(rewriter.parse_assertion(spec_id, tokens));

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -2,7 +2,7 @@
 /// parses the resulting Rust expressions, and then assembles the composite
 /// Prusti assertion.
 
-use proc_macro2::{Delimiter, Group, Spacing, Span, TokenStream, TokenTree};
+use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
 use std::collections::VecDeque;
 use std::mem;
 use syn::parse::{ParseStream, Parse};

--- a/prusti/tests/pass/parse/collect.rs
+++ b/prusti/tests/pass/parse/collect.rs
@@ -16,7 +16,7 @@ fn test2() {}
 fn test3() {
     let mut curr = 0;
     while curr < 2 {
-        invariant!(true);
+        body_invariant!(true);
         curr += 1;
     }
 }
@@ -26,7 +26,7 @@ fn test3() {
 fn test4() {
     let mut curr = 0;
     while curr < 2 {
-        invariant!(true);
+        body_invariant!(true);
         curr += 1;
     }
 }

--- a/prusti/tests/pass/parse/parse_err.rs
+++ b/prusti/tests/pass/parse/parse_err.rs
@@ -11,7 +11,7 @@ fn test2() {}
 
 fn test3() {
     for _ in 0..2 {
-        invariant!(true ++ 1)
+        body_invariant!(true ++ 1)
     }
 }
 
@@ -19,7 +19,7 @@ fn test3() {
 #[ensures(true)]
 fn test4() {
     for _ in 0..2 {
-        invariant!(true ++ 1)
+        body_invariant!(true ++ 1)
     }
 }
 
@@ -27,7 +27,7 @@ fn test4() {
 #[ensures(true ++ 1)]
 fn test5() {
     for _ in 0..2 {
-        invariant!(true ++ 1)
+        body_invariant!(true ++ 1)
     }
 }
 

--- a/prusti/tests/pass/parse/parse_err.stderr
+++ b/prusti/tests/pass/parse/parse_err.stderr
@@ -11,10 +11,10 @@ error: expected expression
   |                 ^
 
 error: expected expression
-  --> $DIR/parse_err.rs:14:26
+  --> $DIR/parse_err.rs:14:31
    |
-14 |         invariant!(true ++ 1)
-   |                          ^
+14 |         body_invariant!(true ++ 1)
+   |                               ^
 
 error: expected expression
 

--- a/prusti/tests/pass/parse/true.rs
+++ b/prusti/tests/pass/parse/true.rs
@@ -15,7 +15,7 @@ fn test2() {}
 
 fn test3() {
     for _ in 0..2 {
-        invariant!(true)
+        body_invariant!(true)
     }
 }
 
@@ -23,7 +23,7 @@ fn test3() {
 #[ensures(true)]
 fn test4() {
     for _ in 0..2 {
-        invariant!(true)
+        body_invariant!(true)
     }
 }
 


### PR DESCRIPTION
Rename `invariant!` to `body_invariant!`.

Motivation:
* The loop invariant in Prusti has unusual semantics that it is only a body invariant. I think naming the macro `body_invariant` makes this point clearer.
* Prusti has not only loop, but also object and trait invariants. While the former are implemented as function-like macros `macro!(...)`, the latter are attribute macros `#[macro(...)]` and, as a result, need to be named differently. Therefore, my proposal is to call the loop invariants `body_invariant!(...)` and trait invariants `#[trait_invariant(...)]`. The additional advantage of having unique names is that it is going to be easier for the users to find the relevant parts of the documentation (once we have it).

cc @karlosss @fpoli @cmatheja @Aurel300 