### PR TITLE
Update toolchain to 2021-04-13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
 dependencies = [
  "flate2",
- "http 0.2.3",
+ "http 0.2.4",
  "log 0.4.14",
  "native-tls",
  "openssl",
@@ -144,11 +144,10 @@ checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
 
 [[package]]
 name = "bincode"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde 1.0.125",
 ]
 
@@ -215,9 +214,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -490,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.1.8"
+version = "3.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b8ec3b5755a188c141c1f6a98e76de31b936209bf066b647979e2a84764a9"
+checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
 dependencies = [
  "nix 0.20.0",
  "winapi 0.3.9",
@@ -620,7 +619,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
  "winapi 0.3.9",
 ]
 
@@ -707,9 +706,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-cpupool"
@@ -723,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -735,15 +734,15 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -894,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -917,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
 
 [[package]]
 name = "humantime"
@@ -1113,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "libgit2-sys"
@@ -2028,9 +2027,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]
@@ -2042,7 +2041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.2",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
 ]
 
 [[package]]
@@ -2201,7 +2200,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.1.16",
  "git2",
- "http 0.2.3",
+ "http 0.2.4",
  "lazy_static",
  "log 0.4.14",
  "nix 0.11.1",
@@ -2213,7 +2212,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tokio-stream",
  "toml",
  "walkdir",
@@ -2265,9 +2264,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -2455,9 +2454,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
+checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2518,7 +2517,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2612,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2651,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -2758,7 +2757,7 @@ checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio 1.4.0",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -2873,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99471a206425fba51842a9186315f32d91c56eadc21ea4c21f847b59cf778f8b"
+checksum = "1768998d9a3b179411618e377dbb134c58a88cda284b0aa71c42c40660127d46"
 dependencies = [
  "glob",
  "lazy_static",
@@ -2939,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -3237,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
 ]

--- a/analysis/tests/test_cases/definitely_initialized/calls.stdout
+++ b/analysis/tests/test_cases/definitely_initialized/calls.stdout
@@ -32,7 +32,7 @@ Result for function main():
         [
           "_1"
         ],
-        "statement: FakeRead(ForLet, _1)"
+        "statement: FakeRead(ForLet(None), _1)"
       ],
       [
         "state:",
@@ -69,7 +69,7 @@ Result for function main():
           "_1",
           "_2"
         ],
-        "statement: FakeRead(ForLet, _2)"
+        "statement: FakeRead(ForLet(None), _2)"
       ],
       [
         "state:",
@@ -194,7 +194,7 @@ Result for function main():
           "_4",
           "_5"
         ],
-        "statement: FakeRead(ForLet, _3)"
+        "statement: FakeRead(ForLet(None), _3)"
       ],
       [
         "state:",
@@ -282,7 +282,7 @@ Result for function main():
           "_5",
           "_7"
         ],
-        "statement: FakeRead(ForLet, _7)"
+        "statement: FakeRead(ForLet(None), _7)"
       ],
       [
         "state:",

--- a/analysis/tests/test_cases/definitely_initialized/repeated_assignment.stdout
+++ b/analysis/tests/test_cases/definitely_initialized/repeated_assignment.stdout
@@ -18,7 +18,7 @@ Result for function main():
         [
           "_1"
         ],
-        "statement: FakeRead(ForLet, _1)"
+        "statement: FakeRead(ForLet(None), _1)"
       ],
       [
         "state:",
@@ -40,7 +40,7 @@ Result for function main():
           "_1",
           "_2"
         ],
-        "statement: FakeRead(ForLet, _2)"
+        "statement: FakeRead(ForLet(None), _2)"
       ],
       [
         "state:",

--- a/analysis/tests/test_cases/definitely_initialized/very_simple_assignment.stdout
+++ b/analysis/tests/test_cases/definitely_initialized/very_simple_assignment.stdout
@@ -18,7 +18,7 @@ Result for function main():
         [
           "_1"
         ],
-        "statement: FakeRead(ForLet, _1)"
+        "statement: FakeRead(ForLet(None), _1)"
       ],
       [
         "state:",

--- a/analysis/tests/test_cases/reaching_definitions/calls.stdout
+++ b/analysis/tests/test_cases/reaching_definitions/calls.stdout
@@ -40,7 +40,7 @@ Result for function main():
             "bb0[1]: _1 = f(const -1_i32) -> [return: bb1, unwind: bb5]"
           ]
         },
-        "statement: FakeRead(ForLet, _1)"
+        "statement: FakeRead(ForLet(None), _1)"
       ],
       [
         "state:",
@@ -96,7 +96,7 @@ Result for function main():
             "bb1[2]: _2 = f(const 1_i32) -> [return: bb2, unwind: bb5]"
           ]
         },
-        "statement: FakeRead(ForLet, _2)"
+        "statement: FakeRead(ForLet(None), _2)"
       ],
       [
         "state:",
@@ -338,7 +338,7 @@ Result for function main():
             "bb2[6]: _6 = CheckedAdd(_4, _5)"
           ]
         },
-        "statement: FakeRead(ForLet, _3)"
+        "statement: FakeRead(ForLet(None), _3)"
       ],
       [
         "state:",
@@ -559,7 +559,7 @@ Result for function main():
             "bb3[6]: _8 = _3"
           ]
         },
-        "statement: FakeRead(ForLet, _7)"
+        "statement: FakeRead(ForLet(None), _7)"
       ],
       [
         "state:",

--- a/analysis/tests/test_cases/reaching_definitions/repeated_assignment.stdout
+++ b/analysis/tests/test_cases/reaching_definitions/repeated_assignment.stdout
@@ -20,7 +20,7 @@ Result for function main():
             "bb0[1]: _1 = const 1_i32"
           ]
         },
-        "statement: FakeRead(ForLet, _1)"
+        "statement: FakeRead(ForLet(None), _1)"
       ],
       [
         "state:",
@@ -50,7 +50,7 @@ Result for function main():
             "bb0[4]: _2 = const 3_i32"
           ]
         },
-        "statement: FakeRead(ForLet, _2)"
+        "statement: FakeRead(ForLet(None), _2)"
       ],
       [
         "state:",

--- a/analysis/tests/test_cases/reaching_definitions/very_simple_assignment.stdout
+++ b/analysis/tests/test_cases/reaching_definitions/very_simple_assignment.stdout
@@ -20,7 +20,7 @@ Result for function main():
             "bb0[1]: _1 = const 123_u32"
           ]
         },
-        "statement: FakeRead(ForLet, _1)"
+        "statement: FakeRead(ForLet(None), _1)"
       ],
       [
         "state:",

--- a/prusti-launch/Cargo.toml
+++ b/prusti-launch/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 walkdir = "2.0.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5.8"
-ctrlc = "3.1.7"
+ctrlc = "3.1.9"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.20"

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -942,7 +942,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         match stmt.kind {
             mir::StatementKind::StorageLive(..)
             | mir::StatementKind::StorageDead(..)
-            | mir::StatementKind::FakeRead(_, _)    // FIXME
+            | mir::StatementKind::FakeRead(..)    // FIXME
             // | mir::StatementKind::ReadForMatch(..)
             // | mir::StatementKind::EndRegion(..)
              => {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-04-01"
+channel = "nightly-2021-04-13"
 components = [ "rustfmt", "rustc-dev", "llvm-tools-preview" ]


### PR DESCRIPTION
The previous version (2021-04-01) had component rustfmt missing, which lead to a multiline warning on each `x.py` call (at least for me).