### PR TITLE
Use env in x.py

### DIFF
--- a/x.py
+++ b/x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """A wrapper for cargo that sets up the Prusti environment."""
 


### PR DESCRIPTION
This is the standard way to specify the shebang for a Python script. Now `./x.py` (rather than `python3 x.py`) works on a(n older) Mac as well.