### PR TITLE
Opt-in to rustc_private for `rust-analyzer`

### DIFF
--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -11,3 +11,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 compiletest_rs = "0.5.0"
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true

--- a/prusti-interface/Cargo.toml
+++ b/prusti-interface/Cargo.toml
@@ -23,3 +23,7 @@ regex = "1.4.3"
 config = "0.9.0"
 rustc-hash = "1.1.0"
 datafrog = "2.0.1"
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true

--- a/prusti-tests/Cargo.toml
+++ b/prusti-tests/Cargo.toml
@@ -9,3 +9,7 @@ compiletest_rs = "0.5.0"
 prusti-server = { path = "../prusti-server" }
 prusti-launch = { path = "../prusti-launch" }
 prusti = { path = "../prusti" }
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true

--- a/prusti-viper/Cargo.toml
+++ b/prusti-viper/Cargo.toml
@@ -23,3 +23,7 @@ serde = "1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true

--- a/prusti/Cargo.toml
+++ b/prusti/Cargo.toml
@@ -24,3 +24,7 @@ lazy_static = "1.4.0"
 
 [build-dependencies]
 chrono = "0.4"
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true


### PR DESCRIPTION
This is suggested to make the dependency on rustc internals explicit in
the crate manifest; see
https://github.com/rust-analyzer/rust-analyzer/pull/7891 for some more
details.

This change adds this hint to all crates that use
`#![feature(rustc_private)]`.

Fixes #437 