### PR TITLE
Continuous deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./prusti-release-ubuntu/prusti.zip
+          asset_path: ./prusti-release-ubuntu-latest/prusti.zip
           asset_name: prusti-release-ubuntu.zip
           asset_content_type: application/zip
       - name: Upload release asset for Windows
@@ -92,7 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./prusti-release-windows/prusti.zip
+          asset_path: ./prusti-release-windows-latest/prusti.zip
           asset_name: prusti-release-windows.zip
           asset_content_type: application/zip
       - name: Upload release asset for MacOS
@@ -101,6 +101,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./prusti-release-macos/prusti.zip
+          asset_path: ./prusti-release-macos-latest/prusti.zip
           asset_name: prusti-release-macos.zip
           asset_content_type: application/zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,10 +58,10 @@ jobs:
       - name: Package Prusti artifacts
         shell: bash
         run: |
-          for os in ubuntu windows macos
+          for os in ubuntu-latest windows-latest macos-latest
           do
             echo "Package Prusti artifact for $os"
-            cd prusti-release-$os-latest
+            cd prusti-release-$os
             mv target/release/* .
             rm -rf target
             zip -r prusti.zip *

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,106 @@
+name: Continuous deployment
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  RUST_BACKTRACE: 1
+  PRUSTI_ASSERT_TIMEOUT: 60000
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+      # Don't cancel when one matrix job fails, so we can compare to the others.
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Setup Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1.0.6
+      - name: Set up the environment
+        run: python x.py setup
+      - name: Build with cargo --release
+        run: python x.py build --all --verbose --release
+      - name: Run "quick" cargo tests
+        run: python x.py test --all --verbose quick
+      - name: Upload Prusti artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: prusti-release-${{ matrix.os }}
+          if-no-files-found: error
+          path: |
+            rust-toolchain
+            viper_tools/
+            target/release/prusti-driver
+            target/release/prusti-server-driver
+            target/release/prusti-server
+            target/release/prusti-rustc
+            target/release/cargo-prusti
+            target/release/libprusti_contracts.rlib
+            target/release/libprusti_contracts_internal.*
+            !target/release/libprusti_contracts_internal.d
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download all Prusti artifacts
+        uses: actions/download-artifact@v2
+      - name: Package Prusti artifacts
+        shell: bash
+        run: |
+          for os in ubuntu windows macos
+          do
+            echo "Package Prusti artifact for $os"
+            cd prusti-release-$os-latest
+            mv target/release/* .
+            rm -rf target
+            zip -r prusti.zip *
+            cd ..
+          done
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload release asset for Ubuntu
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./prusti-release-ubuntu./prustizip
+          asset_name: prusti-release-ubuntu.zip
+          asset_content_type: application/zip
+      - name: Upload release asset for Windows
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./prusti-release-windows/prusti.zip
+          asset_name: prusti-release-windows.zip
+          asset_content_type: application/zip
+      - name: Upload release asset for MacOS
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./prusti-release-macos.z/prustiip
+          asset_name: prusti-release-macos.zip
+          asset_content_type: application/zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./prusti-release-ubuntu./prustizip
+          asset_path: ./prusti-release-ubuntu/prusti.zip
           asset_name: prusti-release-ubuntu.zip
           asset_content_type: application/zip
       - name: Upload release asset for Windows
@@ -101,6 +101,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./prusti-release-macos.z/prustiip
+          asset_path: ./prusti-release-macos/prusti.zip
           asset_name: prusti-release-macos.zip
           asset_content_type: application/zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
       # Don't cancel when one matrix job fails, so we can compare to the others.
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Check out the repo
       uses: actions/checkout@v2

--- a/prusti-launch/src/lib.rs
+++ b/prusti-launch/src/lib.rs
@@ -47,8 +47,10 @@ pub fn find_libjvm<S: AsRef<Path>>(path: S) -> Option<PathBuf> {
     const EXPECTED_JVM_FILENAME: &str = "jvm.dll";
     #[cfg(target_os = "linux")]
     const EXPECTED_JVM_FILENAME: &str = "libjvm.so";
+    // On MacOS, we need to link to libjli instead of libjvm as a workaround to a Java8 bug.
+    // See: https://github.com/jni-rs/jni-rs/pull/230
     #[cfg(target_os = "macos")]
-    const EXPECTED_JVM_FILENAME: &str = "libjvm.dylib";
+    const EXPECTED_JVM_FILENAME: &str = "libjli.dylib";
 
     let walker = walkdir::WalkDir::new(path).follow_links(true);
 

--- a/x.py
+++ b/x.py
@@ -77,11 +77,11 @@ def get_mac_env():
     if os.path.exists(java_home):
         ld_library_path = None
         for root, _, files in os.walk(java_home):
-            if 'libjvm.dylib' in files:
+            if 'libjli.dylib' in files:
                 ld_library_path = root
                 break
         if ld_library_path is None:
-            report("could not find libjvm.dylib in {}", java_home)
+            report("could not find libjli.dylib in {}", java_home)
         else:
             variables.append(('LD_LIBRARY_PATH', ld_library_path))
             variables.append(('DYLD_LIBRARY_PATH', ld_library_path))


### PR DESCRIPTION
In this PR:
* Fix the CI script, to actually test Prusti on Windows and MacOS and not 3 times on Ubuntu. :disappointed:
* Add a GitHub workflow to build and upload Prusti artifacts to a new GitHub release each time a commit is pushed to the master branch.