### PR TITLE
Prevent warnings

### DIFF
--- a/prusti-specs/src/rewriter.rs
+++ b/prusti-specs/src/rewriter.rs
@@ -115,6 +115,7 @@ impl AstRewriter {
         let spec_id_str = spec_id.to_string();
         let assertion_json = crate::specifications::json::to_json_string(&assertion);
         let mut spec_item: syn::ItemFn = syn::parse_quote! {
+            #[allow(unused_must_use, unused_variables)]
             #[prusti::spec_only]
             #[prusti::spec_id = #spec_id_str]
             #[prusti::assertion = #assertion_json]
@@ -142,6 +143,7 @@ impl AstRewriter {
         let spec_id_str = spec_id.to_string();
         let assertion_json = crate::specifications::json::to_json_string(&assertion);
         quote! {
+            #[allow(unused_must_use, unused_variables)]
             #[prusti::spec_only]
             #[prusti::loop_body_invariant_spec]
             #[prusti::spec_id = #spec_id_str]

--- a/prusti-tests/tests/parse/ui/after_expiry.stdout
+++ b/prusti-tests/tests/parse/ui/after_expiry.stdout
@@ -15,6 +15,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -26,6 +27,7 @@ fn prusti_post_item_test1_$(NUM_UUID)(a: bool,
     #[prusti::expr_id = "$(NUM_UUID)_102"]
     || -> bool { a };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -40,6 +42,7 @@ fn prusti_post_item_test1_$(NUM_UUID)(a: bool,
 #[prusti::pledge_spec_id_ref =
   "$(NUM_UUID):$(NUM_UUID)"]
 fn test1(a: bool) { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -51,6 +54,7 @@ fn prusti_post_item_test2_$(NUM_UUID)(a: bool,
     #[prusti::expr_id = "$(NUM_UUID)_101"]
     || -> bool { a };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -65,6 +69,7 @@ fn prusti_post_item_test2_$(NUM_UUID)(a: bool,
 #[prusti::pledge_spec_id_ref =
   "$(NUM_UUID):$(NUM_UUID)"]
 fn test2(a: bool) { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -78,6 +83,7 @@ fn prusti_post_item_test3_$(NUM_UUID)(a: bool,
 }
 #[prusti::pledge_spec_id_ref = ":$(NUM_UUID)"]
 fn test3(a: bool) { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -91,6 +97,7 @@ fn prusti_post_item_test4_$(NUM_UUID)(a: bool,
 }
 #[prusti::pledge_spec_id_ref = ":$(NUM_UUID)"]
 fn test4(a: bool) { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/parse/ui/and.stdout
+++ b/prusti-tests/tests/parse/ui/and.stdout
@@ -15,6 +15,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -31,6 +32,7 @@ fn prusti_pre_item_test1_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test1() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -51,6 +53,7 @@ fn prusti_pre_item_test2_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test2() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -71,6 +74,7 @@ fn prusti_pre_item_test3_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test3() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -91,6 +95,7 @@ fn prusti_pre_item_test4_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test4() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/parse/ui/composite.stdout
+++ b/prusti-tests/tests/parse/ui/composite.stdout
@@ -26,6 +26,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -50,6 +51,7 @@ fn prusti_pre_item_test1_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test1() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -78,6 +80,7 @@ fn prusti_pre_item_test2_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test2() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -98,6 +101,7 @@ fn prusti_pre_item_test3_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test3() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -122,6 +126,7 @@ fn prusti_pre_item_test4_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test4() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -150,6 +155,7 @@ fn prusti_pre_item_test5_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test5() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -182,6 +188,7 @@ fn prusti_pre_item_test6_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test6() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -214,6 +221,7 @@ fn prusti_pre_item_test7_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test7() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -230,6 +238,7 @@ fn prusti_pre_item_test8_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test8() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -246,6 +255,7 @@ fn prusti_pre_item_test9_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test9() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -268,6 +278,7 @@ fn prusti_pre_item_test10_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test10() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -290,6 +301,7 @@ fn prusti_pre_item_test11_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test11() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -308,6 +320,7 @@ fn prusti_pre_item_test12_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test12() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -334,6 +347,7 @@ fn prusti_pre_item_test13_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test13() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -356,6 +370,7 @@ fn prusti_pre_item_test14_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test14() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -378,6 +393,7 @@ fn prusti_pre_item_test15_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test15() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/parse/ui/expression.stdout
+++ b/prusti-tests/tests/parse/ui/expression.stdout
@@ -12,6 +12,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -28,6 +29,7 @@ fn prusti_pre_item_test1_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test1() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/parse/ui/forall.stdout
+++ b/prusti-tests/tests/parse/ui/forall.stdout
@@ -16,6 +16,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -34,6 +35,7 @@ fn prusti_pre_item_test3_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test3() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -52,6 +54,7 @@ fn prusti_pre_item_test4_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test4() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -74,6 +77,7 @@ fn prusti_pre_item_test5_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test5() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -100,6 +104,7 @@ fn prusti_pre_item_test8_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test8() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -130,6 +135,7 @@ fn prusti_pre_item_test9_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test9() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/parse/ui/implies.stdout
+++ b/prusti-tests/tests/parse/ui/implies.stdout
@@ -15,6 +15,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -31,6 +32,7 @@ fn prusti_pre_item_test1_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test1() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -51,6 +53,7 @@ fn prusti_pre_item_test2_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test2() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -71,6 +74,7 @@ fn prusti_pre_item_test3_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test3() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -91,6 +95,7 @@ fn prusti_pre_item_test4_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test4() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/parse/ui/true.stdout
+++ b/prusti-tests/tests/parse/ui/true.stdout
@@ -14,6 +14,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -26,6 +27,7 @@ fn prusti_pre_item_test1_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test1() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -42,6 +44,7 @@ fn test3() {
     for _ in 0..2 {
         if false {
 
+            #[allow(unused_must_use, unused_variables)]
             #[prusti::spec_only]
             #[prusti::loop_body_invariant_spec]
             #[prusti::spec_id = "$(NUM_UUID)"]
@@ -58,6 +61,7 @@ fn test3() {
         }
     }
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -68,6 +72,7 @@ fn prusti_pre_item_test4_$(NUM_UUID)() {
     #[prusti::expr_id = "$(NUM_UUID)_101"]
     || -> bool { true };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -84,6 +89,7 @@ fn test4() {
     for _ in 0..2 {
         if false {
 
+            #[allow(unused_must_use, unused_variables)]
             #[prusti::spec_only]
             #[prusti::loop_body_invariant_spec]
             #[prusti::spec_id = "$(NUM_UUID)"]

--- a/prusti-tests/tests/typecheck/ui/forall_encode_typeck.stdout
+++ b/prusti-tests/tests/typecheck/ui/forall_encode_typeck.stdout
@@ -11,6 +11,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/typecheck/ui/forall_triggers.stdout
+++ b/prusti-tests/tests/typecheck/ui/forall_triggers.stdout
@@ -14,6 +14,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -36,6 +37,7 @@ fn prusti_pre_item_test1_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test1() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -65,6 +67,7 @@ fn prusti_pre_item_test2_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test2() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -99,6 +102,7 @@ fn prusti_pre_item_test3_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test3() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/typecheck/ui/nested_forall.stdout
+++ b/prusti-tests/tests/typecheck/ui/nested_forall.stdout
@@ -13,6 +13,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -38,6 +39,7 @@ fn prusti_pre_item_test1_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test1() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -68,6 +70,7 @@ fn prusti_pre_item_test2_$(NUM_UUID)() {
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 fn test2() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/verify/ui/calls.stdout
+++ b/prusti-tests/tests/verify/ui/calls.stdout
@@ -20,6 +20,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -31,6 +32,7 @@ fn prusti_post_item_max_$(NUM_UUID)(a: i32, b: i32,
     #[prusti::expr_id = "$(NUM_UUID)_101"]
     || -> bool { result == a || result == b };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -61,6 +63,7 @@ fn test_max2() {
     let z = max(a, b);
     if !(z == 5) { { ::std::rt::begin_panic("assertion failed: z == 5") } };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/verify/ui/false.stdout
+++ b/prusti-tests/tests/verify/ui/false.stdout
@@ -12,6 +12,7 @@ use std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/verify/ui/forall_verify.stdout
+++ b/prusti-tests/tests/verify/ui/forall_verify.stdout
@@ -16,6 +16,7 @@ extern crate std;
 use prusti_contracts::*;
 #[prusti::pure]
 fn identity(x: i32) -> i32 { x }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -34,6 +35,7 @@ fn prusti_post_item_test1_$(NUM_UUID)(result: ()) {
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 fn test1() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -52,6 +54,7 @@ fn prusti_post_item_test2_$(NUM_UUID)(result: ()) {
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 fn test2() { }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/verify/ui/pledges.stdout
+++ b/prusti-tests/tests/verify/ui/pledges.stdout
@@ -54,6 +54,7 @@ fn borrows_fail(_x: &mut u32) {
         { ::std::rt::begin_panic("assertion failed: a.f == 6") }
     };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =

--- a/prusti-tests/tests/verify/ui/pure.stdout
+++ b/prusti-tests/tests/verify/ui/pure.stdout
@@ -32,6 +32,7 @@ fn test_identity1() {
         { ::std::rt::begin_panic("assertion failed: 5 == identity(5)") }
     };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -59,6 +60,7 @@ fn test_max2() {
     let z = max(a, b);
     if !(z == 5) { { ::std::rt::begin_panic("assertion failed: z == 5") } };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -83,6 +85,7 @@ fn prusti_post_item_test_max3_$(NUM_UUID)(result: i32) {
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 fn test_max3() -> i32 { let a = 4; let b = 3; max(a, b) }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -94,6 +97,7 @@ fn prusti_pre_item_test_max4_$(NUM_UUID)(a: i32,
     #[prusti::expr_id = "$(NUM_UUID)_101"]
     || -> bool { a > b };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -108,6 +112,7 @@ fn prusti_post_item_test_max4_$(NUM_UUID)(a: i32, b: i32,
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 fn test_max4(a: i32, b: i32) -> i32 { a }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =
@@ -119,6 +124,7 @@ fn prusti_pre_item_test_max5_$(NUM_UUID)(a: i32,
     #[prusti::expr_id = "$(NUM_UUID)_101"]
     || -> bool { a < b };
 }
+#[allow(unused_must_use, unused_variables)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 #[prusti::assertion =


### PR DESCRIPTION
Add `#[allow(unused_must_use, unused_variables)]` to the desugaring of Prusti specifications.