### PR TITLE
(Closures) Support raw functions passed to Fn args

### DIFF
--- a/prusti-common/src/vir/ast/expr.rs
+++ b/prusti-common/src/vir/ast/expr.rs
@@ -85,6 +85,8 @@ pub enum Const {
     Bool(bool),
     Int(i64),
     BigInt(String),
+    /// Used for encoding function pointers.
+    Dummy,
 }
 
 impl fmt::Display for Expr {
@@ -236,6 +238,7 @@ impl fmt::Display for Const {
             &Const::Bool(val) => write!(f, "{}", val),
             &Const::Int(val) => write!(f, "{}", val),
             &Const::BigInt(ref val) => write!(f, "{}", val),
+            &Const::Dummy => write!(f, "Dummy"),
         }
     }
 }
@@ -867,6 +870,7 @@ impl Expr {
                 match constant {
                     Const::Bool(..) => &Type::Bool,
                     Const::Int(..) | Const::BigInt(..) => &Type::Int,
+                    Const::Dummy => &Type::Int,
                 }
             }
             Expr::BinOp(ref kind, box ref base1, box ref base2, _pos) => {

--- a/prusti-common/src/vir/ast/expr.rs
+++ b/prusti-common/src/vir/ast/expr.rs
@@ -85,8 +85,9 @@ pub enum Const {
     Bool(bool),
     Int(i64),
     BigInt(String),
-    /// Used for encoding function pointers.
-    Dummy,
+    /// All function pointers share the same constant, because their function
+    /// is determined by the type system.
+    FnPtr,
 }
 
 impl fmt::Display for Expr {
@@ -238,7 +239,7 @@ impl fmt::Display for Const {
             &Const::Bool(val) => write!(f, "{}", val),
             &Const::Int(val) => write!(f, "{}", val),
             &Const::BigInt(ref val) => write!(f, "{}", val),
-            &Const::Dummy => write!(f, "Dummy"),
+            &Const::FnPtr => write!(f, "FnPtr"),
         }
     }
 }
@@ -847,6 +848,9 @@ impl Expr {
     /// Returns the type of the expression.
     /// For function applications, the return type is provided.
     pub fn get_type(&self) -> &Type {
+        lazy_static! {
+            static ref FN_PTR_TYPE: Type = Type::TypedRef("FnPtr".to_string());
+        }
         match self {
             Expr::Local(LocalVar { ref typ, .. }, _)
             | Expr::Variant(_, Field { ref typ, .. }, _)
@@ -870,7 +874,7 @@ impl Expr {
                 match constant {
                     Const::Bool(..) => &Type::Bool,
                     Const::Int(..) | Const::BigInt(..) => &Type::Int,
-                    Const::Dummy => &Type::Int,
+                    Const::FnPtr => &FN_PTR_TYPE,
                 }
             }
             Expr::BinOp(ref kind, box ref base1, box ref base2, _pos) => {

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -483,7 +483,7 @@ impl<'v, 'a, 'b> ToViper<'v, viper::Expr<'v>> for (&'a Const, &'b Position) {
             &Const::Bool(false) => ast.false_lit_with_pos(self.1.to_viper(ast)),
             &Const::Int(x) => ast.int_lit_with_pos(x, self.1.to_viper(ast)),
             &Const::BigInt(ref x) => ast.int_lit_from_ref_with_pos(x, self.1.to_viper(ast)),
-            &Const::Dummy => ast.int_lit_with_pos(0, self.1.to_viper(ast)),
+            &Const::FnPtr => ast.null_lit_with_pos(self.1.to_viper(ast)),
         }
     }
 }

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -483,6 +483,7 @@ impl<'v, 'a, 'b> ToViper<'v, viper::Expr<'v>> for (&'a Const, &'b Position) {
             &Const::Bool(false) => ast.false_lit_with_pos(self.1.to_viper(ast)),
             &Const::Int(x) => ast.int_lit_with_pos(x, self.1.to_viper(ast)),
             &Const::BigInt(ref x) => ast.int_lit_from_ref_with_pos(x, self.1.to_viper(ast)),
+            &Const::Dummy => ast.int_lit_with_pos(0, self.1.to_viper(ast)),
         }
     }
 }

