### PR TITLE
Killing prusti-server process tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,12 +47,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
-name = "arc-swap"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +528,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
+dependencies = [
+ "nix 0.18.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1233,9 +1237,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libgit2-sys"
@@ -1516,6 +1520,30 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -1848,7 +1876,9 @@ dependencies = [
 name = "prusti-launch"
 version = "0.1.0"
 dependencies = [
+ "ctrlc",
  "glob",
+ "nix 0.19.1",
  "serde 1.0.117",
  "toml 0.5.7",
  "walkdir",
@@ -2333,7 +2363,7 @@ dependencies = [
  "git2",
  "lazy_static 1.4.0",
  "log 0.4.11",
- "nix",
+ "nix 0.11.1",
  "percent-encoding 2.1.0",
  "remove_dir_all",
  "reqwest 0.10.8",
@@ -2543,11 +2573,10 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 

--- a/prusti-launch/Cargo.toml
+++ b/prusti-launch/Cargo.toml
@@ -28,6 +28,10 @@ doctest = false
 walkdir = "2.0.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5.7"
+ctrlc = "3.1.7"
+
+[target.'cfg(unix)'.dependencies]
+nix = "0.19.1"
 
 [dev-dependencies]
 glob = "0.3.0"

--- a/prusti-launch/src/bin/prusti-server.rs
+++ b/prusti-launch/src/bin/prusti-server.rs
@@ -4,8 +4,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf, process::{self, Command, Stdio}};
 use prusti_launch::{find_viper_home, find_z3_exe};
+#[cfg(target_family = "unix")]
+use nix::{unistd::getpgrp, sys::signal::{Signal, killpg}};
 
 fn main() {
     if let Err(code) = process(std::env::args().skip(1).collect()) {
@@ -62,6 +64,9 @@ fn process(args: Vec<String>) -> Result<(), i32> {
         }
     };
 
+    // Register the SIGINT handler; CTRL_C_EVENT or CTRL_BREAK_EVENT on Windows
+    ctrlc::set_handler(sigint_handler).expect("Error setting Ctrl-C handler");
+
     let exit_status = cmd.status().expect("could not run prusti-server-driver");
 
     if exit_status.success() {
@@ -69,4 +74,23 @@ fn process(args: Vec<String>) -> Result<(), i32> {
     } else {
         Err(exit_status.code().unwrap_or(-1))
     }
+}
+
+#[cfg(target_family = "unix")]
+fn sigint_handler() {
+    // Killing the process group terminates the process tree
+    killpg(getpgrp(), Signal::SIGKILL).expect("Error killing process tree.");
+}
+
+#[cfg(target_family = "windows")]
+fn sigint_handler() {
+    // Kill process tree rooted at prusti-server.exe
+    let kill_command: &str = &*format!("TASKKILL /PID {} /T /F", process::id());
+
+    Command::new("cmd")
+        .args(&["/C", kill_command])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Error killing process tree.");
 }

--- a/prusti-launch/src/bin/prusti-server.rs
+++ b/prusti-launch/src/bin/prusti-server.rs
@@ -64,7 +64,8 @@ fn process(args: Vec<String>) -> Result<(), i32> {
         }
     };
 
-    // Move process to group leader if it isn't
+    // Move process to group leader if it isn't. The only applicable error should be EPERM which
+    // can be thrown when the process is already the group leader. Thus, we ignore it.
     #[cfg(target_family = "unix")]
     let _ = setpgid(Pid::this(), Pid::this());
     // Register the SIGINT handler; CTRL_C_EVENT or CTRL_BREAK_EVENT on Windows


### PR DESCRIPTION
This PR is to close issue #249.

SIGINT signals (CTRL_C_EVENT and CTRL_BREAK_EVENT on Windows) are handled by killing the process tree rooted at the prusti-server process to ensure that all children are killed. On *nix, this is done by simply killing the process group, and on Windows, it is handled by `taskkill /pid PID /t /f `.