### PR TITLE
Add interner to safely shorten Viper identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -83,9 +83,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "git2"
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"

--- a/prusti-common/src/config.rs
+++ b/prusti-common/src/config.rs
@@ -91,6 +91,7 @@ lazy_static! {
         settings.set_default("JSON_COMMUNICATION", false).unwrap();
         settings.set_default("JSON_COMMUNICATION", false).unwrap();
         settings.set_default("OPTIMIZATIONS","all").unwrap();
+        settings.set_default("INTERN_NAMES", true).unwrap();
 
         settings.set_default("PRINT_DESUGARED_SPECS", false).unwrap();
         settings.set_default("PRINT_TYPECKD_SPECS", false).unwrap();
@@ -402,4 +403,9 @@ pub fn no_verify() -> bool {
 /// Continue the compilation and generate the binary after Prusti terminates
 pub fn full_compilation() -> bool {
     read_setting("FULL_COMPILATION")
+}
+
+/// Intern Viper identifiers to shorten them when possible.
+pub fn intern_names() -> bool {
+    read_setting("INTERN_NAMES")
 }

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -1505,14 +1505,14 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         self.intern_viper_identifier(full_name, short_name)
     }
 
-    pub fn intern_viper_identifier<S: ToString>(&self, full_name: S, short_name: S) -> String {
+    pub fn intern_viper_identifier<S: AsRef<str>>(&self, full_name: S, short_name: S) -> String {
         let result = if config::disable_name_mangling() {
-            short_name.to_string()
+            short_name.as_ref().to_string()
         } else {
             if config::intern_names() {
                 self.name_interner.borrow_mut().intern(full_name, &[short_name])
             } else {
-                full_name.to_string()
+                full_name.as_ref().to_string()
             }
         };
         result

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -52,6 +52,7 @@ use std::borrow::Borrow;
 use crate::encoder::specs_closures_collector::SpecsClosuresCollector;
 use crate::encoder::memory_eq_encoder::MemoryEqEncoder;
 use rustc_span::MultiSpan;
+use crate::encoder::name_interner::NameInterner;
 use crate::encoder::utils::transpose;
 use crate::encoder::errors::EncodingResult;
 use crate::encoder::errors::SpannedEncodingResult;
@@ -95,6 +96,7 @@ pub struct Encoder<'v, 'tcx: 'v> {
     vir_program_before_viper_writer: RefCell<Box<Write>>,
     pub typaram_repl: RefCell<Vec<HashMap<ty::Ty<'tcx>, ty::Ty<'tcx>>>>,
     encoding_errors_counter: RefCell<usize>,
+    name_interner: RefCell<NameInterner>,
 }
 
 impl<'v, 'tcx> Encoder<'v, 'tcx> {
@@ -153,6 +155,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             type_snapshots: RefCell::new(HashMap::new()),
             snap_mirror_funcs: RefCell::new(HashMap::new()),
             encoding_errors_counter: RefCell::new(0),
+            name_interner: RefCell::new(NameInterner::new()),
         }
     }
 
@@ -1025,33 +1028,14 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         expr
     }
 
-    pub fn encode_identifier(&self, ident: String) -> String {
-        // Rule: the rhs must always have an even number of "$"
-        ident
-            .replace("::", "$$")
-            .replace("#", "$sharp$")
-            .replace("<", "$openang$")
-            .replace(">", "$closeang$")
-            .replace("(", "$openrou$")
-            .replace(")", "$closerou$")
-            .replace("[", "$opensqu$")
-            .replace("]", "$closesqu$")
-            .replace("{", "$opencur$")
-            .replace("}", "$closecur$")
-            .replace(",", "$comma$")
-            .replace(";", "$semic$")
-            .replace(" ", "$space$")
-    }
-
     pub fn encode_item_name(&self, def_id: DefId) -> String {
-        format!(
-            "m_{}",
-            self.encode_identifier(if config::disable_name_mangling() {
-                self.env.get_item_name(def_id)
-            } else {
-                self.env.get_item_def_path(def_id)
-            })
-        )
+        let full_name = format!("m_{}", encode_identifier(self.env.get_item_def_path(def_id)));
+        let short_name = format!("m_{}", encode_identifier(
+            self.env.tcx().opt_item_name(def_id)
+                .map(|s| s.name.to_ident_string())
+                .unwrap_or(self.env.get_item_name(def_id))
+        ));
+        self.intern_viper_identifier(full_name, short_name)
     }
 
     pub fn encode_invariant_func_app(
@@ -1499,18 +1483,56 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     }
 
     pub fn encode_spec_func_name(&self, def_id: ProcedureDefId, kind: SpecFunctionKind) -> String {
-        format!(
+        let kind_name = match kind {
+            SpecFunctionKind::Pre => "pre",
+            SpecFunctionKind::Post => "post",
+            SpecFunctionKind::HistInv => "histinv",
+        };
+        let full_name = format!(
             "sf_{}_{}",
-            match kind {
-                SpecFunctionKind::Pre => "pre",
-                SpecFunctionKind::Post => "post",
-                SpecFunctionKind::HistInv => "histinv",
-            },
-            self.encode_identifier(if config::disable_name_mangling() {
-                self.env.get_item_name(def_id)
-            } else {
-                self.env.get_item_def_path(def_id)
-            })
-        )
+            kind_name,
+            encode_identifier(self.env.get_item_def_path(def_id))
+        );
+        let short_name = format!(
+            "sf_{}_{}",
+            kind_name,
+            encode_identifier(
+                self.env.tcx().opt_item_name(def_id)
+                    .map(|s| s.name.to_ident_string())
+                    .unwrap_or(self.env.get_item_name(def_id))
+            )
+        );
+        self.intern_viper_identifier(full_name, short_name)
     }