--- a/prusti-tests/tests/verify/pass/closures/fn-ptr.rs
+++ b/prusti-tests/tests/verify/pass/closures/fn-ptr.rs
@@ -1,0 +1,24 @@
+use prusti_contracts::*;
+
+#[requires(add |= |a: i32, b: i32| [
+    requires(a >= 0),
+    requires(b >= 0),
+    ensures(result == a + b)
+])]
+#[ensures(result == 16)]
+fn call_add<F: Fn (i32, i32) -> i32>(add: F) -> i32 {
+    // TODO: higher-order calls cannot be encoded yet
+    // add(7, 9)
+    16
+}
+
+#[requires(a >= 0)]
+#[requires(b >= 0)]
+#[ensures(result == a + b)]
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn main() {
+    call_add(add);
+}

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -995,7 +995,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             ty::TyKind::Uint(ast::UintTy::Usize) => scalar_value.to_machine_usize(&self.env().tcx()).unwrap().into(),
             ty::TyKind::FnDef(def_id, _) => {
                 self.encode_spec_funcs(*def_id)?;
-                vir::Expr::Const(vir::Const::Dummy, vir::Position::default())
+                vir::Expr::Const(vir::Const::FnPtr, vir::Position::default())
             }
             ref x => unimplemented!("{:?}", x),
         };

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -978,14 +978,6 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             ));
         };
 
-        fn with_sign(unsigned_val: u128, bit_size: u64) -> i128 {
-            // Handle *signed* integers
-            let shift = 128 - bit_size;
-            let casted_val = unsigned_val as i128;
-            // sign extend the raw representation to be an i128
-            ((casted_val << shift) >> shift).into()
-        }
-
         let expr = match ty.kind() {
             ty::TyKind::Bool => scalar_value.to_bool().unwrap().into(),
             ty::TyKind::Char => scalar_value.to_char().unwrap().into(),
@@ -1001,6 +993,10 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             ty::TyKind::Uint(ast::UintTy::U64) => scalar_value.to_u64().unwrap().into(),
             ty::TyKind::Uint(ast::UintTy::U128) => scalar_value.to_u128().unwrap().into(),
             ty::TyKind::Uint(ast::UintTy::Usize) => scalar_value.to_machine_usize(&self.env().tcx()).unwrap().into(),
+            ty::TyKind::FnDef(def_id, _) => {
+                self.encode_spec_funcs(*def_id)?;
+                vir::Expr::Const(vir::Const::Dummy, vir::Position::default())
+            }
             ref x => unimplemented!("{:?}", x),
         };
         debug!("encode_const_expr {:?} --> {:?}", value, expr);

