### PR TITLE
Workaround for a snapshot/ref encoding bug

### DIFF
--- a/prusti-tests/tests/verify/pass/equality/struct-with-ref.rs
+++ b/prusti-tests/tests/verify/pass/equality/struct-with-ref.rs
@@ -1,0 +1,17 @@
+use prusti_contracts::*;
+
+#[derive(PartialEq, Eq)]
+struct A<'a> {
+    i: &'a mut i32,
+}
+
+#[requires(_x == _y)]
+fn test_eq(_x: &A, _y: &A) {}
+
+fn main() {
+    let mut a = 3;
+    let mut b = 3;
+    let x = A { i: &mut a };
+    let y = A { i: &mut b };
+    test_eq(&x, &y);
+}


### PR DESCRIPTION
This is a small, somewhat hacky fix to a problem that happens when ADTs with `Ref` fields are encoded into snapshots. For some reason, `unfolding` is not properly applied within the snapshot constructor arguments. With this PR, this example works:

```rust
use prusti_contracts::*;

#[derive(PartialEq, Eq)]
struct A<'a> {
    i: &'a mut i32,
}

#[requires(_x == _y)]
fn test_eq(_x: &A, _y: &A) {}

fn main() {}
```