### PR TITLE
Add an analysis crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 name = "analysis"
 version = "0.1.0"
 dependencies = [
- "log",
+ "log 0.4.11",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "analysis"
+version = "0.1.0"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "analysis",
     "prusti",
     "prusti-contracts",
     "prusti-contracts-impl",

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "analysis"
+version = "0.1.0"
+authors = ["Federico Poli <federpoli@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+log = { version = "0.4", features = ["release_max_level_info"] }

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,0 +1,4 @@
+Analysis
+========
+
+Intra-procedural static analysis of MIR functions.

--- a/analysis/src/abstract_domains/definitely_initialized.rs
+++ b/analysis/src/abstract_domains/definitely_initialized.rs
@@ -1,0 +1,14 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::AbstractState;
+
+pub struct DefinitelyInitializedState {}
+impl AbstractState for DefinitelyInitializedState {
+    fn join(self, other: Self) -> Self {
+        unimplemented!()
+    }
+}

--- a/analysis/src/abstract_domains/liveness.rs
+++ b/analysis/src/abstract_domains/liveness.rs
@@ -1,0 +1,15 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::AbstractState;
+
+pub struct LivenessState {}
+
+impl AbstractState for LivenessState {
+    fn join(self, other: Self) -> Self {
+        unimplemented!()
+    }
+}

--- a/analysis/src/abstract_domains/mod.rs
+++ b/analysis/src/abstract_domains/mod.rs
@@ -1,0 +1,13 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+mod liveness;
+mod definitely_initialized;
+mod pcs;
+
+pub use liveness::LivenessState;
+pub use definitely_initialized::DefinitelyInitializedState;
+pub use pcs::PCSState;

--- a/analysis/src/abstract_domains/pcs.rs
+++ b/analysis/src/abstract_domains/pcs.rs
@@ -1,0 +1,14 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::AbstractState;
+
+pub struct PCSState {}
+impl AbstractState for PCSState {
+    fn join(self, other: Self) -> Self {
+        unimplemented!()
+    }
+}

--- a/analysis/src/abstract_state.rs
+++ b/analysis/src/abstract_state.rs
@@ -1,0 +1,10 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+pub trait AbstractState {
+    fn join(self, other: Self) -> Self;
+    // ...
+}

--- a/analysis/src/analysis_error.rs
+++ b/analysis/src/analysis_error.rs
@@ -1,0 +1,11 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use rustc_middle::mir;
+
+pub enum AnalysisError {
+    UnsupportedStatement(mir::Location),
+}

--- a/analysis/src/analyzer.rs
+++ b/analysis/src/analyzer.rs
@@ -30,7 +30,7 @@ impl<'tcx> Analyzer<'tcx> {
         unimplemented!();
     }
 
-    pub fn definitely_initilized_analysis(
+    pub fn definitely_initialized_analysis(
         &self,
         mir: &mir::Body<'tcx>,
     ) -> Result<PointwiseState<DefinitelyInitializedState>> {

--- a/analysis/src/analyzer.rs
+++ b/analysis/src/analyzer.rs
@@ -1,0 +1,46 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use rustc_middle::ty::TyCtxt;
+use rustc_middle::mir;
+pub use crate::PointwiseState;
+pub use crate::AnalysisError;
+pub use crate::abstract_domains::*;
+
+type Result<T> = std::result::Result<T, AnalysisError>;
+
+pub struct Analyzer<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> Analyzer<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Analyzer {
+            tcx,
+        }
+    }
+
+    pub fn liveness_analysis(
+        &self,
+        mir: &mir::Body<'tcx>,
+    ) -> Result<PointwiseState<LivenessState>> {
+        unimplemented!();
+    }
+
+    pub fn definitely_initilized_analysis(
+        &self,
+        mir: &mir::Body<'tcx>,
+    ) -> Result<PointwiseState<DefinitelyInitializedState>> {
+        unimplemented!();
+    }
+
+    pub fn pcs_analysis(
+        &self,
+        mir: &mir::Body<'tcx>,
+    ) -> Result<PointwiseState<PCSState>> {
+        unimplemented!();
+    }
+}

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -6,17 +6,15 @@
 
 #![feature(rustc_private)]
 
-extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
-extern crate rustc_ast;
-extern crate rustc_attr;
 
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::mir;
+use rustc_span::def_id::LocalDefId;
 
-pub struct LivenessAnalysisState {}
-pub struct DefinitelyInitializedAnalysisState {}
+pub struct LivenessState {}
+pub struct DefinitelyInitializedState {}
 pub struct PCSState {}
 
 pub trait AnalysisResult {
@@ -32,6 +30,7 @@ type Result<T> = std::result::Result<T, AnalysisError>;
 
 pub struct Analyzer<'tcx> {
     tcx: TyCtxt<'tcx>,
+    // We can add caching, using e.g. a RefCell<HashMap<LocalDefId, Result<...>>>
 }
 
 impl<'tcx> Analyzer<'tcx> {
@@ -41,17 +40,19 @@ impl<'tcx> Analyzer<'tcx> {
         }
     }
 
+    // Instead of `mir: &mir::Body<'tcx>` we could ask for a `LocalDefId`, which can be resolved
+    // using https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TyCtxt.html#method.mir_promoted
     pub fn liveness_analysis(
         &self,
         mir: &mir::Body<'tcx>,
-    ) -> Result<Box<dyn AnalysisResult<AbstractState = LivenessAnalysisState>>> {
+    ) -> Result<Box<dyn AnalysisResult<AbstractState = LivenessState>>> {
         unimplemented!();
     }
 
     pub fn definitely_initilized_analysis(
         &self,
         mir: &mir::Body<'tcx>,
-    ) -> Result<Box<dyn AnalysisResult<AbstractState = DefinitelyInitializedAnalysisState>>> {
+    ) -> Result<Box<dyn AnalysisResult<AbstractState = DefinitelyInitializedState>>> {
         unimplemented!();
     }
 

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -1,0 +1,64 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#![feature(rustc_private)]
+
+extern crate rustc_hir;
+extern crate rustc_middle;
+extern crate rustc_span;
+extern crate rustc_ast;
+extern crate rustc_attr;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_middle::mir;
+
+pub struct LivenessAnalysisState {}
+pub struct DefinitelyInitializedAnalysisState {}
+pub struct PCSState {}
+
+pub trait AnalysisResult {
+    type AbstractState;
+    fn lookup(&self, location: mir::Location) -> Self::AbstractState;
+}
+
+pub enum AnalysisError {
+    UnsupportedStatement(mir::Location),
+}
+
+type Result<T> = std::result::Result<T, AnalysisError>;
+
+pub struct Analyzer<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> Analyzer<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Analyzer {
+            tcx,
+        }
+    }
+
+    pub fn liveness_analysis(
+        &self,
+        mir: &mir::Body<'tcx>,
+    ) -> Result<Box<dyn AnalysisResult<AbstractState = LivenessAnalysisState>>> {
+        unimplemented!();
+    }
+
+    pub fn definitely_initilized_analysis(
+        &self,
+        mir: &mir::Body<'tcx>,
+    ) -> Result<Box<dyn AnalysisResult<AbstractState = DefinitelyInitializedAnalysisState>>> {
+        unimplemented!();
+    }
+
+    pub fn pcs_analysis(
+        &self,
+        mir: &mir::Body<'tcx>,
+    ) -> Result<Box<dyn AnalysisResult<AbstractState = PCSState>>> {
+        unimplemented!();
+    }
+}

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -7,59 +7,16 @@
 #![feature(rustc_private)]
 
 extern crate rustc_middle;