--- a/prusti-viper/src/encoder/spec_encoder.rs
+++ b/prusti-viper/src/encoder/spec_encoder.rs
@@ -269,7 +269,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
                     debug!("spec ent repl: {:?} -> {:?}", ty, ty_repl);
 
                     match ty_repl.kind() {
-                        ty::TyKind::Closure(def_id, substs) => {
+                        ty::TyKind::Closure(def_id, _substs)
+                        | ty::TyKind::FnDef(def_id, _substs) => {
                             let encoded_pres = pres.iter()
                                 .map(|x| self.encode_assertion(x))
                                 .collect::<Result<Vec<vir::Expr>, _>>()?

--- a/prusti-viper/src/encoder/spec_function_encoder.rs
+++ b/prusti-viper/src/encoder/spec_function_encoder.rs
@@ -30,6 +30,7 @@ pub struct SpecFunctionEncoder<'p, 'v: 'p, 'tcx: 'v> {
     procedure: &'p Procedure<'p, 'tcx>,
     span: Span,
     proc_def_id: ProcedureDefId,
+    is_closure: bool,
     mir: &'p mir::Body<'tcx>,
     mir_encoder: MirEncoder<'p, 'v, 'tcx>,
 }
@@ -43,6 +44,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecFunctionEncoder<'p, 'v, 'tcx> {
             procedure: procedure,
             span: procedure.get_span(),
             proc_def_id: procedure.get_id(),
+            is_closure: encoder.env().tcx().is_closure(procedure.get_id()),
             mir: procedure.get_mir(),
             mir_encoder: MirEncoder::new(encoder, procedure.get_mir(), procedure.get_id())
         }
@@ -102,7 +104,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecFunctionEncoder<'p, 'v, 'tcx> {
             name: self.encoder.encode_spec_func_name(self.procedure.get_id(),
                                                      SpecFunctionKind::Pre),
             formal_args: encoded_args.into_iter()
-                                     .skip(1) // FIXME: "self" is skipped, see TypeEncoder
+                                     .skip(if self.is_closure { 1 } else { 0 }) // FIXME: "self" is skipped, see TypeEncoder
                                      .collect(),
             return_type: vir::Type::Bool,
             pres: Vec::new(),
@@ -150,7 +152,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecFunctionEncoder<'p, 'v, 'tcx> {
             name: self.encoder.encode_spec_func_name(self.procedure.get_id(),
                                                      SpecFunctionKind::Post),
             formal_args: encoded_args.into_iter()
-                                     .skip(1) // FIXME: "self" is skipped, see TypeEncoder
+                                     .skip(if self.is_closure { 1 } else { 0 }) // FIXME: "self" is skipped, see TypeEncoder
                                      .chain(std::iter::once(encoded_return))
                                      .collect(),
             return_type: vir::Type::Bool,

--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -185,7 +185,8 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
             // To unify how parameters are passed to functions, we treat them like a reference.
             ty::TyKind::Adt(_, _)
             | ty::TyKind::Tuple(_)
-            | ty::TyKind::Closure(_, _) => {
+            | ty::TyKind::Closure(_, _)
+            | ty::TyKind::FnDef(_, _) => {
                 let type_name = self.encoder.encode_type_predicate_use(self.ty)?;
                 vir::Field::new("val_ref", vir::Type::TypedRef(type_name))
             }

--- a/prusti-viper/src/utils/type_visitor.rs
+++ b/prusti-viper/src/utils/type_visitor.rs
@@ -63,6 +63,9 @@ pub trait TypeVisitor<'tcx>: Sized {
             TyKind::Closure(def_id, substs) => {
                 self.visit_closure(def_id, substs)
             }
+            TyKind::FnDef(def_id, substs) => {
+                self.visit_fndef(def_id, substs)
+            }
             ref x => {
                 self.visit_unsupported_sty(x)
             }
@@ -182,6 +185,15 @@ pub trait TypeVisitor<'tcx>: Sized {
         trace!("visit_closure({:?})", def_id);
         walk_closure(self, def_id, substs)
     }
+
+    fn visit_fndef(
+        &mut self,
+        def_id: DefId,
+        substs: SubstsRef<'tcx>
+    ) -> Result<(), Self::Error> {
+        trace!("visit_fndef({:?})", def_id);
+        walk_fndef(self, def_id, substs)
+    }
 }
 
 pub fn walk_adt<'tcx, E, V: TypeVisitor<'tcx, Error = E>>(
@@ -262,4 +274,15 @@ pub fn walk_closure<'tcx, E, V: TypeVisitor<'tcx, Error = E>>(
         visitor.visit_ty(ty)?;
     }
     visitor.visit_ty(fn_sig.output())
+}
+
+pub fn walk_fndef<'tcx, E, V: TypeVisitor<'tcx, Error = E>>(
+    visitor: &mut V,
+    def_id: DefId,
+    substs: SubstsRef<'tcx>
+) -> Result<(), E> {
+    for ty in substs.types() {
+        visitor.visit_ty(ty)?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
Add support for encoding regular functions passed to `Fn` arguments.

```rust
// specs...
fn call_add<F: Fn (i32, i32) -> i32>(add: F) -> i32 { ... }
// specs...
fn add(a: i32, b: i32) -> i32 { a + b }
fn main() { call_add(add); }
```