### PR TITLE
Check for extra parameters to #[pure], #[trusted] attributes

### DIFF
--- a/prusti-specs/src/lib.rs
+++ b/prusti-specs/src/lib.rs
@@ -211,7 +211,14 @@ fn generate_for_after_expiry_if(attr: TokenStream, item: &untyped::AnyFnItem) ->
 }
 
 /// Generate spec items and attributes to typecheck and later retrieve "pure" annotations.
-fn generate_for_pure(_attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_pure(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+    if !attr.is_empty() {
+        return Err(syn::Error::new(
+            attr.span(),
+            "the `#[pure]` attribute does not take parameters"
+        ));
+    }
+
     Ok((
         vec![],
         vec![parse_quote_spanned! {item.span()=>
@@ -221,7 +228,14 @@ fn generate_for_pure(_attr: TokenStream, item: &untyped::AnyFnItem) -> Generated
 }
 
 /// Generate spec items and attributes to typecheck and later retrieve "trusted" annotations.
-fn generate_for_trusted(_attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_trusted(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+    if !attr.is_empty() {
+        return Err(syn::Error::new(
+            attr.span(),
+            "the `#[trusted]` attribute does not take parameters"
+        ));
+    }
+
     Ok((
         vec![],
         vec![parse_quote_spanned! {item.span()=>

--- a/prusti-tests/tests/parse/ui/no-attr-params.rs
+++ b/prusti-tests/tests/parse/ui/no-attr-params.rs
@@ -1,0 +1,16 @@
+// compile-flags: -Pprint_desugared_specs=true -Pprint_typeckd_specs=true -Pno_verify=true -Phide_uuids=true
+// normalize-stdout-test: "[a-z0-9]{32}" -> "$(NUM_UUID)"
+// normalize-stdout-test: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}" -> "$(UUID)"
+
+use prusti_contracts::*;
+
+
+#[pure(dont write things here)]
+fn pure_err() -> bool {
+    true
+}
+
+#[trusted(dont write things here)]
+fn trusted_err() {}
+
+fn main() {}

--- a/prusti-tests/tests/parse/ui/no-attr-params.stderr
+++ b/prusti-tests/tests/parse/ui/no-attr-params.stderr
@@ -1,0 +1,14 @@
+error: the `#[pure]` attribute does not take parameters
+ --> $DIR/no-attr-params.rs:8:8
+  |
+8 | #[pure(dont write things here)]
+  |        ^^^^^^^^^^^^^^^^^^^^^^
+
+error: the `#[trusted]` attribute does not take parameters
+  --> $DIR/no-attr-params.rs:13:11
+   |
+13 | #[trusted(dont write things here)]
+   |           ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Constructs like `#[pure(123)]` are not allowed, so explicitly refuse
them with a relevant error message.