### PR TITLE
Make update-rustc deterministic

### DIFF
--- a/.github/workflows/update-rustc.yml
+++ b/.github/workflows/update-rustc.yml
@@ -22,7 +22,8 @@ jobs:
           echo "The updated version of rustc is $NIGHTLY_VERSION"
           sed -i 's/^channel\s*=.*$/channel = "'"$NIGHTLY_VERSION"'"/' rust-toolchain
           declare -a DEVELOPERS=(Aurel300 fpoli vakaras)
-          DEVELOPER="${DEVELOPERS[$(( RANDOM % ${#DEVELOPERS[@]} ))]}"
+          UPDATE_NUMBER=$(( $(date +%m) * 2 + ($(date +%d) / 15) - 2 ))
+          DEVELOPER="${DEVELOPERS[ $UPDATE_NUMBER % ${#DEVELOPERS[@]} ]}"
           echo "The randomly chosen developer is $DEVELOPER"
           echo "NIGHTLY_VERSION=$NIGHTLY_VERSION" >> $GITHUB_ENV
           echo "DEVELOPER=$DEVELOPER" >> $GITHUB_ENV


### PR DESCRIPTION
Replace the Russian roulette with a round robin, such that it's easier to make plans.

With this change the next update will be assigned to @vakaras.
