### PR TITLE
Try changing linker on Windows

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,5 @@
 [target.x86_64-pc-windows-msvc]
 # Statically link the C runtime, such that installing the Visual C++ Build Tools is not a requirement for Prusti
 rustflags = ["-Ctarget-feature=+crt-static"]
+# Use a different linked to avoid a 0xc0000005 exit code on Windows
+linker = "lld-link.exe"

--- a/.cargo/config
+++ b/.cargo/config
@@ -2,4 +2,4 @@
 # Statically link the C runtime, such that installing the Visual C++ Build Tools is not a requirement for Prusti
 rustflags = ["-Ctarget-feature=+crt-static"]
 # Use a different linked to avoid a 0xc0000005 exit code on Windows
-linker = "lld-link.exe"
+linker = "rust-lld"


### PR DESCRIPTION
After enabling LTO, the `pass/equality/pure-post-*.rs` tests fail on Windows with the exit code 0xc0000005 and no stderr/stdout.