+
+    pub fn intern_viper_identifier<S: ToString>(&self, full_name: S, short_name: S) -> String {
+        let result = if config::disable_name_mangling() {
+            short_name.to_string()
+        } else {
+            if config::intern_names() {
+                self.name_interner.borrow_mut().intern(full_name, &[short_name])
+            } else {
+                full_name.to_string()
+            }
+        };
+        result
+    }
+}
+
+fn encode_identifier(ident: String) -> String {
+    // Rule: the rhs must always have an even number of "$"
+    ident
+        .replace("::", "$$")
+        .replace("#", "$sharp$")
+        .replace("<", "$openang$")
+        .replace(">", "$closeang$")
+        .replace("(", "$openrou$")
+        .replace(")", "$closerou$")
+        .replace("[", "$opensqu$")
+        .replace("]", "$closesqu$")
+        .replace("{", "$opencur$")
+        .replace("}", "$closecur$")
+        .replace(",", "$comma$")
+        .replace(";", "$semic$")
+        .replace(" ", "$space$")
 }

--- a/prusti-viper/src/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mod.rs
@@ -18,6 +18,7 @@ mod mir_encoder;
 mod mir_successor;
 mod mir_interpreter;
 mod memory_eq_encoder;
+mod name_interner;
 mod places;
 mod procedure_encoder;
 mod pure_function_encoder;

