### PR TITLE
Update dependencies (nightly-2021-04-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.1.0"
 dependencies = [
  "compiletest_rs",
  "log 0.4.14",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
 ]
 
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arrayvec"
@@ -110,12 +110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
 dependencies = [
  "byteorder",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -194,7 +188,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -278,7 +272,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "time 0.1.43",
+ "time",
  "winapi 0.3.9",
 ]
 
@@ -345,10 +339,10 @@ dependencies = [
  "lazy_static",
  "libc",
  "log 0.4.14",
- "miow 0.3.6",
+ "miow 0.3.7",
  "regex",
  "rustfix",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_derive",
  "serde_json",
  "tester",
@@ -357,14 +351,14 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -372,30 +366,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
 name = "cookie"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 dependencies = [
- "time 0.1.43",
+ "time",
  "url 1.7.2",
-]
-
-[[package]]
-name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "percent-encoding 2.1.0",
- "time 0.2.26",
- "version_check 0.9.3",
 ]
 
 [[package]]
@@ -404,32 +381,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 dependencies = [
- "cookie 0.12.0",
+ "cookie",
  "failure",
  "idna 0.1.5",
  "log 0.4.14",
  "publicsuffix",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
- "time 0.1.43",
+ "time",
  "try_from",
  "url 1.7.2",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3818dfca4b0cb5211a659bbcbb94225b7127407b2b135e650d717bfb78ab10d3"
-dependencies = [
- "cookie 0.14.4",
- "idna 0.2.2",
- "log 0.4.14",
- "publicsuffix",
- "serde 1.0.124",
- "serde_json",
- "time 0.2.26",
- "url 2.2.1",
 ]
 
 [[package]]
@@ -515,7 +476,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -580,16 +541,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "dtoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -904,7 +859,7 @@ dependencies = [
  "http 0.1.21",
  "mime 0.3.16",
  "sha-1",
- "time 0.1.43",
+ "time",
 ]
 
 [[package]]
@@ -990,7 +945,7 @@ dependencies = [
  "log 0.4.14",
  "net2",
  "rustc_version",
- "time 0.1.43",
+ "time",
  "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
@@ -1120,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1158,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
+checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "libgit2-sys"
@@ -1200,16 +1155,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
-dependencies = [
- "serde 0.8.23",
- "serde_test",
 ]
 
 [[package]]
@@ -1340,13 +1285,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log 0.4.14",
- "miow 0.3.6",
+ "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
 ]
@@ -1376,11 +1321,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi 0.3.9",
 ]
 
@@ -1442,18 +1386,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
-]
-
-[[package]]
-name = "nix"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
 ]
 
 [[package]]
@@ -1703,9 +1635,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -1736,7 +1668,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.14",
  "regex",
- "serde 1.0.124",
+ "serde 1.0.125",
  "uuid 0.8.2",
  "viper",
 ]
