### PR TITLE
has_prusti_attr and has_spec_only_attr

### DIFF
--- a/prusti-interface/src/environment/collect_closure_defs_visitor.rs
+++ b/prusti-interface/src/environment/collect_closure_defs_visitor.rs
@@ -1,11 +1,12 @@
 use rustc_hir::intravisit::{Visitor, NestedVisitorMap, ErasedMap, walk_expr, FnKind};
 use rustc_hir as hir;
 use rustc_middle::hir::map::Map;
-use crate::environment::{collect_prusti_spec_visitor::contains_name, Environment};
+use crate::environment::Environment;
 use log::{trace, debug};
 use rustc_hir::def_id::DefId;
 use rustc_span::Span;
 use rustc_middle::ty::TypeckResults;
+use crate::utils::has_spec_only_attr;
 
 pub struct CollectClosureDefsVisitor<'env, 'tcx: 'env> {
     env: &'env Environment<'tcx>,
@@ -36,7 +37,7 @@ impl<'env, 'tcx> Visitor<'tcx> for CollectClosureDefsVisitor<'env, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
         match expr.kind {
             hir::ExprKind::Closure(_, _, _, _, _) => {
-                if !contains_name(&expr.attrs, "spec_only") {
+                if !has_spec_only_attr(&expr.attrs) {
                     let tcx = self.env.tcx();
                     let def_id = self.map.local_def_id(expr.hir_id).to_def_id();
                     let item_def_path = self.env.get_item_def_path(def_id);

--- a/prusti-interface/src/environment/collect_prusti_spec_visitor.rs
+++ b/prusti-interface/src/environment/collect_prusti_spec_visitor.rs
@@ -14,28 +14,7 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 use log::{trace, debug};
 use rustc_ast::ast;
-
-/// Check whether the `attrs` contain `prusti::$name` attribute.
-/// FIXME: Move this function to utils.
-pub(crate) fn contains_name(attrs: &[ast::Attribute], name: &str) -> bool {
-    for attr in attrs {
-        match &attr.kind {
-            ast::AttrKind::DocComment(_, symbol) => {},
-            ast::AttrKind::Normal(ast::AttrItem {
-                path: ast::Path { span: _, segments, tokens: _ },
-                args: _,
-                tokens: _,
-            }) => {
-                if segments.len() == 2 && segments[0].ident.name.with(
-                    |attr_name| attr_name == "prusti"
-                ) && segments[1].ident.name.with(|attr_name| attr_name == name) {
-                    return true;
-                }
-            }
-        }
-    }
-    false
-}
+use crate::utils::has_spec_only_attr;
 
 pub struct CollectPrustiSpecVisitor<'a, 'tcx: 'a> {
     env: &'a Environment<'tcx>,
@@ -62,8 +41,7 @@ impl<'a, 'tcx> CollectPrustiSpecVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx> ItemLikeVisitor<'tcx> for CollectPrustiSpecVisitor<'a, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
-        if contains_name(&item.attrs, "spec_only")
-        {
+        if has_spec_only_attr(&item.attrs) {
             return;
         }
         if let hir::ItemKind::Fn(..) = item.kind {
@@ -75,8 +53,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for CollectPrustiSpecVisitor<'a, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, trait_item: &hir::TraitItem) {
-        if contains_name(&trait_item.attrs, "spec_only")
-        {
+        if has_spec_only_attr(&trait_item.attrs) {
             return;
         }
 
@@ -98,8 +75,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for CollectPrustiSpecVisitor<'a, 'tcx> {
     }
 
     fn visit_impl_item(&mut self, impl_item: &hir::ImplItem) {
-        if contains_name(&impl_item.attrs, "spec_only")
-        {
+        if has_spec_only_attr(&impl_item.attrs) {
             return;
         }
 

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -190,7 +190,7 @@ impl<'tcx> Environment<'tcx> {
     /// Find whether the procedure has a particular attribute
     pub fn has_attribute_name(&self, def_id: ProcedureDefId, name: &str) -> bool {
         let tcx = self.tcx();
-        crate::environment::collect_prusti_spec_visitor::contains_name(tcx.get_attrs(def_id), name)
+        crate::utils::has_prusti_attr(tcx.get_attrs(def_id), name)
     }
 
     /// Dump various information from the borrow checker.

--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -245,30 +245,7 @@ fn build_reachable_basic_blocks(mir: &Mir) -> HashSet<BasicBlock> {
 }
 
 fn is_spec_closure(def_id: def_id::DefId, tcx: &TyCtxt) -> bool {
-    use rustc_ast::ast;
-    tcx
-        .get_attrs(def_id)
-        .iter()
-        .any(|attr|
-            match &attr.kind {
-                ast::AttrKind::Normal(ast::AttrItem {
-                    path: ast::Path { span: _, segments, tokens: _ },
-                    args: ast::MacArgs::Empty,
-                    tokens: _
-                }) => {
-                    segments.len() == 2
-                    && segments[0]
-                        .ident
-                        .name
-                        .with(|attr_name| attr_name == "prusti")
-                    && segments[1]
-                        .ident
-                        .name
-                        .with(|attr_name| attr_name == "spec_only")
-                },
-                _ => false,
-            }
-        )
+    crate::utils::has_spec_only_attr(tcx.get_attrs(def_id))
 }
 
 fn is_spec_basic_block(bb_data: &BasicBlockData, tcx: &TyCtxt) -> bool {

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -8,6 +8,7 @@ use rustc_span::symbol::Symbol;
 use rustc_hir::def_id::LocalDefId;
 use std::collections::HashMap;
 use std::convert::TryInto;
+use crate::utils::has_spec_only_attr;
 
 pub mod typed;
 
@@ -98,28 +99,6 @@ fn reconstruct_typed_assertion<'tcx>(
     tcx: TyCtxt<'tcx>
 ) -> typed::Assertion<'tcx> {
     assertion.to_typed(typed_expressions, tcx)
-}
-
-/// Check if `prusti::spec_only` is among the attributes.
-fn has_spec_only_attr(attrs: &[ast::Attribute]) -> bool {
-    attrs.iter().any(|attr| match &attr.kind {
-        ast::AttrKind::Normal(ast::AttrItem {
-            path: ast::Path { span: _, segments, tokens: _ },
-            args: ast::MacArgs::Empty,
-            tokens: _,
-        }) => {
-            segments.len() == 2
-                && segments[0]
-                    .ident
-                    .name
-                    .with(|attr_name| attr_name == "prusti")
-                && segments[1]
-                    .ident
-                    .name
-                    .with(|attr_name| attr_name == "spec_only")
-        }
-        _ => false,
-    })
 }
 
 /// Read the value stored in a Prusti attribute (e.g. `prusti::<attr_name>="...")`.

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -263,6 +263,34 @@ impl<'tcx> VecPlace<'tcx> {
     }
 }
 
+/// Check if `prusti::<name>` is among the attributes.
+/// The attribute must not have any arguments.
+pub fn has_prusti_attr(attrs: &[ast::Attribute], name: &str) -> bool {
+    attrs.iter().any(|attr| match &attr.kind {
+        ast::AttrKind::Normal(ast::AttrItem {
+                                  path: ast::Path { span: _, segments, tokens: _ },
+                                  args: ast::MacArgs::Empty,
+                                  tokens: _,
+                              }) => {
+            segments.len() == 2
+                && segments[0]
+                .ident
+                .name
+                .with(|attr_name| attr_name == "prusti")
+                && segments[1]
+                .ident
+                .name
+                .with(|attr_name| attr_name == name)
+        }
+        _ => false,
+    })
+}
+
+/// Check if `prusti::spec_only` is among the attributes.
+pub fn has_spec_only_attr(attrs: &[ast::Attribute]) -> bool {
+    has_prusti_attr(attrs, "spec_only")
+}
+
 // pub fn get_attr_value(attr: &ast::Attribute) -> String {
 //     use syntax::parse::token;
 //     use syntax::tokenstream::TokenTree;

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -28,6 +28,7 @@ use prusti_interface::data::ProcedureDefId;
 use prusti_interface::environment::Environment;
 use prusti_interface::specs::typed;
 use prusti_interface::specs::typed::SpecificationId;
+use prusti_interface::utils::has_spec_only_attr;
 // use prusti_interface::specs::{
 //     SpecID, SpecificationSet, TypedAssertion,
 //     TypedSpecificationMap, TypedSpecificationSet,
@@ -383,31 +384,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     /// Is the closure specified with the `def_id` is spec only?
     pub fn is_spec_closure(&self, def_id: DefId) -> bool {
         use rustc_ast::ast;
-        self
-            .env()
-            .tcx()
-            .get_attrs(def_id)
-            .iter()
-            .any(|attr|
-                match &attr.kind {
-                    ast::AttrKind::Normal(ast::AttrItem {
-                        path: ast::Path { span: _, segments, tokens: _ },
-                        args: ast::MacArgs::Empty,
-                        tokens: _,
-                    }) => {
-                        segments.len() == 2
-                        && segments[0]
-                            .ident
-                            .name
-                            .with(|attr_name| attr_name == "prusti")
-                        && segments[1]
-                            .ident
-                            .name
-                            .with(|attr_name| attr_name == "spec_only")
-                    },
-                    _ => false,
-                }
-            )
+        has_spec_only_attr(self.env().tcx().get_attrs(def_id))
     }
 
     fn get_opt_spec_id(&self, def_id: DefId) -> Vec<SpecIdRef> {


### PR DESCRIPTION
 - added `prusti_interface::utils::{has_prusti_attr, has_spec_only_attr}`
 - cleaned up places where a duplicate function was found

There are still places where attributes are checked similarly, but not quite the same. `prusti_interface::specs::read_prusti_attr` checks for attributes with arguments, `prusti_viper::encoder::Encoder::get_opt_spec_id` likewise.

Once merged I will rebase #145.