### PR TITLE
Kill server and prepare for TOML in rust-toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,6 @@ dependencies = [
  "log 0.4.11",
  "regex",
  "serde 1.0.116",
- "serde_derive",
  "uuid 0.8.1",
  "viper",
 ]
@@ -1501,7 +1500,6 @@ dependencies = [
  "regex",
  "rustc-hash",
  "serde 1.0.116",
- "serde_derive",
 ]
 
 [[package]]
@@ -1510,7 +1508,6 @@ version = "0.1.0"
 dependencies = [
  "glob",
  "serde 1.0.116",
- "serde_derive",
  "toml 0.5.6",
  "walkdir",
 ]
@@ -1529,7 +1526,6 @@ dependencies = [
  "prusti-common",
  "reqwest",
  "serde 1.0.116",
- "serde_derive",
  "tokio",
  "viper",
  "warp",
@@ -2842,7 +2838,6 @@ dependencies = [
  "lazy_static 1.4.0",
  "log 0.4.11",
  "serde 1.0.116",
- "serde_derive",
  "uuid 0.8.1",
  "viper-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,9 @@ name = "prusti-launch"
 version = "0.1.0"
 dependencies = [
  "glob",
+ "serde 1.0.116",
+ "serde_derive",
+ "toml 0.5.6",
  "walkdir",
 ]
 

--- a/prusti-common/Cargo.toml
+++ b/prusti-common/Cargo.toml
@@ -10,8 +10,7 @@ doctest = false # we have no doc tests
 log = { version = "0.4", features = ["release_max_level_info"] }
 viper = { path = "../viper" }
 config = "0.9.0"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4.0"
 uuid = { version = "0.8", features = ["v4"] }
 regex = "1.3.9"

--- a/prusti-common/src/lib.rs
+++ b/prusti-common/src/lib.rs
@@ -16,11 +16,10 @@ extern crate config as config_crate;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
+#[macro_use]
 extern crate serde;
 extern crate uuid;
 extern crate viper;
-#[macro_use]
-extern crate serde_derive;
 
 pub mod config;
 pub mod report;

--- a/prusti-interface/Cargo.toml
+++ b/prusti-interface/Cargo.toml
@@ -17,8 +17,7 @@ log = { version = "0.4", features = ["release_max_level_info"] }
 lazy_static = "1.4.0"
 polonius-engine = "0.12.1"
 csv = "1"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 regex = "1.3.9"
 config = "0.9.0"
 rustc-hash = "1.1.0"

--- a/prusti-interface/src/lib.rs
+++ b/prusti-interface/src/lib.rs
@@ -46,7 +46,7 @@ extern crate rustc_index;
 // extern crate rustc_mir;
 // extern crate rustc_target;
 // #[macro_use]
-// extern crate serde_derive;
+// extern crate serde;
 // extern crate serde;
 // extern crate syntax;
 // extern crate syntax_pos;

--- a/prusti-launch/Cargo.toml
+++ b/prusti-launch/Cargo.toml
@@ -26,8 +26,7 @@ doctest = false
 
 [dependencies]
 walkdir = "2.0.0"
-serde = { version = "1.0" }
-serde_derive = "1.0.0"
+serde = { version = "1.0", features = ["derive"] }
 toml = "0.5.0"
 
 [dev-dependencies]

--- a/prusti-launch/Cargo.toml
+++ b/prusti-launch/Cargo.toml
@@ -25,7 +25,10 @@ test = false
 doctest = false
 
 [dependencies]
-walkdir = "2"
+walkdir = "2.0.0"
+serde = { version = "1.0" }
+serde_derive = "1.0.0"
+toml = "0.5.0"
 
 [dev-dependencies]
 glob = "0.3.0"

--- a/prusti-launch/src/bin/cargo-prusti.rs
+++ b/prusti-launch/src/bin/cargo-prusti.rs
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::process::Command;
+use prusti_launch::get_rust_toolchain_channel;
 
 fn main(){
     if let Err(code) = process(std::env::args().skip(1)) {
@@ -23,12 +24,10 @@ fn process<I>(args: I) -> Result<(), i32>
         prusti_rustc_path.set_extension("exe");
     }
 
-    let rust_toolchain = include_str!("../../../rust-toolchain");
-
     let exit_status = Command::new("cargo".to_string())
         .arg("check")
         .args(args)
-        .env("RUST_TOOLCHAIN", rust_toolchain)
+        .env("RUST_TOOLCHAIN", get_rust_toolchain_channel())
         .env("PRUSTI_QUIET", "true")
         .env("PRUSTI_FULL_COMPILATION", "true")
         .env("RUSTC_WRAPPER", prusti_rustc_path)

--- a/prusti-launch/src/lib.rs
+++ b/prusti-launch/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 /// Append paths to the loader environment variable
 pub fn add_to_loader_path(paths: Vec<PathBuf>, cmd: &mut Command) {

--- a/prusti-server/Cargo.toml
+++ b/prusti-server/Cargo.toml
@@ -27,8 +27,7 @@ reqwest = "0.9.1"
 warp = "0.1.11"
 tokio = "0.1.11"
 num_cpus = "1.8.0"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/prusti-server/src/lib.rs
+++ b/prusti-server/src/lib.rs
@@ -15,7 +15,7 @@ extern crate num_cpus;
 extern crate prusti_common;
 extern crate tokio;
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 mod service;
 mod verifier_runner;

--- a/viper/Cargo.toml
+++ b/viper/Cargo.toml
@@ -12,8 +12,7 @@ error-chain = "0.12.0"
 viper-sys = { path = "../viper-sys" }
 jni = { version = "0.17.0", features = ["backtrace", "invocation"] }
 uuid = { version = "0.8", features = ["v4"] }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/viper/src/lib.rs
+++ b/viper/src/lib.rs
@@ -15,7 +15,7 @@ extern crate log;
 extern crate uuid;
 extern crate viper_sys;
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 mod ast_factory;
 mod ast_utils;


### PR DESCRIPTION
* Be sure that the server is killed in the tests of `prusti-launch`.
* Be ready to parse the [TOML format](https://github.com/rust-lang/rustup/pull/2438) of `rust-toolchain`, which will be available in the next release of  `rustup`.