### PR TITLE
Fix encoding of unsupported types

### DIFF
--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -505,38 +505,13 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                 format!("__TYPARAM__${}$__", param_ty.name.as_str())
             }
 
-            ty::TyKind::Dynamic(..) => {
-                return Err(PositionlessEncodingError::unsupported(
-                    "trait objects are not supported"
-                ));
-            }
-
-            ty::TyKind::FnPtr(..) => {
-                return Err(PositionlessEncodingError::unsupported(
-                    "function pointer types are not supported"
-                ));
-            }
-
-            ty::TyKind::FnDef(..) => {
-                return Err(PositionlessEncodingError::unsupported(
-                    "function types are not supported"
-                ));
-            }
-
             ty::TyKind::Projection(ty::ProjectionTy { item_def_id, .. }) => {
                 self.encoder.encode_item_name(*item_def_id)
             }
 
-            ty::TyKind::Foreign(..) => {
-                return Err(PositionlessEncodingError::unsupported(
-                    "foreign types are not supported"
-                ));
-            }
-
             ref ty_variant => {
-                return Err(PositionlessEncodingError::unsupported(
-                    format!("type {:?} is not supported", ty_variant)
-                ));
+                debug!("Type {:?} is not supported", ty_variant);
+                "unsupported".to_string()
             }
         };
         Ok(result)

--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -509,8 +509,23 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                 self.encoder.encode_item_name(*item_def_id)
             }
 
+            ty::TyKind::Dynamic(..) => {
+                "unsupported$dynamic".to_string()
+            }
+
+            ty::TyKind::FnPtr(..) => {
+                "unsupported$fnptr".to_string()
+            }
+
+            ty::TyKind::FnDef(..) => {
+                "unsupported$fndef".to_string()
+            }
+
+            ty::TyKind::Foreign(..) => {
+                "unsupported$foreign".to_string()
+            }
+
             ref ty_variant => {
-                debug!("Type {:?} is not supported", ty_variant);
                 "unsupported".to_string()
             }
         };

--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -507,7 +507,7 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
 
             ty::TyKind::Dynamic(..) => {
                 return Err(PositionlessEncodingError::unsupported(
-                    "dynamic trait types are not supported"
+                    "trait objects are not supported"
                 ));
             }
 


### PR DESCRIPTION
With this PR, Prusti will not generate an error message for unsupported types, but it will fail in same way when the unsupported type is used. The error would probably show up as a fold-unfold error, because the encoding might try to use fields that don't exist in the encoding. In other words, it would be a Viper consistency error or a Java exception if not for the fold-unfold pass.

It is very easy to encode all unsupported types using the *same* abstract predicate (a "predicate unsupportedType(self: Ref)"), which is what this PR is doing. I don't see a clear benefit in encoding different unsupported types with different abstract predicates, but I'm open to discuss this.
