### PR TITLE
Update dependencies (nightly-2021-04-15)

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-04-01"
+channel = "nightly-2021-04-15"
 components = [ "rustfmt", "rustc-dev", "llvm-tools-preview" ]


### PR DESCRIPTION
* [x] Update rustc version to `nightly-2021-04-15`.
* [ ] Manualy update outdated dependencies (see the list below).
* [ ] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ cargo outdated --root-deps-only --workspace

prusti-contracts
================
Name      Project  Compat  Latest  Kind         Platform
----      -------  ------  ------  ----         --------
trybuild  1.0.41   1.0.42  1.0.42  Development  ---

prusti-specs
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
syn   1.0.68   1.0.69  1.0.69  Normal  ---

prusti-server
================
Name     Project  Compat  Latest  Kind    Platform
----     -------  ------  ------  ----    --------
bincode  1.3.2    1.3.3   1.3.3   Normal  ---
futures  0.1.31   ---     0.3.14  Normal  ---
reqwest  0.9.24   ---     0.11.3  Normal  ---
tokio    0.1.22   ---     1.5.0   Normal  ---
warp     0.1.23   ---     0.3.1   Normal  ---

prusti-launch
================
Name   Project  Compat  Latest  Kind    Platform
----   -------  ------  ------  ----    --------
ctrlc  3.1.8    3.1.9   3.1.9   Normal  ---
```
</details>

@fpoli could you take care of this?