### PR TITLE
Delete the nll-facts directory to avoid running out of hard drive space.

### DIFF
--- a/prusti-tests/tests/compiletest.rs
+++ b/prusti-tests/tests/compiletest.rs
@@ -107,6 +107,11 @@ fn run_prusti_tests(group_name: &str, filter: &Option<String>, rustc_flags: Opti
         config.src_base = path;
         run_tests(&config);
     }
+
+    // Delete the nll-facts directory to avoid running out of hard drive
+    // space. Ignore any errors that may occur.
+    let _ = std::fs::remove_dir_all("nll-facts");
+    let _ = std::fs::remove_dir_all("log/nll-facts");
 }
 
 fn run_no_verification(group_name: &str, filter: &Option<String>) {


### PR DESCRIPTION
An attempt to fix #412 