-extern crate rustc_span;
+
+mod pointwise_state;
+mod abstract_state;
+mod analysis_error;
+mod analyzer;
+pub mod abstract_domains;
 
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::mir;
-use rustc_span::def_id::LocalDefId;
-
-pub struct LivenessState {}
-pub struct DefinitelyInitializedState {}
-pub struct PCSState {}
-
-pub trait AnalysisResult {
-    type AbstractState;
-    fn lookup(&self, location: mir::Location) -> Self::AbstractState;
-}
-
-pub enum AnalysisError {
-    UnsupportedStatement(mir::Location),
-}
-
-type Result<T> = std::result::Result<T, AnalysisError>;
-
-pub struct Analyzer<'tcx> {
-    tcx: TyCtxt<'tcx>,
-    // We can add caching, using e.g. a RefCell<HashMap<LocalDefId, Result<...>>>
-}
-
-impl<'tcx> Analyzer<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
-        Analyzer {
-            tcx,
-        }
-    }
-
-    // Instead of `mir: &mir::Body<'tcx>` we could ask for a `LocalDefId`, which can be resolved
-    // using https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TyCtxt.html#method.mir_promoted
-    pub fn liveness_analysis(
-        &self,
-        mir: &mir::Body<'tcx>,
-    ) -> Result<Box<dyn AnalysisResult<AbstractState = LivenessState>>> {
-        unimplemented!();
-    }
-
-    pub fn definitely_initilized_analysis(
-        &self,
-        mir: &mir::Body<'tcx>,
-    ) -> Result<Box<dyn AnalysisResult<AbstractState = DefinitelyInitializedState>>> {
-        unimplemented!();
-    }
-
-    pub fn pcs_analysis(
-        &self,
-        mir: &mir::Body<'tcx>,
-    ) -> Result<Box<dyn AnalysisResult<AbstractState = PCSState>>> {
-        unimplemented!();
-    }
-}
+pub use pointwise_state::PointwiseState;
+pub use abstract_state::AbstractState;
+pub use analysis_error::AnalysisError;
+pub use analyzer::Analyzer;

