### PR TITLE
Convert more panics to error messages

### DIFF
--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -6,18 +6,16 @@
 
 //! This module defines the interface provided to a verifier.
 
+use rustc_ast::ast;
+use rustc_hir as hir;
 use rustc_middle::mir;
 use rustc_hir::hir_id::HirId;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::ty::{self, TyCtxt, ParamEnv};
 use std::path::PathBuf;
 use std::cell::Ref;
-
 use rustc_span::{Span, MultiSpan, symbol::Symbol};
-use rustc_hir as hir;
 use std::collections::HashSet;
-use rustc_hir::def_id::LocalDefId;
-use rustc_ast::ast;
 use log::debug;
 
 pub mod borrowck;
@@ -211,11 +209,16 @@ impl<'tcx> Environment<'tcx> {
         Procedure::new(self.tcx(), proc_def_id)
     }
 
-    /// Get the MIR or a procedure.
-    pub fn mir<'a>(&self, def_id: LocalDefId) -> Ref<'a, mir::Body<'tcx>> {
+    /// Get the MIR body of a local procedure.
+    pub fn local_mir<'a>(&self, def_id: LocalDefId) -> Ref<'a, mir::Body<'tcx>> {
         self.tcx().mir_promoted(
             ty::WithOptConstParam::unknown(def_id)
         ).0.borrow()
+    }
+
+    /// Get the MIR body of an external procedure.
+    pub fn external_mir<'a>(&self, def_id: DefId) -> &'a mir::Body<'tcx> {
+        self.tcx().optimized_mir(def_id)
     }
 
     /// Get all relevant trait declarations for some type.

--- a/prusti-viper/src/encoder/borrows.rs
+++ b/prusti-viper/src/encoder/borrows.rs
@@ -21,6 +21,8 @@ use crate::utils::type_visitor::{self, TypeVisitor};
 use prusti_interface::specs::typed;
 use log::{trace, debug};
 use crate::encoder::errors::PositionlessEncodingError;
+use crate::encoder::errors::PositionlessEncodingResult;
+use crate::encoder::errors::EncodingResult;
 
 #[derive(Clone, Debug)]
 pub struct BorrowInfo<P>
