### PR TITLE
Revert PR that breaks cargo run

### DIFF
--- a/prusti-tests/tests/compiletest.rs
+++ b/prusti-tests/tests/compiletest.rs
@@ -146,8 +146,6 @@ fn run_verification_core_proof(group_name: &str, filter: &Option<String>) {
 }
 
 fn test_runner(_tests: &[&()]) {
-    env::set_var("PRUSTI_TESTS", "1");
-
     // Spawn server process as child (so it stays around until main function terminates)
     let server_address = ServerSideService::spawn_off_thread();
     env::set_var("PRUSTI_SERVER_ADDRESS", server_address.to_string());

--- a/prusti/src/arg_value.rs
+++ b/prusti/src/arg_value.rs
@@ -1,0 +1,45 @@
+// Copyright 2014-2020 The Rust Project Developers
+//
+// Licensed under the Apache License, Version 2.0<LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// https://opensource.org/licenses/MIT>, at your option. Files in the project may not be copied,
+// modified, or distributed except according to those terms.
+
+/// Source: https://github.com/rust-lang/rust-clippy/blob/master/src/driver.rs
+use std::ops::Deref;
+
+/// If a command-line option matches `find_arg`, then apply the predicate `pred` on its value. If
+/// true, then return it. The parameter is assumed to be either `--arg=value` or `--arg value`.
+pub fn arg_value<'a, T: Deref<Target = str>>(
+    args: &'a [T],
+    find_arg: &str,
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a str> {
+    let mut args = args.iter().map(Deref::deref);
+    while let Some(arg) = args.next() {
+        let mut arg = arg.splitn(2, '=');
+        if arg.next() != Some(find_arg) {
+            continue;
+        }
+
+        match arg.next().or_else(|| args.next()) {
+            Some(v) if pred(v) => return Some(v),
+            _ => {},
+        }
+    }
+    None
+}
+
+#[test]
+fn test_arg_value() {
+    let args = &["--bar=bar", "--foobar", "123", "--foo"];
+
+    assert_eq!(arg_value(&[] as &[&str], "--foobar", |_| true), None);
+    assert_eq!(arg_value(args, "--bar", |_| false), None);
+    assert_eq!(arg_value(args, "--bar", |_| true), Some("bar"));
+    assert_eq!(arg_value(args, "--bar", |p| p == "bar"), Some("bar"));
+    assert_eq!(arg_value(args, "--bar", |p| p == "foo"), None);
+    assert_eq!(arg_value(args, "--foobar", |p| p == "foo"), None);
+    assert_eq!(arg_value(args, "--foobar", |p| p == "123"), Some("123"));
+    assert_eq!(arg_value(args, "--foo", |_| true), None);
+}

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -123,11 +123,11 @@ fn main() {
     // added by RUSTC_WRAPPER.
     let rustc_args: Vec<String> = env::args().collect();
 
-    // If the environment asks us to actually be rustc, then do that.
-    // If cargo is compiling a dependency, then be rustc.
-    let prusti_be_rustc = config::be_rustc()
-        || arg_value(&rustc_args, "--cap-lints", |val| val == "allow").is_some();
-    if prusti_be_rustc {
+    // If the environment asks us to actually be rustc, or if lints have been disabled, then
+    // run `rustc` instead of Prusti.
+    let prusti_be_rustc = config::be_rustc();
+    let are_lints_disabled = arg_value(&rustc_args, "--cap-lints", |val| val == "allow").is_some();
+    if prusti_be_rustc || are_lints_disabled {
         rustc_driver::main();
     }
 

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -30,6 +30,7 @@ extern crate prusti_common;
 
 mod callbacks;
 mod verifier;
+mod arg_value;
 
 use log::debug;
 use std::{env, panic, borrow::Cow, path::PathBuf};
@@ -39,6 +40,7 @@ use lazy_static::lazy_static;
 use callbacks::PrustiCompilerCalls;
 use rustc_middle::ty::TyCtxt;
 use prusti_common::config;
+use arg_value::arg_value;
 
 /// Link to report Prusti bugs
 const BUG_REPORT_URL: &str = "https://github.com/viperproject/prusti-dev/issues/new";
@@ -123,11 +125,8 @@ fn main() {
 
     // If the environment asks us to actually be rustc, then do that.
     // If cargo is compiling a dependency, then be rustc.
-    let is_prusti_test = env::var("PRUSTI_TESTS").is_ok();
-    let is_cargo_running = env::var("CARGO_PKG_NAME").is_ok();
-    let in_primary_package = env::var("CARGO_PRIMARY_PACKAGE").is_ok();
     let prusti_be_rustc = config::be_rustc()
-        || (!is_prusti_test && is_cargo_running && !in_primary_package);
+        || arg_value(&rustc_args, "--cap-lints", |val| val == "allow").is_some();
     if prusti_be_rustc {
         rustc_driver::main();
     }


### PR DESCRIPTION
Revert PR #316, which breaks `./x.py run --bin prusti-rustc ...`

We should test `./x.py run --bin prusti-rustc ...` in CI to avoid future regressions.