--- a/analysis/src/pointwise_state.rs
+++ b/analysis/src/pointwise_state.rs
@@ -4,13 +4,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::collections::{ HashMap, BTreeMap };
+use std::collections::HashMap;
 use rustc_middle::mir;
 use crate::AbstractState;
 
 pub struct PointwiseState<S: AbstractState> {
     state_before: HashMap<mir::Location, S>,
-    state_after_block: HashMap<mir::BasicBlock, BTreeMap<mir::BasicBlock, S>>,
+    /// We use a vector, not a map, to reflect the type of `TerminatorKind::Switch::targets`.
+    /// In particular, there might be multiple CFG edges all going to the same CFG block, and we
+    /// want to distinguish them.
+    state_after_block: HashMap<mir::BasicBlock, Vec<(mir::BasicBlock, S)>>,
 }
 
 impl<S: AbstractState> PointwiseState<S> {
@@ -25,7 +28,7 @@ impl<S: AbstractState> PointwiseState<S> {
     }
 
     /// Return the abstract state on the outgoing CFG edges
-    pub fn lookup_afterblock(&self, block: mir::BasicBlock) -> BTreeMap<mir::BasicBlock, &S> {
+    pub fn lookup_after_block(&self, block: mir::BasicBlock) -> &[(mir::BasicBlock, S)] {
         unimplemented!();
     }
 
@@ -40,10 +43,10 @@ impl<S: AbstractState> PointwiseState<S> {
     }
 
     /// Return the abstract state on the outgoing CFG edges
-    pub(crate) fn lookup_mut_block(
+    pub(crate) fn lookup_mut_after_block(
         &mut self,
         block: mir::BasicBlock,
-    ) -> BTreeMap<mir::BasicBlock, &mut S> {
+    ) -> &mut Vec<(mir::BasicBlock, S)> {
         unimplemented!();
     }
 }

--- a/analysis/src/pointwise_state.rs
+++ b/analysis/src/pointwise_state.rs
@@ -1,0 +1,49 @@
+// © 2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::collections::{ HashMap, BTreeMap };
+use rustc_middle::mir;
+use crate::AbstractState;
+
+pub struct PointwiseState<S: AbstractState> {
+    state_before: HashMap<mir::Location, S>,
+    state_after_block: HashMap<mir::BasicBlock, BTreeMap<mir::BasicBlock, S>>,
+}
+
+impl<S: AbstractState> PointwiseState<S> {
+    /// The location can point to a statement or terminator.
+    pub fn lookup_before(&self, location: mir::Location) -> &S {
+        unimplemented!();
+    }
+
+    /// The location should point to a statement, not a terminator.
+    pub fn lookup_after(&self, location: mir::Location) -> &S {
+        unimplemented!();
+    }
+
+    /// Return the abstract state on the outgoing CFG edges
+    pub fn lookup_afterblock(&self, block: mir::BasicBlock) -> BTreeMap<mir::BasicBlock, &S> {
+        unimplemented!();
+    }
+
+    /// The location can point to a statement or terminator.
+    pub(crate) fn lookup_mut_before(&mut self, location: mir::Location) -> &mut S {
+        unimplemented!();
+    }
+
+    /// The location should point to a statement, not a terminator.
+    pub(crate) fn lookup_mut_after(&mut self, location: mir::Location) -> &mut S {
+        unimplemented!();
+    }
+
+    /// Return the abstract state on the outgoing CFG edges
+    pub(crate) fn lookup_mut_block(
+        &mut self,
+        block: mir::BasicBlock,
+    ) -> BTreeMap<mir::BasicBlock, &mut S> {
+        unimplemented!();
+    }
+}


### PR DESCRIPTION
The plan is to move the existing liveness and definitely-initialized analysis to the `analysis` crate, avoiding code duplication whenever possible. We'll then add the PCS analysis to the `analysis` crate, using the result of that analysis to generate `fold/unfold` statements in Prusti's encoding.