@@ -1782,7 +1714,7 @@ dependencies = [
  "prusti-specs",
  "regex",
  "rustc-hash",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -1791,8 +1723,8 @@ version = "0.1.0"
 dependencies = [
  "ctrlc",
  "glob",
- "nix 0.19.1",
- "serde 1.0.124",
+ "nix 0.20.0",
+ "serde 1.0.125",
  "toml",
  "walkdir",
 ]
@@ -1810,7 +1742,7 @@ dependencies = [
  "num_cpus",
  "prusti-common",
  "reqwest",
- "serde 1.0.124",
+ "serde 1.0.125",
  "tokio 0.1.22",
  "viper",
  "warp",
@@ -1822,7 +1754,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "syn",
  "uuid 0.8.2",
@@ -1850,7 +1782,7 @@ dependencies = [
  "prusti-server",
  "prusti-specs",
  "regex",
- "serde 1.0.124",
+ "serde 1.0.125",
  "viper",
 ]
 
@@ -1862,15 +1794,6 @@ checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
 dependencies = [
  "idna 0.2.2",
  "url 2.2.1",
-]
-
-[[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -2165,8 +2088,8 @@ checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 dependencies = [
  "base64 0.10.1",
  "bytes 0.4.12",
- "cookie 0.12.0",
- "cookie_store 0.7.0",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "flate2",
  "futures",
@@ -2177,10 +2100,10 @@ dependencies = [
  "mime 0.3.16",
  "mime_guess 2.0.3",
  "native-tls",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_urlencoded 0.5.5",
- "time 0.1.43",
+ "time",
  "tokio 0.1.22",
  "tokio-executor",
  "tokio-io",
@@ -2241,7 +2164,7 @@ checksum = "f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e"
 dependencies = [
  "anyhow",
  "log 0.4.14",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
 ]
 
@@ -2266,9 +2189,9 @@ checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "rustwide"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d731d5599d26212123d5fcc38eea214a72210a0fbe4140b34b144a577a97d1"
+checksum = "0120e19e7ae6e42bbabc9ba1f794b6ea7c119dee241eec050a8b260afa77a37b"
 dependencies = [
  "attohttpc",
  "base64 0.12.3",
@@ -2285,12 +2208,12 @@ dependencies = [
  "percent-encoding 2.1.0",
  "remove_dir_all",
  "scopeguard",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "tar",
  "tempfile",
  "thiserror",
- "tokio 1.3.0",
+ "tokio 1.4.0",
  "tokio-stream",
  "toml",
  "walkdir",
@@ -2352,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2365,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2396,9 +2319,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
@@ -2410,7 +2333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
 dependencies = [
  "lazy_static",
- "linked-hash-map 0.3.0",
  "num-traits 0.1.43",
  "regex",
  "serde 0.8.23",
@@ -2418,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2435,16 +2357,7 @@ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.124",
-]
-
-[[package]]
-name = "serde_test"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
-dependencies = [
- "serde 0.8.23",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -2455,7 +2368,7 @@ checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.124",
+ "serde 1.0.125",
  "url 1.7.2",
 ]
 
@@ -2467,7 +2380,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.124",
+ "serde 1.0.125",
  "url 2.2.1",
 ]
 
@@ -2482,12 +2395,6 @@ dependencies = [
  "fake-simd",
  "opaque-debug",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2520,85 +2427,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "standback"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2beb4d1860a61f571530b3f855a1b538d0200f7871c63331ecd6f17b1f014f8"
-dependencies = [
- "version_check 0.9.3",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde 1.0.124",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde 1.0.124",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "string"
@@ -2617,9 +2455,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.64"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2716,7 +2554,7 @@ dependencies = [
  "prusti",
  "prusti-launch",
  "rustwide",
- "serde 1.0.124",
+ "serde 1.0.125",
  "toml",
 ]
 
@@ -2773,44 +2611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8cbfbf47955132d0202d1662f49b2423ae35862aee471f3ba4b133358f372"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check 0.9.3",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,15 +2651,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.7.10",
+ "mio 0.7.11",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
@@ -2952,13 +2752,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c535f53c0cfa1acace62995a8994fc9cc1f12d202420da96ff306ee24d576469"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio 1.3.0",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -3053,7 +2853,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -3079,7 +2879,7 @@ checksum = "99471a206425fba51842a9186315f32d91c56eadc21ea4c21f847b59cf778f8b"
 dependencies = [
  "glob",
  "lazy_static",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "termcolor",
  "toml",
@@ -3175,17 +2975,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "1.5.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294b85ef5dbc3670a72e82a89971608a1fcc4ed5c7c5a2895230d31a95f0569b"
+checksum = "6fbeb1aabb07378cf0e084971a74f24241273304653184f54cdce113c0d7df1b"
 dependencies = [
  "base64 0.13.0",
  "chunked_transfer",
- "cookie 0.14.4",
- "cookie_store 0.12.0",
  "log 0.4.14",
  "once_cell",
- "qstring",
  "rustls",
  "url 2.2.1",
  "webpki",
@@ -3243,7 +3040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.2",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -3280,7 +3077,7 @@ dependencies = [
  "jni",
  "lazy_static",
  "log 0.4.14",
- "serde 1.0.124",
+ "serde 1.0.125",
  "uuid 0.8.2",
  "viper-sys",
 ]
@@ -3306,9 +3103,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi 0.3.9",
@@ -3342,7 +3139,7 @@ dependencies = [
  "mime_guess 2.0.3",
  "multipart",
  "scoped-tls",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_urlencoded 0.6.1",
  "tokio 0.1.22",
@@ -3366,9 +3163,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3376,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3391,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3401,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3414,15 +3211,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3530,5 +3327,5 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
- "linked-hash-map 0.5.4",
+ "linked-hash-map",
 ]

--- a/jni-gen/systest/Cargo.toml
+++ b/jni-gen/systest/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 jni-gen = { path = ".." }
 error-chain = "0.12.0"
 env_logger = "0.8.2"
-ureq = "1.5.2"
+ureq = "2.1.0"
 tempdir = "0.3.5"
 
 [dependencies]

--- a/jni-gen/systest/build.rs
+++ b/jni-gen/systest/build.rs
@@ -21,17 +21,10 @@ fn main() {
         Some(location) => location,
         None => {
             let target = "https://repo.maven.apache.org/maven2/asm/asm/3.3.1/asm-3.3.1.jar";
-            let response = ureq::get(target).call();
-            if let Some(error) = response.synthetic_error() {
-                panic!("{}", error);
-            }
+            let response = ureq::get(target).call().unwrap();
             let fname = deps_dir.path().join("asm.jar");
-            let mut dest = File::create(fname.clone()).unwrap_or_else(|e| {
-                panic!("{}", e);
-            });
-            copy(&mut response.into_reader(), &mut dest).unwrap_or_else(|e| {
-                panic!("{}", e);
-            });
+            let mut dest = File::create(fname.clone()).unwrap();
+            copy(&mut response.into_reader(), &mut dest).unwrap();
             fname.to_str().unwrap().to_string()
         }
     };

--- a/prusti-common/Cargo.toml
+++ b/prusti-common/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false # we have no doc tests
 [dependencies]
 log = { version = "0.4", features = ["release_max_level_info"] }
 viper = { path = "../viper" }
-config = "0.10"
+config = "0.11"
 itertools = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4.0"

--- a/prusti-interface/Cargo.toml
+++ b/prusti-interface/Cargo.toml
@@ -20,7 +20,7 @@ polonius-engine = "0.12.1"
 csv = "1"
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.4"
-config = "0.10"
+config = "0.11"
 rustc-hash = "1.1.0"
 datafrog = "2.0.1"
 

--- a/prusti-interface/src/environment/borrowck/facts.rs
+++ b/prusti-interface/src/environment/borrowck/facts.rs
@@ -87,7 +87,7 @@ impl FromStr for Region {
 
     fn from_str(region: &str) -> Result<Self, Self::Err> {
         lazy_static! {
-            static ref RE: Regex = Regex::new(r"^\\'_#(?P<id>\d+)r$").unwrap();
+            static ref RE: Regex = Regex::new(r"^'_#(?P<id>\d+)r$").unwrap();
         }
         let caps = RE.captures(region).unwrap();
         let id: usize = caps["id"].parse().unwrap();

--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -157,11 +157,12 @@ impl<'a, 'tcx> Procedure<'a, 'tcx> {
             destination: ref _destination,
             func:
                 mir::Operand::Constant(box mir::Constant {
-                    literal:
+                    literal: mir::ConstantKind::Ty(
                         ty::Const {
                             ty,
                             ..
                         },
+                    ),
                     ..
                 }),
             ..

--- a/prusti-launch/Cargo.toml
+++ b/prusti-launch/Cargo.toml
@@ -31,7 +31,7 @@ toml = "0.5.8"
 ctrlc = "3.1.7"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.19.1"
+nix = "0.20"
 
 [dev-dependencies]
 glob = "0.3.0"

--- a/prusti-viper/src/encoder/borrows.rs
+++ b/prusti-viper/src/encoder/borrows.rs
@@ -30,14 +30,14 @@ where
     P: fmt::Debug,
 {
     /// Region of this borrow. None means static.
-    pub region: Option<ty::BoundRegion>,
+    pub region: Option<ty::BoundRegionKind>,
     pub blocking_paths: Vec<(P, Mutability)>,
     pub blocked_paths: Vec<(P, Mutability)>,
     //blocked_lifetimes: Vec<String>, TODO: Get this info from the constraints graph.
 }
 
 impl<P: fmt::Debug> BorrowInfo<P> {
-    fn new(region: Option<ty::BoundRegion>) -> Self {
+    fn new(region: Option<ty::BoundRegionKind>) -> Self {
         BorrowInfo {
             region,
             blocking_paths: Vec::new(),
@@ -50,8 +50,8 @@ impl<P: fmt::Debug> fmt::Display for BorrowInfo<P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let lifetime = match self.region {
             None => format!("static"),
-            Some(ty::BoundRegion {kind: ty::BoundRegionKind::BrAnon(id)}) => format!("#{}", id),
-            Some(ty::BoundRegion {kind: ty::BoundRegionKind::BrNamed(_, name)}) => name.to_string(),
+            Some(ty::BoundRegionKind::BrAnon(id)) => format!("#{}", id),
+            Some(ty::BoundRegionKind::BrNamed(_, name)) => name.to_string(),
             _ => unimplemented!(),
         };
         writeln!(f, "BorrowInfo<{}> {{", lifetime)?;
@@ -279,16 +279,14 @@ impl<'tcx> BorrowInfoCollectingVisitor<'tcx> {
         Ok(())
     }
 
-    fn extract_bound_region(&self, region: ty::Region<'tcx>) -> Option<ty::BoundRegion> {
+    fn extract_bound_region(&self, region: ty::Region<'tcx>) -> Option<ty::BoundRegionKind> {
         match region {
-            &ty::RegionKind::ReFree(free_region) => Some(ty::BoundRegion {
-                kind: free_region.bound_region
-            }),
+            &ty::RegionKind::ReFree(free_region) => Some(free_region.bound_region),
             // TODO: is this correct?!
-            &ty::RegionKind::ReLateBound(_, bound_region) => Some(bound_region),
-            &ty::RegionKind::ReEarlyBound(early_region) => Some(ty::BoundRegion {
-                kind: ty::BoundRegionKind::BrNamed(early_region.def_id, early_region.name)
-            }),
+            &ty::RegionKind::ReLateBound(_, bound_region) => Some(bound_region.kind),
+            &ty::RegionKind::ReEarlyBound(early_region) => Some(
+                ty::BoundRegionKind::BrNamed(early_region.def_id, early_region.name),
+            ),
             &ty::RegionKind::ReStatic => None,
             &ty::RegionKind::ReErased => None,
             // &ty::RegionKind::ReScope(_scope) => None,
@@ -298,7 +296,7 @@ impl<'tcx> BorrowInfoCollectingVisitor<'tcx> {
 
     fn get_or_create_borrow_info(
         &mut self,
-        region: Option<ty::BoundRegion>,
+        region: Option<ty::BoundRegionKind>,
     ) -> &mut BorrowInfo<mir::Place<'tcx>> {
         if let Some(index) = self
             .borrow_infos

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -1042,10 +1042,10 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
                 const_value
                     .try_to_scalar()
             }
-            ty::ConstKind::Unevaluated(def, substs, promoted) => {
+            ty::ConstKind::Unevaluated(ct) => {
                 let tcx = self.env().tcx();
-                let param_env = tcx.param_env(def.did);
-                tcx.const_eval_resolve(param_env, *def, substs, *promoted, None)
+                let param_env = tcx.param_env(ct.def.did);
+                tcx.const_eval_resolve(param_env, *ct, None)
                     .ok()
                     .and_then(|const_value| const_value.try_to_scalar())
             }

--- a/prusti-viper/src/encoder/mir_encoder.rs
+++ b/prusti-viper/src/encoder/mir_encoder.rs
@@ -377,9 +377,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
         trace!("Encode operand expr {:?}", operand);
         Ok(match operand {
             &mir::Operand::Constant(box mir::Constant {
-                literal: ty::Const { ty, val },
+                literal: mir::ConstantKind::Ty(ty::Const { ty, val }),
                 ..
             }) => self.encoder.encode_const_expr(ty, val)?,
+            &mir::Operand::Constant(box mir::Constant {
+                literal: mir::ConstantKind::Val(val, ty),
+                ..
+            }) => self.encoder.encode_const_expr(ty, &ty::ConstKind::Value(val))?,
             &mir::Operand::Copy(ref place) | &mir::Operand::Move(ref place) => {
                 let val_place = self.eval_place(&place)?;
                 val_place.into()

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -661,11 +661,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 ref destination,
                 func:
                     mir::Operand::Constant(box mir::Constant {
-                        literal:
+                        literal: mir::ConstantKind::Ty(
                             ty::Const {
                                 ty,
                                 val: _,
                             },
+                        ),
                         ..
                     }),
                 ..

--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -482,10 +482,10 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                             rustc_target::abi::Size::from_bits(64)
                         ).unwrap()
                     },
-                    ty::ConstKind::Unevaluated(def, ref substs, promoted) => {
+                    ty::ConstKind::Unevaluated(ct) => {
                         let tcx = self.encoder.env().tcx();
-                        let param_env = tcx.param_env(def.did);
-                        tcx.const_eval_resolve(param_env, def, substs, promoted, None)
+                        let param_env = tcx.param_env(ct.def.did);
+                        tcx.const_eval_resolve(param_env, ct, None)
                             .ok()
                             .and_then(|const_value| const_value.try_to_bits(
                                 rustc_target::abi::Size::from_bits(64)

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-03-15"
+channel = "nightly-2021-04-01"
 components = [ "rustfmt", "rustc-dev", "llvm-tools-preview" ]

--- a/test-crates/Cargo.toml
+++ b/test-crates/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 prusti-launch = { path = "../prusti-launch" }
 prusti = { path = "../prusti" }
 color-backtrace = "0.5.0"
-rustwide = "0.11.0"
+rustwide = "0.12"
 env_logger = "0.8.2"
 log = "0.4.14"
 csv = "1.1.5"

--- a/viper-sys/Cargo.toml
+++ b/viper-sys/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 jni-gen = { path = "../jni-gen" }
 error-chain = "0.12.0"
 env_logger = "0.8.2"
-ureq = "1.5.2"
+ureq = "2.1.0"
 tempdir = "0.3.5"
 
 [dependencies]

--- a/viper-sys/build.rs
+++ b/viper-sys/build.rs
@@ -31,17 +31,10 @@ fn main() {
         Some(location) => location,
         None => {
             let target = "https://repo.maven.apache.org/maven2/asm/asm/3.3.1/asm-3.3.1.jar";
-            let response = ureq::get(target).call();
-            if let Some(error) = response.synthetic_error() {
-                panic!("{}", error);
-            }
+            let response = ureq::get(target).call().unwrap();
             let fname = deps_dir.path().join("asm.jar");
-            let mut dest = File::create(fname.clone()).unwrap_or_else(|e| {
-                panic!("{}", e);
-            });
-            copy(&mut response.into_reader(), &mut dest).unwrap_or_else(|e| {
-                panic!("{}", e);
-            });
+            let mut dest = File::create(fname.clone()).unwrap();
+            copy(&mut response.into_reader(), &mut dest).unwrap();
             fname.to_str().unwrap().to_string()
         }
     };


### PR DESCRIPTION
* [x] Update rustc version to `nightly-2021-04-01`.
* [x] Manualy update outdated dependencies (see the list below).
* [x] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ cargo outdated --root-deps-only --workspace

analysis
================
Name   Project  Compat   Latest   Kind    Platform
----   -------  ------   ------   ----    --------
serde  1.0.124  1.0.125  1.0.125  Normal  ---

prusti-common
================
Name    Project  Compat   Latest   Kind    Platform
----    -------  ------   ------   ----    --------
config  0.10.1   ---      0.11.0   Normal  ---
serde   1.0.124  1.0.125  1.0.125  Normal  ---

viper
================
Name   Project  Compat   Latest   Kind    Platform
----   -------  ------   ------   ----    --------
serde  1.0.124  1.0.125  1.0.125  Normal  ---

viper-sys
================
Name  Project  Compat  Latest  Kind   Platform
----  -------  ------  ------  ----   --------
ureq  1.5.4    ---     2.1.0   Build  ---

prusti-contracts-impl
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.24   1.0.26  1.0.26  Normal  ---

prusti-specs
================
Name         Project  Compat   Latest   Kind    Platform
----         -------  ------   ------   ----    --------
proc-macro2  1.0.24   1.0.26   1.0.26   Normal  ---
serde        1.0.124  1.0.125  1.0.125  Normal  ---
syn          1.0.64   1.0.68   1.0.68   Normal  ---

prusti-contracts-internal
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.24   1.0.26  1.0.26  Normal  ---

prusti-interface
================
Name    Project  Compat   Latest   Kind    Platform
----    -------  ------   ------   ----    --------
config  0.10.1   ---      0.11.0   Normal  ---
serde   1.0.124  1.0.125  1.0.125  Normal  ---

prusti-viper
================
Name   Project  Compat   Latest   Kind    Platform
----   -------  ------   ------   ----    --------
serde  1.0.124  1.0.125  1.0.125  Normal  ---

prusti-server
================
Name     Project  Compat   Latest   Kind    Platform
----     -------  ------   ------   ----    --------
futures  0.1.31   ---      0.3.13   Normal  ---
reqwest  0.9.24   ---      0.11.2   Normal  ---
serde    1.0.124  1.0.125  1.0.125  Normal  ---
tokio    0.1.22   ---      1.4.0    Normal  ---
warp     0.1.23   ---      0.3.1    Normal  ---

prusti-launch
================
Name     Project  Compat   Latest   Kind    Platform
----     -------  ------   ------   ----    --------
nix      0.19.1   ---      0.20.0   Normal  cfg(unix)
serde    1.0.124  1.0.125  1.0.125  Normal  ---
walkdir  2.3.1    2.3.2    2.3.2    Normal  ---

test-crates
================
Name      Project  Compat   Latest   Kind    Platform
----      -------  ------   ------   ----    --------
rustwide  0.11.1   ---      0.12.0   Normal  ---
serde     1.0.124  1.0.125  1.0.125  Normal  ---

systest
================
Name  Project  Compat  Latest  Kind   Platform
----  -------  ------  ------  ----   --------
ureq  1.5.4    ---     2.1.0   Build  ---
```
</details>

@Aurel300 could you take care of this?