### PR TITLE
When adding a statement, also pick up on nested labels.

### DIFF
--- a/prusti-common/src/vir/cfg/method.rs
+++ b/prusti-common/src/vir/cfg/method.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::iter::FromIterator;
 use uuid::Uuid;
 use vir::ast::*;
+use vir::gather_labels::gather_labels;
 
 pub(super) const RETURN_LABEL: &str = "end_of_method";
 
@@ -232,14 +233,14 @@ impl CfgMethod {
     }
 
     pub fn add_stmt(&mut self, index: CfgBlockIndex, stmt: Stmt) {
-        if let &Stmt::Label(ref label_name) = &stmt {
+        for label_name in gather_labels(&stmt) {
             assert!(
-                self.is_fresh_local_name(label_name),
+                self.is_fresh_local_name(&label_name),
                 "label {} is not fresh",
                 label_name
             );
-            self.labels.insert(label_name.clone());
-        };
+            self.labels.insert(label_name);
+        }
         self.basic_blocks[index.block_index].stmts.push(stmt);
     }
 

--- a/prusti-common/src/vir/gather_labels.rs
+++ b/prusti-common/src/vir/gather_labels.rs
@@ -1,0 +1,19 @@
+use vir::StmtWalker;
+use vir::ast;
+
+pub(super) fn gather_labels(stmt: &ast::Stmt) -> Vec<String> {
+    let mut gather_labels = GatherLabels::default();
+    gather_labels.walk(stmt);
+    gather_labels.labels
+}
+
+#[derive(Default)]
+struct GatherLabels {
+    labels: Vec<String>
+}
+
+impl StmtWalker for GatherLabels {
+    fn walk_label(&mut self, label: &str) {
+        self.labels.push(label.to_string());
+    }
+}

--- a/prusti-common/src/vir/mod.rs
+++ b/prusti-common/src/vir/mod.rs
@@ -19,3 +19,4 @@ pub mod optimizations;
 mod to_viper;
 pub mod utils;
 mod program;
+mod gather_labels;


### PR DESCRIPTION
Adding a statement to a CFG checks if the statement is a label, and adds it to a CFG-global list of labels if this is the case. However, this misses labels when they are nested within other statements (e.g., if statements). With this change, also nested labels are added to the CFG-global list of labels.