--- a/prusti-viper/src/encoder/name_interner.rs
+++ b/prusti-viper/src/encoder/name_interner.rs
@@ -1,0 +1,129 @@
+// © 2021, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::collections::{HashMap, HashSet};
+use log::debug;
+
+/// Name interner.
+/// This structure can be used to shorten long unique names without losing the uniqueness property.
+#[derive(Debug)]
+pub struct NameInterner {
+    name_to_symbol: HashMap<String, String>,
+    used_symbols: HashSet<String>,
+}
+
+impl NameInterner {
+    pub fn new() -> Self {
+        NameInterner {
+            name_to_symbol: HashMap::new(),
+            used_symbols: HashSet::new(),
+        }
+    }
+
+    /// Intern a full unique name, returning a possibly readable string that uniquely identifies it.
+    /// The `readable_names` must not collide with past or future `full_unique_name`s.
+    pub fn intern<S: ToString>(&mut self, full_unique_name: S, readable_names: &[S]) -> String {
+        let full_unique_name = full_unique_name.to_string();
+        let readable_names: Vec<_> = readable_names.iter().map(|s| s.to_string()).collect();
+        assert!(!readable_names.contains(&"".to_string()));
+
+        // Return the symbol, if we already interned the full name
+        if let Some(symbol) = self.name_to_symbol.get(&full_unique_name) {
+            debug!("Interning of {:?} is {:?}", &full_unique_name, symbol);
+            return symbol.clone();
+        }
+
+        // Check that the readable name is not equal to full names passed in the past.
+        assert!(!readable_names.iter().any(|r| self.name_to_symbol.contains_key(r)));
+
+        // Check that readable names passed in the past are not equal to the current full name.
+        assert!(!self.used_symbols.contains(&full_unique_name));
+
+        let symbol = readable_names.into_iter()
+            .find(|r| !self.used_symbols.contains(r))
+            .unwrap_or(full_unique_name.clone());
+        debug!("Interning of {:?} is {:?}", &full_unique_name, symbol);
+        self.used_symbols.insert(symbol.clone());
+        self.name_to_symbol.insert(full_unique_name, symbol.clone());
+
+        symbol
+    }
+}
+
+impl Default for NameInterner {
+    fn default() -> Self {
+        NameInterner::new()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_name_interner() {
+        let mut interner = NameInterner::new();
+        assert_eq!(interner.intern("unreadable$name", &["name"]), "name");
+        assert_eq!(interner.intern("unreadable$name", &["name"]), "name");
+        assert_eq!(interner.intern("another$name", &["name"]), "another$name");
+        assert_eq!(interner.intern("another$name", &["name"]), "another$name");
+        assert_eq!(interner.intern("unreadable$name", &["name"]), "name");
+        assert_eq!(interner.intern("another$name", &["name"]), "another$name");
+        assert_eq!(interner.intern("third$name", &["third"]), "third");
+        assert_eq!(interner.intern("unreadable$name", &["name"]), "name");
+        assert_eq!(interner.intern("another$name", &["name"]), "another$name");
+        assert_eq!(interner.intern("third$name", &["third"]), "third");
+    }
+
+    #[test]
+    fn test_multiple_readable_names() {
+        let mut interner = NameInterner::new();
+        assert_eq!(interner.intern("my$first$name", &["name", "first$name"]), "name");
+        assert_eq!(interner.intern("my$first$name", &["name", "first$name"]), "name");
+        assert_eq!(interner.intern("my$second$name", &["name", "second$name"]), "second$name");
+        assert_eq!(interner.intern("my$second$name", &[]), "second$name");
+        assert_eq!(interner.intern("my$first$name", &["name", "first$name"]), "name");
+        assert_eq!(interner.intern("my$third$name", &["name", "third$name"]), "third$name");
+        assert_eq!(interner.intern("another$second$name", &["name", "second$name"]), "another$second$name");
+        assert_eq!(interner.intern("my$second$name", &[]), "second$name");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_readable_name_eq_past_full_name_1() {
+        let mut interner = NameInterner::new();
+        assert_eq!(interner.intern("first", &["name"]), "name");
+        // The readable name is one of the past full names
+        let _ = interner.intern("second", &["first"]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_readable_name_eq_past_full_name_2() {
+        let mut interner = NameInterner::new();
+        assert_eq!(interner.intern("first", &["first"]), "first");
+        // The readable name is one of the past full names
+        let _ = interner.intern("second", &["first"]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_readable_name_eq_future_full_name() {
+        let mut interner = NameInterner::new();
+        // The readable name is one of the future full names
+        assert_eq!(interner.intern("first", &["second"]), "second");
+        let _ = interner.intern("second", &["name"]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_empty_readable_name() {
+        let mut interner = NameInterner::new();
+        // The readable name is empty
+        let _ = interner.intern("second", &[""]);
+    }
+}

--- a/prusti-viper/src/encoder/name_interner.rs
+++ b/prusti-viper/src/encoder/name_interner.rs
@@ -28,7 +28,7 @@ impl NameInterner {
     pub fn intern<S: ToString>(&mut self, full_unique_name: S, readable_names: &[S]) -> String {
         let full_unique_name = full_unique_name.to_string();
         let readable_names: Vec<_> = readable_names.iter().map(|s| s.to_string()).collect();
-        assert!(!readable_names.contains(&"".to_string()));
+        debug_assert!(!readable_names.contains(&"".to_string()));
 
         // Return the symbol, if we already interned the full name
         if let Some(symbol) = self.name_to_symbol.get(&full_unique_name) {
@@ -37,10 +37,10 @@ impl NameInterner {
         }
 
         // Check that the readable name is not equal to full names passed in the past.
-        assert!(!readable_names.iter().any(|r| self.name_to_symbol.contains_key(r)));
+        debug_assert!(!readable_names.iter().any(|r| self.name_to_symbol.contains_key(r)));
 
         // Check that readable names passed in the past are not equal to the current full name.
-        assert!(!self.used_symbols.contains(&full_unique_name));
+        debug_assert!(!self.used_symbols.contains(&full_unique_name));
 
         let symbol = readable_names.into_iter()
             .find(|r| !self.used_symbols.contains(r))

--- a/prusti-viper/src/encoder/name_interner.rs
+++ b/prusti-viper/src/encoder/name_interner.rs
@@ -24,10 +24,12 @@ impl NameInterner {
     }
 
     /// Intern a full unique name, returning a possibly readable string that uniquely identifies it.
-    /// The `readable_names` must not collide with past or future `full_unique_name`s.
+    /// The `readable_names` must not collide with past or future `full_unique_name`s, except for
+    /// the `full_unique_name` passed in the same call.
     pub fn intern<S: ToString>(&mut self, full_unique_name: S, readable_names: &[S]) -> String {
         let full_unique_name = full_unique_name.to_string();
         let readable_names: Vec<_> = readable_names.iter().map(|s| s.to_string()).collect();
+
         debug_assert!(!readable_names.contains(&"".to_string()));
 
         // Return the symbol, if we already interned the full name
@@ -77,6 +79,12 @@ mod tests {
         assert_eq!(interner.intern("unreadable$name", &["name"]), "name");
         assert_eq!(interner.intern("another$name", &["name"]), "another$name");
         assert_eq!(interner.intern("third$name", &["third"]), "third");
+    }
+
+    #[test]
+    fn test_full_name_eq_readable_names() {
+        let mut interner = NameInterner::new();
+        assert_eq!(interner.intern("my$first$name", &["my$first$name"]), "my$first$name");
     }
 
     #[test]

--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -400,6 +400,28 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
         })
     }
 
+    /// The string to be appended to the encoding of certain types to make generics "less fragile".
+    fn encode_substs(&self, substs: ty::subst::SubstsRef<'tcx>) -> EncodingResult<String> {
+        let mut composed_name = vec![];
+        composed_name.push("_beg_".to_string()); // makes generics "less fragile"
+        let mut first = true;
+        for kind in substs.iter() {
+            if first {
+                first = false
+            } else {
+                // makes generics "less fragile"
+                composed_name.push("_sep_".to_string());
+            }
+            if let ty::subst::GenericArgKind::Type(ty) = kind.unpack() {
+                composed_name.push(
+                    self.encoder.encode_type_predicate_use(ty)?
+                )
+            }
+        }
+        composed_name.push("_end_".to_string()); // makes generics "less fragile"
+        Ok(composed_name.join("$"))
+    }
+
     pub fn encode_predicate_use(self) -> EncodingResult<String> {
         debug!("Encode type predicate name '{:?}'", self.ty);
 
@@ -431,22 +453,8 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
 
             ty::TyKind::Adt(adt_def, subst) => {
                 let mut composed_name = vec![self.encoder.encode_item_name(adt_def.did)];
-                composed_name.push("_beg_".to_string()); // makes generics "less fragile"
-                let mut first = true;
-                for kind in subst.iter() {
-                    if first {
-                        first = false
-                    } else {
-                        // makes generics "less fragile"
-                        composed_name.push("_sep_".to_string());
-                    }
-                    if let ty::subst::GenericArgKind::Type(ty) = kind.unpack() {
-                        composed_name.push(
-                            self.encoder.encode_type_predicate_use(ty)?
-                        )
-                    }
-                }
-                composed_name.push("_end_".to_string()); // makes generics "less fragile"
+                // makes generics "less fragile"
+                composed_name.push(self.encode_substs(subst)?);
                 composed_name.join("$")
             }
 
@@ -521,8 +529,11 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                 format!("__TYPARAM__${}$__", param_ty.name.as_str())
             }
 
-            ty::TyKind::Projection(ty::ProjectionTy { item_def_id, .. }) => {
-                self.encoder.encode_item_name(*item_def_id)
+            ty::TyKind::Projection(ty::ProjectionTy { item_def_id, substs }) => {
+                let mut composed_name = vec![self.encoder.encode_item_name(*item_def_id)];
+                // makes generics "less fragile"
+                composed_name.push(self.encode_substs(substs)?);
+                composed_name.join("$")
             }
 
             ty::TyKind::Dynamic(..) => {

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -32,7 +32,6 @@ mod callbacks;
 mod verifier;
 mod arg_value;
 
-use log::debug;
 use std::{env, panic, borrow::Cow, path::PathBuf};
 use prusti_common::report::user;
 use lazy_static::lazy_static;


### PR DESCRIPTION
The interner can be disabled with `PRUSTI_INTERN_NAMES=false`. It does a good job at shortening function names and types, except for the annoying `_beg_..._sep_..._end_` suffix that is kept for the encoding of generics.