@@ -258,7 +260,7 @@ impl<'tcx> BorrowInfoCollectingVisitor<'tcx> {
     }
 
     fn analyse_return_ty(&mut self, ty: Ty<'tcx>)
-        -> Result<(), PositionlessEncodingError>
+        -> PositionlessEncodingResult<()>
     {
         self.is_path_blocking = true;
         self.current_path = Some(mir::RETURN_PLACE.into());
@@ -268,7 +270,7 @@ impl<'tcx> BorrowInfoCollectingVisitor<'tcx> {
     }
 
     fn analyse_arg(&mut self, arg: mir::Local, ty: Ty<'tcx>)
-        -> Result<(), PositionlessEncodingError>
+        -> PositionlessEncodingResult<()>
     {
         self.is_path_blocking = false;
         self.current_path = Some(arg.into());
@@ -416,7 +418,7 @@ pub fn compute_procedure_contract<'p, 'a, 'tcx>(
     tcx: TyCtxt<'tcx>,
     specification: typed::SpecificationSet<'tcx>,
     maybe_tymap: Option<&HashMap<ty::Ty<'tcx>, ty::Ty<'tcx>>>,
-) -> Result<ProcedureContractMirDef<'tcx>, PositionlessEncodingError>
+) -> PositionlessEncodingResult<ProcedureContractMirDef<'tcx>>
 where
     'a: 'p,
     'tcx: 'a,

--- a/prusti-viper/src/encoder/errors/encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/encoding_error.rs
@@ -68,4 +68,12 @@ impl EncodingError {
     pub fn as_positionless(&self) -> &PositionlessEncodingError {
         &self.error
     }
+
+    pub fn with_span<S: Into<MultiSpan>>(self, span: S) -> EncodingError {
+        // TODO: Stack error spans
+        EncodingError {
+            span: span.into(),
+            ..self
+        }
+    }
 }

--- a/prusti-viper/src/encoder/errors/with_span.rs
+++ b/prusti-viper/src/encoder/errors/with_span.rs
@@ -15,10 +15,15 @@ pub trait WithSpan<T> {
 }
 
 impl<T> WithSpan<T> for Result<T, PositionlessEncodingError> {
-    fn with_span<S: Into<MultiSpan>>(self, span: S)
-        -> Result<T, EncodingError>
-    {
+    fn with_span<S: Into<MultiSpan>>(self, span: S) -> Result<T, EncodingError> {
         trace!("Converting a PositionlessEncodingError to EncodingError in a Result");
+        self.map_err(|err| err.with_span(span))
+    }
+}
+
+impl<T> WithSpan<T> for Result<T, EncodingError> {
+    fn with_span<S: Into<MultiSpan>>(self, span: S) -> Result<T, EncodingError> {
+        trace!("Replacing the span of an EncodingError in a Result");
         self.map_err(|err| err.with_span(span))
     }
 }

--- a/prusti-viper/src/encoder/initialisation.rs
+++ b/prusti-viper/src/encoder/initialisation.rs
@@ -15,6 +15,8 @@ use rustc_middle::{mir, ty::{self, TyCtxt}};
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use crate::encoder::errors::{EncodingError, PositionlessEncodingError};
+use crate::encoder::errors::PositionlessEncodingResult;
+use crate::encoder::errors::EncodingResult;
 
 pub struct InitInfo {
     //mir_acc_before_block: HashMap<mir::BasicBlock, HashSet<mir::Place<'tcx>>>,
@@ -56,7 +58,7 @@ fn contains_prefix(set: &HashSet<vir::Expr>, place: &vir::Expr) -> bool {
 fn convert_to_vir<'tcx, T: Eq + Hash + Clone>(
     map: &HashMap<T, HashSet<mir::Place<'tcx>>>,
     mir_encoder: &MirEncoder<'_, '_, 'tcx>,
-) -> Result<HashMap<T, HashSet<vir::Expr>>, PositionlessEncodingError> {
+) -> PositionlessEncodingResult<HashMap<T, HashSet<vir::Expr>>> {
     let mut result = HashMap::new();
     for (loc, set) in map.iter() {
         let mut new_set = HashSet::new();
@@ -75,7 +77,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> InitInfo {
         tcx: ty::TyCtxt<'tcx>,
         def_id: DefId,
         mir_encoder: &MirEncoder<'p, 'v, 'tcx>,
-    ) -> Result<Self, PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<Self> {
         let def_path = tcx.hir().def_path(def_id.expect_local());
         let initialisation = compute_definitely_initialized(&mir, tcx, def_path);
         let mir_acc_before_block: HashMap<_, _> = initialisation

--- a/prusti-viper/src/encoder/memory_eq_encoder.rs
+++ b/prusti-viper/src/encoder/memory_eq_encoder.rs
@@ -13,6 +13,8 @@ use prusti_common::vir::ExprIterator;
 use crate::encoder::Encoder;
 use crate::encoder::type_encoder::compute_discriminant_values;
 use crate::encoder::errors::PositionlessEncodingError;
+use crate::encoder::errors::PositionlessEncodingResult;
+use crate::encoder::errors::EncodingResult;
 
 /// Encoder of memory equality functions
 pub struct MemoryEqEncoder {
@@ -40,7 +42,7 @@ impl MemoryEqEncoder {
         second: vir::Expr,
         self_ty: ty::Ty<'tcx>,
         position: vir::Position,
-    ) -> Result<vir::Expr, PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<vir::Expr> {
         let typ = first.get_type().clone();
         assert!(&typ == second.get_type());
         let mut name = typ.name();
@@ -66,7 +68,7 @@ impl MemoryEqEncoder {
         encoder: &Encoder<'_, 'tcx>,
         name: String,
         self_ty: ty::Ty<'tcx>
-    ) -> Result<(), PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<()> {
         assert!(!self.memory_eq_funcs.contains_key(&name));
         // Mark that we started encoding this function to avoid infinite recursion.
         self.memory_eq_funcs.insert(name.clone(), None);
@@ -125,7 +127,7 @@ impl MemoryEqEncoder {
         first: vir::Expr,
         second: vir::Expr,
         self_ty: ty::Ty<'tcx>
-    ) -> Result<Option<vir::Expr>, PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<Option<vir::Expr>> {
         let eq = match self_ty.kind() {
             ty::TyKind::Bool
             | ty::TyKind::Int(_)
@@ -186,7 +188,7 @@ impl MemoryEqEncoder {
         second: vir::Expr,
         adt_def: &'tcx ty::AdtDef,
         subst: ty::subst::SubstsRef<'tcx>,
-    ) -> Result<vir::Expr, PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<vir::Expr> {
         let tcx = encoder.env().tcx();
         let num_variants = adt_def.variants.len();
         let mut conjuncts = Vec::new();
@@ -252,7 +254,7 @@ impl MemoryEqEncoder {
         first: vir::Expr,
         second: vir::Expr,
         elems: ty::subst::SubstsRef<'tcx>,
-    ) -> Result<vir::Expr, PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<vir::Expr> {
         let mut conjuncts = Vec::new();
         for (field_num, arg) in elems.iter().enumerate() {
             let ty = arg.expect_ty();
@@ -314,7 +316,7 @@ impl MemoryEqEncoder {
         typ: vir::Type,
         self_variant: &ty::VariantDef,
         subst: ty::subst::SubstsRef<'tcx>,
-    ) -> Result<(), PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<()> {
         assert!(!self.memory_eq_funcs.contains_key(&name));
         // Mark that we started encoding this function to avoid infinite recursion.
         self.memory_eq_funcs.insert(name.clone(), None);

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -4260,7 +4260,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 kind => unreachable!("Only calls are expected. Found: {:?}", kind),
             }
         } else {
-            let ref_mir = self.encoder.env().mir(containing_def_id.expect_local());
+            let ref_mir = self.encoder.env().local_mir(containing_def_id.expect_local());
             let mir = ref_mir.borrow();
             let return_ty = mir.return_ty();
             let arg_tys = mir.args_iter().map(|arg| mir.local_decls[arg].ty).collect();

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -70,7 +70,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             "Pure function {} has been encoded with expr: {}",
             function_name, body_expr
         );
-        let subst_strings = self.encoder.type_substitution_strings();
+        let subst_strings = self.encoder.type_substitution_strings().with_span(self.mir.span)?;
         let patched_body_expr = body_expr.patch_types(&subst_strings);
         Ok(patched_body_expr)
     }
@@ -88,12 +88,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 vir::Expr::local(
                     self.interpreter
                         .mir_encoder()
-                        .encode_local(arg)
-                        .unwrap()
+                        .encode_local(arg)?
                 ),
                 arg_ty
             );
-            let new_place: vir::Expr = self.encode_local(arg).into();
+            let new_place: vir::Expr = self.encode_local(arg)?.into();
             state.substitute_place(&target_place, new_place);
         }
 
@@ -104,7 +103,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         );
 
         // if the function returns a snapshot, we take a snapshot of the body
-        if self.encode_function_return_type().is_domain() {
+        if self.encode_function_return_type()?.is_domain() {
             let ty = self.encoder.resolve_typaram(self.mir.return_ty());
 
             if !self.encoder.env().type_is_copy(ty) {
@@ -154,7 +153,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let contract = self.encoder
             .get_procedure_contract_for_def(self.proc_def_id)
             .with_span(self.mir.span)?;
-        let subst_strings = self.encoder.type_substitution_strings();
+        let subst_strings = self.encoder.type_substitution_strings().with_span(self.mir.span)?;
 
         let (type_precondition, func_precondition) = self.encode_precondition_expr(&contract)?;
         let patched_type_precondition = type_precondition.patch_types(&subst_strings);
@@ -162,27 +161,26 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let mut precondition = vec![patched_type_precondition, func_precondition];
         let mut postcondition = vec![self.encode_postcondition_expr(&contract)?];
 
-        let formal_args: Vec<_> = self
-            .mir
-            .args_iter()
-            .map(|local| {
-                let var_name = self.interpreter.mir_encoder().encode_local_var_name(local);
-                let mir_type = self.interpreter.mir_encoder().get_local_ty(local);
-                let var_type = self
-                    .encoder
-                    .encode_value_or_ref_type(self.encoder.resolve_typaram(mir_type));
-                let var_type = var_type.patch(&subst_strings);
-                vir::LocalVar::new(var_name, var_type)
-            })
-            .collect();
-        let return_type = self.encode_function_return_type();
+        let mut formal_args = vec![];
+        for local in self.mir.args_iter() {
+            let mir_encoder = self.interpreter.mir_encoder();
+            let var_name = mir_encoder.encode_local_var_name(local);
+            let var_span = mir_encoder.get_local_span(local);
+            let mir_type = mir_encoder.get_local_ty(local);
+            let var_type = self
+                .encoder
+                .encode_value_or_ref_type(self.encoder.resolve_typaram(mir_type))
+                .with_span(var_span)?;
+            let var_type = var_type.patch(&subst_strings);
+            formal_args.push(vir::LocalVar::new(var_name, var_type))
+        };
+        let return_type = self.encode_function_return_type()?;
 
         let res_value_range_pos = self.encoder.error_manager().register(
             self.mir.span,
             ErrorCtxt::PureFunctionPostconditionValueRangeOfResult,
         );
-        let pure_fn_return_variable =
-            vir::LocalVar::new("__result", self.encode_function_return_type());
+        let pure_fn_return_variable = vir::LocalVar::new("__result", return_type.clone());
         // Add value range of the arguments and return value to the pre/postconditions
         if config::check_overflows() {
             let return_bounds: Vec<_> = self
@@ -267,27 +265,28 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         &self,
         contract: &ProcedureContract<'tcx>,
     ) -> Result<(vir::Expr, vir::Expr), EncodingError> {
-        let type_spec = contract.args.iter().flat_map(|&local| {
+        let mut type_spec = vec![];
+        for &local in contract.args.iter() {
             let local_ty = self.interpreter.mir_encoder().get_local_ty(local.into());
-            let fraction = if let ty::TyKind::Ref(_, _, hir::Mutability::Not) =
-                local_ty.kind()
-            {
+            let fraction = if let ty::TyKind::Ref(_, _, hir::Mutability::Not) = local_ty.kind() {
                 vir::PermAmount::Read
             } else {
                 vir::PermAmount::Write
             };
-            self.interpreter
-                .mir_encoder()
-                .encode_place_predicate_permission(self.encode_local(local.into()).into(), fraction)
-        });
+            let opt_pred_perm = self.interpreter.mir_encoder()
+                .encode_place_predicate_permission(self.encode_local(local.into())?.into(), fraction);
+            if let Some(spec) = opt_pred_perm {
+                type_spec.push(spec)
+            }
+        };
         let mut func_spec: Vec<vir::Expr> = vec![];
 
         // Encode functional specification
         let encoded_args: Vec<vir::Expr> = contract
             .args
             .iter()
-            .map(|local| self.encode_local(local.clone().into()).into())
-            .collect();
+            .map(|local| self.encode_local(local.clone().into()).map(|l| l.into()))
+            .collect::<Result<_, _>>()?;
         for item in contract.functional_precondition() {
             debug!("Encode spec item: {:?}", item);
             func_spec.push(self.encoder.encode_assertion(
@@ -329,9 +328,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let encoded_args: Vec<vir::Expr> = contract
             .args
             .iter()
-            .map(|local| self.encode_local(local.clone().into()).into())
-            .collect();
-        let encoded_return = self.encode_local(contract.returned_value.clone().into());
+            .map(|local| self.encode_local(local.clone().into()).map(|l| l.into()))
+            .collect::<Result<_, _>>()?;
+        let encoded_return = self.encode_local(contract.returned_value.clone().into())?;
         debug!("encoded_return: {:?}", encoded_return);
 
         for item in contract.functional_postcondition() {
@@ -359,7 +358,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
 
         // Fix return variable
         let pure_fn_return_variable =
-            vir::LocalVar::new("__result", self.encode_function_return_type());
+            vir::LocalVar::new("__result", self.encode_function_return_type()?);
 
         let post = post.replace_place(&encoded_return.into(), &pure_fn_return_variable.into())
             .set_default_pos(postcondition_pos);
@@ -371,12 +370,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         )
     }
 
-    fn encode_local(&self, local: mir::Local) -> vir::LocalVar {
-        let var_name = self.interpreter.mir_encoder().encode_local_var_name(local);
-        let var_type = self
-            .encoder
-            .encode_value_or_ref_type(self.interpreter.mir_encoder().get_local_ty(local));
-        vir::LocalVar::new(var_name, var_type)
+    fn encode_local(&self, local: mir::Local) -> Result<vir::LocalVar, EncodingError> {
+        let mir_encoder = self.interpreter.mir_encoder();
+        let var_name = mir_encoder.encode_local_var_name(local);
+        let var_span = mir_encoder.get_local_span(local);
+        let var_type = self.encoder
+            .encode_value_or_ref_type(self.interpreter.mir_encoder().get_local_ty(local))
+            .with_span(var_span)?;
+        Ok(vir::LocalVar::new(var_name, var_type))
     }
 
     fn get_local_span(&self, local: mir::Local) -> Span {
@@ -387,9 +388,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         self.encoder.encode_item_name(self.proc_def_id)
     }
 
-    pub fn encode_function_return_type(&self) -> vir::Type {
+    pub fn encode_function_return_type(&self) -> Result<vir::Type, EncodingError> {
         let ty = self.encoder.resolve_typaram(self.mir.return_ty());
-        self.encoder.encode_value_type(ty)
+        let return_local = mir::Place::return_place().as_local().unwrap();
+        let span = self.interpreter.mir_encoder().get_local_span(return_local);
+        self.encoder.encode_value_type(ty).with_span(span)
     }
 }
 
@@ -445,22 +448,24 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
         // Generate a function call that leaves the expression undefined.
         let unreachable_expr = |pos| {
-            let encoded_type = self.encoder.encode_value_or_ref_type(self.mir.return_ty());
-            let function_name =
-                self.encoder
-                    .encode_builtin_function_use(BuiltinFunctionKind::Unreachable(
-                        encoded_type.clone(),
-                    ));
-            vir::Expr::func_app(function_name, vec![], vec![], encoded_type, pos)
+            self.encoder.encode_value_or_ref_type(self.mir.return_ty()).map(|encoded_type| {
+                let function_name =
+                    self.encoder
+                        .encode_builtin_function_use(BuiltinFunctionKind::Unreachable(
+                            encoded_type.clone(),
+                        ));
+                vir::Expr::func_app(function_name, vec![], vec![], encoded_type, pos)
+            })
         };
 
         // Generate a function call that leaves the expression undefined.
         let undef_expr = |pos| {
-            let encoded_type = self.encoder.encode_value_or_ref_type(self.mir.return_ty());
-            let function_name = self
-                .encoder
-                .encode_builtin_function_use(BuiltinFunctionKind::Undefined(encoded_type.clone()));
-            vir::Expr::func_app(function_name, vec![], vec![], encoded_type, pos)
+            self.encoder.encode_value_or_ref_type(self.mir.return_ty()).map(|encoded_type| {
+                let function_name = self
+                    .encoder
+                    .encode_builtin_function_use(BuiltinFunctionKind::Undefined(encoded_type.clone()));
+                vir::Expr::func_app(function_name, vec![], vec![], encoded_type, pos)
+            })
         };
 
         Ok(match term.kind {
@@ -470,7 +475,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     .encoder
                     .error_manager()
                     .register(term.source_info.span, ErrorCtxt::Unexpected);
-                MultiExprBackwardInterpreterState::new_single(undef_expr(pos))
+                MultiExprBackwardInterpreterState::new_single(
+                    undef_expr(pos).with_span(term.source_info.span)?
+                )
             }
 
             TerminatorKind::Abort | TerminatorKind::Resume { .. } => {
@@ -479,7 +486,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     .encoder
                     .error_manager()
                     .register(term.source_info.span, ErrorCtxt::Unexpected);
-                MultiExprBackwardInterpreterState::new_single(unreachable_expr(pos))
+                MultiExprBackwardInterpreterState::new_single(
+                    unreachable_expr(pos).with_span(term.source_info.span)?
+                )
             }
 
             TerminatorKind::Drop { ref target, .. } => {
@@ -509,7 +518,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
             TerminatorKind::Return => {
                 assert!(states.is_empty());
                 trace!("Return type: {:?}", self.mir.return_ty());
-                let return_type = self.encoder.encode_type(self.mir.return_ty());
+                let return_type = self.encoder.encode_type(self.mir.return_ty()).with_span(span)?;
                 let return_var = vir::LocalVar::new("_0", return_type);
                 MultiExprBackwardInterpreterState::new_single(
                     self.encoder.encode_value_expr(
@@ -690,6 +699,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 let is_pure_function = self.encoder.is_pure(def_id);
                                 let (function_name, return_type) = if is_pure_function {
                                     self.encoder.encode_pure_function_use(def_id)
+                                        .with_span(term.source_info.span)
+                                        .run_if_err(cleanup)?
                                 } else {
                                     // this is an ugly hack as self.env.get_procedure crashes in a compiler-internal
                                     // function
@@ -700,11 +711,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                             if self.encoder.has_structural_eq_impl(arg_ty) => {
                                                 is_cmp_call = true;
                                                 self.encoder.encode_cmp_pure_function_use(def_id, arg_ty, true)
+                                                    .run_if_err(cleanup)?
                                             }
                                             "std::cmp::PartialEq::ne"
                                             if self.encoder.has_structural_eq_impl(arg_ty) => {
                                                 is_cmp_call = true;
                                                 self.encoder.encode_cmp_pure_function_use(def_id, arg_ty, false)
+                                                    .run_if_err(cleanup)?
                                             }
                                             _ => {
                                                 // TODO: interestingly, this crashes for
@@ -712,10 +725,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                                 // is not local; for details, see
                                                 // https://github.com/viperproject/prusti-dev/issues/188.
                                                 self.encoder.encode_stub_pure_function_use(def_id)
+                                                    .run_if_err(cleanup)?
                                             }
                                         }
                                     } else {
                                         self.encoder.encode_stub_pure_function_use(def_id)
+                                            .run_if_err(cleanup)?
                                     }
                                 };
                                 if is_pure_function {
@@ -738,12 +753,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     .iter()
                                     .enumerate()
                                     .map(|(i, arg)| {
-                                        vir::LocalVar::new(
-                                            format!("x{}", i),
-                                            self.mir_encoder.encode_operand_expr_type(arg),
-                                        )
+                                        self.mir_encoder.encode_operand_expr_type(arg)
+                                            .map(|ty| vir::LocalVar::new(format!("x{}", i), ty))
                                     })
-                                    .collect();
+                                    .collect::<Result<_, _>>()
+                                    .with_span(term.source_info.span)
+                                    .run_if_err(cleanup)?;
 
                                 let err_ctxt = if is_pure_function {
                                     ErrorCtxt::PureFunctionCall
@@ -790,7 +805,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                             .encoder
                             .error_manager()
                             .register(term.source_info.span, error_ctxt);
-                        MultiExprBackwardInterpreterState::new_single(unreachable_expr(pos))
+                        MultiExprBackwardInterpreterState::new_single(
+                            unreachable_expr(pos).with_span(term.source_info.span)
+                                .run_if_err(cleanup)?
+                        )
                     };
 
                     cleanup();
@@ -834,15 +852,17 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                             let failure_result = if self.is_encoding_assertion {
                                 // We are encoding an assertion, so all failures should be
                                 // equivalent to false.
-                                false.into()
+                                Ok(false.into())
                             } else {
                                 // We are encoding a pure function, so all failures should
                                 // be unreachable.
-                                unreachable_expr(pos)
+                                unreachable_expr(pos).with_span(term.source_info.span)
                             };
-                            vir::Expr::ite(viper_guard.clone(), expr.clone(), failure_result)
+                            failure_result.map(
+                                |result| vir::Expr::ite(viper_guard.clone(), expr.clone(), result)
+                            )
                         })
-                        .collect(),
+                        .collect::<Result<_, _>>()?,
                 )
             }
 

--- a/prusti-viper/src/encoder/snapshot_encoder.rs
+++ b/prusti-viper/src/encoder/snapshot_encoder.rs
@@ -10,7 +10,7 @@ use rustc_middle::ty;
 use prusti_common::vir::{PermAmount};
 use log::warn;
 use crate::encoder::errors::{PositionlessEncodingError, PositionlessEncodingResult};
-
+use crate::encoder::errors::EncodingResult;
 
 const SNAPSHOT_DOMAIN_PREFIX: &str = "Snap$";
 const SNAPSHOT_CONS: &str = "cons$";
@@ -243,7 +243,7 @@ impl<'p, 'v, 'r: 'v, 'a: 'r, 'tcx: 'a> SnapshotEncoder<'p, 'v, 'tcx> {
     }
 
     fn encode_snap_primitive(&self, field: vir::Field)
-        -> Result<Snapshot, PositionlessEncodingError>
+        -> PositionlessEncodingResult<Snapshot>
     {
         Ok(Snapshot {
             predicate_name: self.predicate_name.clone(),
@@ -253,7 +253,7 @@ impl<'p, 'v, 'r: 'v, 'a: 'r, 'tcx: 'a> SnapshotEncoder<'p, 'v, 'tcx> {
     }
 
     fn encode_snap_func_primitive(&self, field: vir::Field)
-        -> Result<vir::Function, PositionlessEncodingError>
+        -> PositionlessEncodingResult<vir::Function>
     {
         let return_type = self.encoder.encode_value_type(self.ty)?;
         let body = self.encode_snap_arg_field(field);

--- a/prusti-viper/src/encoder/snapshot_encoder.rs
+++ b/prusti-viper/src/encoder/snapshot_encoder.rs
@@ -179,7 +179,7 @@ impl<'p, 'v, 'r: 'v, 'a: 'r, 'tcx: 'a> SnapshotEncoder<'p, 'v, 'tcx> {
             | ty::TyKind::Bool => {
                 self.encode_snap_primitive(
                     self.encoder.encode_value_field(self.ty)
-                )
+                )?
             }
             ty::TyKind::Param(_) => {
                 self.encode_snap_generic()?
@@ -242,19 +242,24 @@ impl<'p, 'v, 'r: 'v, 'a: 'r, 'tcx: 'a> SnapshotEncoder<'p, 'v, 'tcx> {
         }
     }
 
-    fn encode_snap_primitive(&self, field: vir::Field) -> Snapshot {
-        Snapshot {
+    fn encode_snap_primitive(&self, field: vir::Field)
+        -> Result<Snapshot, PositionlessEncodingError>
+    {
+        Ok(Snapshot {
             predicate_name: self.predicate_name.clone(),
-            snap_func: Some(self.encode_snap_func_primitive(field)),
+            snap_func: Some(self.encode_snap_func_primitive(field)?),
             snap_domain: None,
-        }
+        })
     }
 
-    fn encode_snap_func_primitive(&self, field: vir::Field) -> vir::Function {
-        let return_type = self.encoder.encode_value_type(self.ty);
+    fn encode_snap_func_primitive(&self, field: vir::Field)
+        -> Result<vir::Function, PositionlessEncodingError>
+    {
+        let return_type = self.encoder.encode_value_type(self.ty)?;
         let body = self.encode_snap_arg_field(field);
-        self.encode_snap_func(return_type, body)
+        Ok(self.encode_snap_func(return_type, body))
     }
+
     fn encode_snap_func(&self, return_type: vir::Type, body: vir::Expr) -> vir::Function {
         vir::Function {
             name: SNAPSHOT_GET.to_string(),
@@ -527,7 +532,7 @@ impl<'p, 'v, 'r: 'v, 'a: 'r, 'tcx: 'a> SnapshotEncoder<'p, 'v, 'tcx> {
             ty::TyKind::Tuple(elems) => {
                 for (field_num, field_ty) in elems.iter().enumerate() {
                     self.encoder.encode_snapshot(field_ty.expect_ty()); // ensure there is a snapshot
-                    let field_type = self.encoder.encode_value_type(field_ty.expect_ty());
+                    let field_type = self.encoder.encode_value_type(field_ty.expect_ty())?;
                     formal_args.push(
                         self.encode_local_var(field_num, &field_type)
                     );

--- a/prusti-viper/src/encoder/snapshot_spec_patcher.rs
+++ b/prusti-viper/src/encoder/snapshot_spec_patcher.rs
@@ -9,6 +9,8 @@ use prusti_common::vir::{ExprFolder, compute_identifier, FallibleExprFolder};
 use prusti_common::vir;
 use crate::encoder::snapshot_encoder::Snapshot;
 use crate::encoder::errors::PositionlessEncodingError;
+use crate::encoder::errors::PositionlessEncodingResult;
+use crate::encoder::errors::EncodingResult;
 
 pub struct SnapshotSpecPatcher<'p, 'v: 'p, 'tcx: 'v> {
     encoder: &'p Encoder<'v, 'tcx>,
@@ -22,7 +24,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotSpecPatcher<'p, 'v, 'tcx> {
     }
 
     pub fn patch_spec(&self, spec: vir::Expr)
-        -> Result<vir::Expr, PositionlessEncodingError>
+        -> PositionlessEncodingResult<vir::Expr>
     {
         PostSnapshotPatcher {
             encoder: self.encoder
@@ -127,7 +129,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PostSnapshotPatcher<'p, 'v, 'tcx> {
         mirror_func: vir::DomainFunc,
         args: Vec<vir::Expr>,
         pos: vir::Position
-    ) -> Result<vir::Expr, PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<vir::Expr> {
         let patched_args = args
             .into_iter()
             .map(|a|
@@ -167,7 +169,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PostSnapshotPatcher<'p, 'v, 'tcx> {
         formal_args: Vec<vir::LocalVar>,
         return_type: vir::Type,
         pos: vir::Position,
-    ) -> Result<vir::Expr, PositionlessEncodingError> {
+    ) -> PositionlessEncodingResult<vir::Expr> {
         // we need to rectify cases in which there is a mismatch between the
         // functions formal arguments (which do not involve snapshots)
         // and its actual arguments (which may involve snapshots)

--- a/prusti-viper/src/encoder/spec_encoder.rs
+++ b/prusti-viper/src/encoder/spec_encoder.rs
@@ -273,7 +273,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
         inner_def_id: DefId,
     ) -> EncodingResult<(vir::Expr, DefId, mir::Location)> {
         debug!("translate_expr_to_closure_def_site {} {:?}", expr, inner_def_id);
-        let inner_mir = self.encoder.env().mir(inner_def_id.expect_local());
+        let inner_mir = self.encoder.env().local_mir(inner_def_id.expect_local());
         let inner_mir_encoder = MirEncoder::new(self.encoder, &inner_mir, inner_def_id);
         let inner_attrs = self.encoder.env().tcx().get_attrs(inner_def_id);
 
@@ -288,7 +288,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
         ) = opt_instantiation.expect(
             &format!("cannot find definition site for closure {:?}", inner_def_id)
         );
-        let outer_mir = self.encoder.env().mir(outer_def_id.expect_local());
+        let outer_mir = self.encoder.env().local_mir(outer_def_id.expect_local());
         let outer_mir_encoder = MirEncoder::new(self.encoder, &outer_mir, outer_def_id);
         let outer_span = outer_mir_encoder.get_span_of_location(outer_location);
         trace!("Replacing variables of {:?} captured from {:?}", inner_def_id, outer_def_id);
@@ -406,7 +406,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
         target_location: mir::BasicBlock,
     ) -> EncodingResult<vir::Expr> {
         debug!("translate_expr_to_state {} {:?} {:?}", expr, def_id, expr_location);
-        let mir = self.encoder.env().mir(def_id.expect_local());
+        let mir = self.encoder.env().local_mir(def_id.expect_local());
 
         // Translate an intermediate state to the state at the beginning of the method
         let state = MultiExprBackwardInterpreterState::new_single(
@@ -470,7 +470,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
 
         // At this point `curr_def_id` should be either a SPEC item (when encoding a contract) or
         // the method being verified (when encoding a loop invariant).
-        let mir = self.encoder.env().mir(curr_def_id.expect_local());
+        let mir = self.encoder.env().local_mir(curr_def_id.expect_local());
         let mir_encoder = MirEncoder::new(self.encoder, &mir, curr_def_id);
 
         // Replacements to use the provided `target_args` and `target_return`

--- a/prusti-viper/src/encoder/spec_encoder.rs
+++ b/prusti-viper/src/encoder/spec_encoder.rs
@@ -57,7 +57,7 @@ pub fn encode_spec_assertion<'v, 'tcx: 'v>(
     target_return: Option<&vir::Expr>,
     targets_are_values: bool,
     assertion_location: Option<mir::BasicBlock>,
-) -> Result<vir::Expr, EncodingError> {
+) -> EncodingResult<vir::Expr> {
     let spec_encoder = SpecEncoder::new(
         encoder,
         pre_label.unwrap_or(""),
@@ -190,7 +190,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
 
     /// Encode a specification item as a single expression.
     pub fn encode_assertion(&self, assertion: &typed::Assertion<'tcx>)
-        -> Result<vir::Expr, EncodingError>
+        -> EncodingResult<vir::Expr>
     {
         trace!("encode_assertion {:?}", assertion);
         Ok(match assertion.kind {
@@ -271,7 +271,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
         &self,
         expr: vir::Expr,
         inner_def_id: DefId,
-    ) -> Result<(vir::Expr, DefId, mir::Location), EncodingError> {
+    ) -> EncodingResult<(vir::Expr, DefId, mir::Location)> {
         debug!("translate_expr_to_closure_def_site {} {:?}", expr, inner_def_id);
         let inner_mir = self.encoder.env().mir(inner_def_id.expect_local());
         let inner_mir_encoder = MirEncoder::new(self.encoder, &inner_mir, inner_def_id);
@@ -404,7 +404,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
         def_id: DefId,
         expr_location: mir::Location,
         target_location: mir::BasicBlock,
-    ) -> Result<vir::Expr, EncodingError> {
+    ) -> EncodingResult<vir::Expr> {
         debug!("translate_expr_to_state {} {:?} {:?}", expr, def_id, expr_location);
         let mir = self.encoder.env().mir(def_id.expect_local());
 
@@ -436,7 +436,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
 
     /// Encode the assertion of a contract or loop invariant.
     fn encode_expression(&self, assertion_expr: &typed::Expression)
-        -> Result<vir::Expr, EncodingError>
+        -> EncodingResult<vir::Expr>
     {
         debug!("encode_expression {:?}", assertion_expr);
 

--- a/prusti-viper/src/encoder/spec_encoder.rs
+++ b/prusti-viper/src/encoder/spec_encoder.rs
@@ -372,7 +372,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
                     local_arg.ty,
                     &forall_id
                 );
-                let encoded_arg = inner_mir_encoder.encode_local(local_arg_index).unwrap();
+                let encoded_arg = inner_mir_encoder.encode_local(local_arg_index)?;
                 let value_field = self.encoder.encode_value_field(local_arg.ty);
                 let encoded_arg_value = vir::Expr::local(encoded_arg).field(value_field);
                 trace!(
@@ -477,32 +477,26 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
         let mut replacements: Vec<(vir::Expr, vir::Expr)> = vec![];
 
         // Replacement 1: replace the arguments with the `target_args`.
-        replacements.extend(
-            mir.args_iter()
-                .zip(self.target_args)
-                .map(|(local, target_arg)| {
-                    let local_ty = mir.local_decls[local].ty;
-                    // will panic if attempting to encode unsupported type
-                    let spec_local = mir_encoder.encode_local(local).unwrap();
-                    let spec_local_place: vir::Expr = if self.targets_are_values {
-                        self.encoder.encode_value_expr(
-                            vir::Expr::local(spec_local),
-                            local_ty
-                        )
-                    } else {
-                        spec_local.into()
-                    };
-                    (spec_local_place, target_arg.clone())
-                })
-        );
+        for (local, target_arg) in mir.args_iter().zip(self.target_args) {
+            let local_ty = mir.local_decls[local].ty;
+            let spec_local = mir_encoder.encode_local(local)?;
+            let spec_local_place: vir::Expr = if self.targets_are_values {
+                self.encoder.encode_value_expr(
+                    vir::Expr::local(spec_local),
+                    local_ty
+                )
+            } else {
+                spec_local.into()
+            };
+            replacements.push((spec_local_place, target_arg.clone()));
+        }
 
         // Replacement 2: replace the fake return variable (last argument) of SPEC items with
         // `target_return`
         if let Some(target_return) = self.target_return {
             let fake_return_local = mir.args_iter().last().unwrap();
             let fake_return_ty = mir.local_decls[fake_return_local].ty;
-            // will panic if attempting to encode unsupported type
-            let spec_fake_return = mir_encoder.encode_local(fake_return_local).unwrap();
+            let spec_fake_return = mir_encoder.encode_local(fake_return_local)?;
             let spec_fake_return_place: vir::Expr = if self.targets_are_values {
                 self.encoder.encode_value_expr(
                     vir::Expr::local(spec_fake_return),

--- a/prusti-viper/src/encoder/specs_closures_collector.rs
+++ b/prusti-viper/src/encoder/specs_closures_collector.rs
@@ -58,7 +58,7 @@ impl<'tcx> SpecsClosuresCollector<'tcx> {
             self.visited.insert(def_id);
         }
         let tcx = env.tcx();
-        let mir = env.mir(def_id);
+        let mir = env.local_mir(def_id);
         for (bb_index, bb_data) in mir.basic_blocks().iter_enumerated() {
             for (stmt_index, stmt) in bb_data.statements.iter().enumerate() {
                 if let mir::StatementKind::Assign(

--- a/prusti-viper/src/encoder/stub_function_encoder.rs
+++ b/prusti-viper/src/encoder/stub_function_encoder.rs
@@ -12,6 +12,8 @@ use rustc_middle::mir;
 use log::{trace, debug};
 use crate::encoder::errors::EncodingError;
 use crate::encoder::errors::WithSpan;
+use crate::encoder::errors::PositionlessEncodingResult;
+use crate::encoder::errors::EncodingResult;
 
 pub struct StubFunctionEncoder<'p, 'v: 'p, 'tcx: 'v> {
     encoder: &'p Encoder<'v, 'tcx>,
@@ -35,7 +37,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> StubFunctionEncoder<'p, 'v, 'tcx> {
         }
     }
 
-    pub fn encode_function(&self) -> Result<vir::Function, EncodingError> {
+    pub fn encode_function(&self) -> EncodingResult<vir::Function> {
         let function_name = self.encode_function_name();
         debug!("Encode stub function {}", function_name);
         let subst_strings = self.encoder.type_substitution_strings().with_span(self.mir.span)?;
@@ -82,7 +84,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> StubFunctionEncoder<'p, 'v, 'tcx> {
         base_name
     }
 
-    pub fn encode_function_return_type(&self) -> Result<vir::Type, EncodingError> {
+    pub fn encode_function_return_type(&self) -> EncodingResult<vir::Type> {
         let ty = self.encoder.resolve_typaram(self.mir.return_ty());
         let return_local = mir::Place::return_place().as_local().unwrap();
         let span = self.mir_encoder.get_local_span(return_local);

--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -121,7 +121,12 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                 if snapshot.is_defined() {
                     snapshot.get_type()
                 } else {
-                    unreachable!()
+                    return Err(PositionlessEncodingError::internal(
+                        format!(
+                            "unexpected failure while encoding the snapshot of the '{:?}' type",
+                            self.ty
+                        )
+                    ))
                 }
             },
 
@@ -149,7 +154,12 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                         .encode_type_predicate_use(self.ty)?;
                     Ok(vir::Type::TypedRef(type_name))
                 } else {
-                    unreachable!()
+                    Err(PositionlessEncodingError::internal(
+                        format!(
+                            "unexpected failure while encoding the snapshot of the '{:?}' type",
+                            self.ty
+                        )
+                    ))
                 }
             },
 

--- a/prusti-viper/src/encoder/utils.rs
+++ b/prusti-viper/src/encoder/utils.rs
@@ -4,6 +4,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+/// Converts a tuple of results into a result containing a tuple.
+pub fn transpose<U, V, E>(tuple: (Result<U, E>, Result<V, E>)) -> Result<(U, V), E> {
+    Ok((tuple.0?, tuple.1?))
+}
 
 pub fn range_extract<T: Ord + Copy + Eq + PartialEq + PlusOne>(mut values: Vec<T>) -> Vec<(T, T)> {
     if values.is_empty() {


### PR DESCRIPTION
With this PR the following program (from #320) no longer panics, but reports the error message "unexpected failure while encoding the snapshot of the 'Vector' type".

```rust
use prusti_contracts::*;

#[derive(Copy, Clone)]
struct Vector(i32, i32);

impl Vector {
    #[pure]
    fn valid(self) -> bool {
        self.0 != i32::MIN && self.1 != i32::MIN
    }

    #[requires(self.valid())] //~ ERROR unexpected failure while encoding the snapshot of the 'Vector' type
    #[ensures(self.valid())]
    fn neg(self) -> Self {
        Self(-self.0, -self.1)
    }
}

fn main(){}
```