### PR TITLE
More descriptive error messages

### DIFF
--- a/prusti-tests/tests/verify/fail/unsupported/non_closure_call.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/non_closure_call.rs
@@ -1,0 +1,9 @@
+pub fn max_by_key<A, B: Ord>(a: A, b: A, key: impl Fn(&A) -> B) -> A {
+    if key(&a) > key(&b) { //~ Error: only calls to closures are supported
+        a
+    } else {
+        b
+    }
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2053,7 +2053,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                                     )?);
                                 }
 
-                                _ => unreachable!()
+                                _ => {
+                                    unimplemented!(
+                                        "Only calls to closures are supported. The term at {:?} is a {:?}, not a closure.",
+                                        term.source_info.span, cl_type.kind()
+                                    )
+                                }
                             }
                         }
 

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2055,7 +2055,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
                                 _ => {
                                     cleanup(&self);
-                                    return Err(SpannedEncodingError::internal(
+                                    return Err(SpannedEncodingError::unsupported(
                                         format!("only calls to closures are supported. The term is a {:?}, not a closure.", cl_type.kind()),
                                         term.source_info.span,
                                     ));

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2054,10 +2054,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                                 }
 
                                 _ => {
-                                    unimplemented!(
-                                        "Only calls to closures are supported. The term at {:?} is a {:?}, not a closure.",
-                                        term.source_info.span, cl_type.kind()
-                                    )
+                                    cleanup(&self);
+                                    return Err(SpannedEncodingError::internal(
+                                        format!("only calls to closures are supported. The term is a {:?}, not a closure.", cl_type.kind()),
+                                        term.source_info.span,
+                                    ));
                                 }
                             }
                         }

--- a/prusti-viper/src/utils/type_visitor.rs
+++ b/prusti-viper/src/utils/type_visitor.rs
@@ -268,10 +268,10 @@ pub fn walk_closure<'tcx, E, V: TypeVisitor<'tcx, Error = E>>(
 ) -> Result<(), E> {
     let cl_substs = substs.as_closure();
     // TODO: when are there bound typevars? can type visitor deal with generics?
-    let fn_sig = match cl_substs.sig().no_bound_vars() {
-        Some(t) => t,
-        None => unimplemented!("Bound variables not supported at {:?}", def_id)
-    };
+    let fn_sig =
+        cl_substs.sig()
+                 .no_bound_vars()
+                 .expect(&format!("bound variables are not supported at {:?}", def_id));
     for ty in fn_sig.inputs() {
         visitor.visit_ty(ty)?;
     }

--- a/prusti-viper/src/utils/type_visitor.rs
+++ b/prusti-viper/src/utils/type_visitor.rs
@@ -268,7 +268,10 @@ pub fn walk_closure<'tcx, E, V: TypeVisitor<'tcx, Error = E>>(
 ) -> Result<(), E> {
     let cl_substs = substs.as_closure();
     // TODO: when are there bound typevars? can type visitor deal with generics?
-    let fn_sig = cl_substs.sig().no_bound_vars().unwrap();
+    let fn_sig = match cl_substs.sig().no_bound_vars() {
+        Some(t) => t,
+        None => unimplemented!("Bound variables not supported at {:?}", def_id)
+    };
     for ty in fn_sig.inputs() {
         visitor.visit_ty(ty)?;
     }


### PR DESCRIPTION
When verifying things with Prusti I would sometimes hit errors and have no indication what code was responsible (for example, https://github.com/viperproject/prusti-dev/issues/410). This PR makes the errors somewhat more descriptive by adding the location of the problematic code Prusti encountered. 

Feel free to close the PR if this is better addressed in another way.