### PR TITLE
Do not release for Ubuntu 16.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, ubuntu-16.04, windows-latest ]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -62,7 +62,7 @@ jobs:
       - name: Package Prusti artifacts
         shell: bash
         run: |
-          for os in ubuntu-latest ubuntu-16.04 windows-latest macos-latest
+          for os in ubuntu-latest windows-latest macos-latest
           do
             echo "Package Prusti artifact for $os"
             cd prusti-release-$os
@@ -83,7 +83,7 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           release_name: Nightly Release ${{ env.TAG_NAME }}
           keep_num: 2
-      - name: Upload release asset for Ubuntu latest
+      - name: Upload release asset for Ubuntu
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,15 +91,6 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./prusti-release-ubuntu-latest/prusti.zip
           asset_name: prusti-release-ubuntu.zip
-          asset_content_type: application/zip
-      - name: Upload release asset for Ubuntu 16.04
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./prusti-release-ubuntu-16.04/prusti.zip
-          asset_name: prusti-release-ubuntu-16.04.zip
           asset_content_type: application/zip
       - name: Upload release asset for Windows
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Compiling on `ubuntu-16.04` provide no benefit, as the binaries released by the GitHub actions still require the `libssl.so.1.1` and `libcrypto.so.1.1` system libraries that seem to be not available on apt. Ubuntu 16.04 users (like me) can install OpenSSL 1.1.0 following [these instructions](https://stackoverflow.com/a/44789238/2491528), then Prusti will run fine.
