### PR TITLE
Added a flake for building Prusti with the Nix package manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,126 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1614513358,
+        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1618068541,
+        "narHash": "sha256-enxg0QB53Zis0VJWfJsrX7zCjurpi7lW78EKXbJdzpQ=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "b3b099d669fc8b18d361c249091c9fe95d57ebbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1618573837,
+        "narHash": "sha256-OVt37RIRQ35FyrpW4f2cgSMaOOnnNtxdvYTebn9ZW3o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "262b73f8af242f9879801ecc23734286e801eed9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1618343055,
+        "narHash": "sha256-yux3woyNtMt6ynYRq7+DYe19CC+SoI/LJW+zSJd0UOs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e019872af81e4013fd518fcacfba74b1de21a50e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1617325113,
+        "narHash": "sha256-GksR0nvGxfZ79T91UUtWjjccxazv6Yh/MvEJ82v1Xmw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "54c1e44240d8a527a8f4892608c4bce5440c3ecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1618539867,
+        "narHash": "sha256-rVqcD0gd+vOUR3g+I6xHw2QOL7cYVnxEiHcnTXG7dRM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "22e1be77770928d5b6ae692f62c774df1f36d146",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1618217525,
+        "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c6169a2772643c4a93a0b5ac1c61e296cba68544",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1618068541,
-        "narHash": "sha256-enxg0QB53Zis0VJWfJsrX7zCjurpi7lW78EKXbJdzpQ=",
+        "lastModified": 1618844365,
+        "narHash": "sha256-Z9t0rr+5OG/ru3jdg3jivfYVU4ydV/nqt8UwIut7uHs=",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "b3b099d669fc8b18d361c249091c9fe95d57ebbb",
+        "rev": "32e3ba39d9d83098b13720a4384bdda191dd0445",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1618573837,
-        "narHash": "sha256-OVt37RIRQ35FyrpW4f2cgSMaOOnnNtxdvYTebn9ZW3o=",
+        "lastModified": 1619148368,
+        "narHash": "sha256-JC0Hk+In4p94GXKmMTPM6Vtqatpq79qdag9ztp0W+1M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "262b73f8af242f9879801ecc23734286e801eed9",
+        "rev": "cc9e099e6310a380850324a038d9f4f3185b89a9",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1618343055,
-        "narHash": "sha256-yux3woyNtMt6ynYRq7+DYe19CC+SoI/LJW+zSJd0UOs=",
+        "lastModified": 1619057301,
+        "narHash": "sha256-1Y1nCnwGSQHM76KGIhz+8tOAGOT3wlP+dKjwoyQXCtg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e019872af81e4013fd518fcacfba74b1de21a50e",
+        "rev": "d235056d6d6dcbd2999bd55fd120d831d4df6304",
         "type": "github"
       },
       "original": {
@@ -92,11 +92,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1618539867,
-        "narHash": "sha256-rVqcD0gd+vOUR3g+I6xHw2QOL7cYVnxEiHcnTXG7dRM=",
+        "lastModified": 1619144889,
+        "narHash": "sha256-9+nfsUEb89TyNcK8F2pTia76GhPDYDigypCEGBRxAxo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "22e1be77770928d5b6ae692f62c774df1f36d146",
+        "rev": "49a8f52d0e15e8ccbd1946f3d7abff01931260a4",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1618217525,
-        "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
+        "lastModified": 1618868421,
+        "narHash": "sha256-vyoJhLV6cJ8/tWz+l9HZLIkb9Rd9esE7p+0RL6zDR6Y=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c6169a2772643c4a93a0b5ac1c61e296cba68544",
+        "rev": "eed214942bcfb3a8cc09eb3b28ca7d7221e44a94",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -43,10 +43,8 @@
               pkgs.makeWrapper
             ];
 
-            copyLibs = true;
-            copyLibsFilter = ''
-              select(.reason == "compiler-artifact" and ((.target.kind | contains(["lib"])) and (.package_id | test("prusti-contracts"))) and .profile.test == false)
-            '';
+            copyTarget = true;
+            compressTarget = false;
 
             override = _: {
               preBuild = ''
@@ -55,7 +53,11 @@
                 export Z3_EXE="${packages.viper}/z3/bin/z3"
                 export ASM_JAR="${packages.ow2_asm}/asm.jar"
               '';
+            };
+            overrideMain = _: {
               postInstall = ''
+                rm $out/bin/test-crates
+
                 for f in $(find $out/bin/ $out/libexec/ -type f -executable); do
                   wrapProgram $f \
                     --set RUST_SYSROOT "${rust}" \
@@ -65,8 +67,11 @@
                     --set Z3_EXE "${packages.viper}/z3/bin/z3"
                 done
 
-                cp -r $out/lib/. $out/bin
-                rm -rf $out/lib/
+                mkdir $out/bin/deps
+                cp $out/target/release/libprusti_contracts.rlib $out/bin
+                cp $out/target/release/deps/libprusti_contracts_internal-* $out/bin/deps
+                rm -rf $out/target
+                rm $out/bin/deps/*.{rlib,rmeta}
               '';
             };
           };
@@ -75,7 +80,7 @@
             name = "viper";
             url = "https://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip";
             stripRoot = false;
-            hash = "sha256-oV9VgGmzNrLW6n08vXU2rlV6S9Eca3U0L+gNbVxKhEE=";
+            hash = "sha256-82vnyO7QWaLzehnBzPJxuEmdqK0MnWWwQnmdLq28sQc=";
           };
 
           ow2_asm = pkgs.stdenv.mkDerivation rec {

--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,53 @@
           };
         };
 
+        checks = {
+          # prusti-test = naersk-lib.buildPackage {
+          #   name = "prusti-test";
+          #   version = "${prusti-version}";
+          #   root = ./.;
+          #   checkInputs = [
+          #     pkgs.pkg-config
+          #     pkgs.wget
+          #     pkgs.gcc
+          #     pkgs.openssl
+          #     pkgs.jdk11
+          #     packages.viper
+          #     packages.ow2_asm
+          #   ];
+
+          #   doCheck = true;
+
+          #   override = _: {
+          #     preBuild = ''
+          #       export LD_LIBRARY_PATH="${pkgs.jdk11}/lib/openjdk/lib/server"
+          #       export VIPER_HOME="${packages.viper}/backends"
+          #       export Z3_EXE="${packages.viper}/z3/bin/z3"
+          #       export ASM_JAR="${packages.ow2_asm}/asm.jar"
+          #     '';
+          #     preCheck = ''
+          #       export RUST_SYSROOT="${rust}"
+          #       export JAVA_HOME="${pkgs.jdk11}/lib/openjdk"
+          #       export LD_LIBRARY_PATH="${pkgs.jdk11}/lib/openjdk/lib/server"
+          #       export VIPER_HOME="${packages.viper}/backends"
+          #       export Z3_EXE="${packages.viper}/z3/bin/z3"
+          #     '';
+          #   };
+          # };
+
+          prusti-simple-test = pkgs.runCommand "prusti-simple-test" {
+            buildInputs = [
+              defaultPackage
+              rust
+            ];
+          }
+          ''
+            cargo new --name example $out/example
+            sed -i '1s/^/use prusti_contracts::*;\n/;s/println.*$/assert!(true);/' $out/example/src/main.rs
+            cargo-prusti --manifest-path=$out/example/Cargo.toml
+          '';
+        };
+
         defaultPackage = packages.prusti;
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,92 @@
+{
+  description = "A static verifier for Rust, based on the Viper verification infrastructure.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    naersk.url = "github:nmattia/naersk";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, naersk, rust-overlay, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlay ];
+        };
+
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain;
+
+        naersk-lib = naersk.lib."${system}".override {
+          cargo = rust;
+          rustc = rust;
+        };
+
+        prusti-version = "${self.tag or "${self.lastModifiedDate}.${self.shortRev or "dirty"}"}";
+      in rec {
+        packages.prusti = naersk-lib.buildPackage {
+          name = "prusti";
+          version = "${prusti-version}";
+          root = ./.;
+          buildInputs = [
+            pkgs.pkg-config
+            pkgs.wget
+            pkgs.gcc
+            pkgs.openssl
+            pkgs.jdk11
+            packages.viper
+            packages.ow2_asm
+          ];
+          nativeBuildInputs = [
+            pkgs.makeWrapper
+          ];
+
+          copyLibs = true;
+
+          override = _: {
+            preBuild = ''
+              export LD_LIBRARY_PATH="${pkgs.jdk11}/lib/openjdk/lib/server"
+              export VIPER_HOME="${packages.viper}/backends"
+              export Z3_EXE="${packages.viper}/z3/bin/z3"
+              export ASM_JAR="${packages.ow2_asm}/asm.jar"
+            '';
+            postInstall = ''
+              for f in $(find $out/bin/ $out/libexec/ -type f -executable); do
+                wrapProgram $f \
+                  --set PRUSTI_SYSROOT "${rust}" \
+                  --set JAVA_HOME "${pkgs.jdk11}/lib/openjdk" \
+                  --set LD_LIBRARY_PATH "${pkgs.jdk11}/lib/openjdk/lib/server" \
+                  --set VIPER_HOME "${packages.viper}/backends" \
+                  --set Z3_EXE "${packages.viper}/z3/bin/z3"
+              done
+            '';
+          };
+        };
+
+        packages.viper = pkgs.fetchzip {
+          name = "viper";
+          url = "https://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip";
+          stripRoot = false;
+          hash = "sha256-oV9VgGmzNrLW6n08vXU2rlV6S9Eca3U0L+gNbVxKhEE=";
+        };
+
+        packages.ow2_asm = pkgs.stdenv.mkDerivation rec {
+          name = "asm";
+          version = "3.3.1";
+          src = pkgs.fetchurl {
+            url = "https://repo.maven.apache.org/maven2/${name}/${name}/${version}/${name}-${version}.jar";
+            hash = "sha256-wrOSdfjpUbx0dQCAoSZs2rw5OZvF4T1kK/LTRkSd9/M=";
+          };
+          dontUnpack = true;
+          dontBuild = true;
+          installPhase = ''
+            mkdir $out
+            cp ${src} $out/asm.jar
+          '';
+        };
+
+        defaultPackage = packages.prusti;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,65 +25,73 @@
 
         prusti-version = "${self.tag or "${self.lastModifiedDate}.${self.shortRev or "dirty"}"}";
       in rec {
-        packages.prusti = naersk-lib.buildPackage {
-          name = "prusti";
-          version = "${prusti-version}";
-          root = ./.;
-          buildInputs = [
-            pkgs.pkg-config
-            pkgs.wget
-            pkgs.gcc
-            pkgs.openssl
-            pkgs.jdk11
-            packages.viper
-            packages.ow2_asm
-          ];
-          nativeBuildInputs = [
-            pkgs.makeWrapper
-          ];
+        packages = {
+          prusti = naersk-lib.buildPackage {
+            name = "prusti";
+            version = "${prusti-version}";
+            root = ./.;
+            buildInputs = [
+              pkgs.pkg-config
+              pkgs.wget
+              pkgs.gcc
+              pkgs.openssl
+              pkgs.jdk11
+              packages.viper
+              packages.ow2_asm
+            ];
+            nativeBuildInputs = [
+              pkgs.makeWrapper
+            ];
 
-          copyLibs = true;
-
-          override = _: {
-            preBuild = ''
-              export LD_LIBRARY_PATH="${pkgs.jdk11}/lib/openjdk/lib/server"
-              export VIPER_HOME="${packages.viper}/backends"
-              export Z3_EXE="${packages.viper}/z3/bin/z3"
-              export ASM_JAR="${packages.ow2_asm}/asm.jar"
+            copyLibs = true;
+            copyLibsFilter = ''
+              select(.reason == "compiler-artifact" and ((.target.kind | contains(["lib"])) and (.package_id | test("prusti-contracts"))) and .profile.test == false)
             '';
-            postInstall = ''
-              for f in $(find $out/bin/ $out/libexec/ -type f -executable); do
-                wrapProgram $f \
-                  --set PRUSTI_SYSROOT "${rust}" \
-                  --set JAVA_HOME "${pkgs.jdk11}/lib/openjdk" \
-                  --set LD_LIBRARY_PATH "${pkgs.jdk11}/lib/openjdk/lib/server" \
-                  --set VIPER_HOME "${packages.viper}/backends" \
-                  --set Z3_EXE "${packages.viper}/z3/bin/z3"
-              done
+
+            override = _: {
+              preBuild = ''
+                export LD_LIBRARY_PATH="${pkgs.jdk11}/lib/openjdk/lib/server"
+                export VIPER_HOME="${packages.viper}/backends"
+                export Z3_EXE="${packages.viper}/z3/bin/z3"
+                export ASM_JAR="${packages.ow2_asm}/asm.jar"
+              '';
+              postInstall = ''
+                for f in $(find $out/bin/ $out/libexec/ -type f -executable); do
+                  wrapProgram $f \
+                    --set RUST_SYSROOT "${rust}" \
+                    --set JAVA_HOME "${pkgs.jdk11}/lib/openjdk" \
+                    --set LD_LIBRARY_PATH "${pkgs.jdk11}/lib/openjdk/lib/server" \
+                    --set VIPER_HOME "${packages.viper}/backends" \
+                    --set Z3_EXE "${packages.viper}/z3/bin/z3"
+                done
+
+                cp -r $out/lib/. $out/bin
+                rm -rf $out/lib/
+              '';
+            };
+          };
+
+          viper = pkgs.fetchzip {
+            name = "viper";
+            url = "https://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip";
+            stripRoot = false;
+            hash = "sha256-oV9VgGmzNrLW6n08vXU2rlV6S9Eca3U0L+gNbVxKhEE=";
+          };
+
+          ow2_asm = pkgs.stdenv.mkDerivation rec {
+            name = "asm";
+            version = "3.3.1";
+            src = pkgs.fetchurl {
+              url = "https://repo.maven.apache.org/maven2/${name}/${name}/${version}/${name}-${version}.jar";
+              hash = "sha256-wrOSdfjpUbx0dQCAoSZs2rw5OZvF4T1kK/LTRkSd9/M=";
+            };
+            dontUnpack = true;
+            dontBuild = true;
+            installPhase = ''
+              mkdir $out
+              cp ${src} $out/asm.jar
             '';
           };
-        };
-
-        packages.viper = pkgs.fetchzip {
-          name = "viper";
-          url = "https://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip";
-          stripRoot = false;
-          hash = "sha256-oV9VgGmzNrLW6n08vXU2rlV6S9Eca3U0L+gNbVxKhEE=";
-        };
-
-        packages.ow2_asm = pkgs.stdenv.mkDerivation rec {
-          name = "asm";
-          version = "3.3.1";
-          src = pkgs.fetchurl {
-            url = "https://repo.maven.apache.org/maven2/${name}/${name}/${version}/${name}-${version}.jar";
-            hash = "sha256-wrOSdfjpUbx0dQCAoSZs2rw5OZvF4T1kK/LTRkSd9/M=";
-          };
-          dontUnpack = true;
-          dontBuild = true;
-          installPhase = ''
-            mkdir $out
-            cp ${src} $out/asm.jar
-          '';
         };
 
         defaultPackage = packages.prusti;

--- a/prusti-launch/src/lib.rs
+++ b/prusti-launch/src/lib.rs
@@ -119,7 +119,7 @@ pub fn get_rust_toolchain_channel() -> String {
 
 /// Find Prusti's sysroot
 pub fn prusti_sysroot() -> Option<PathBuf> {
-    match env::var("PRUSTI_SYSROOT") {
+    match env::var("RUST_SYSROOT") {
         Ok(prusti_sysroot) => Some(PathBuf::from(prusti_sysroot)),
         Err(_) => get_sysroot_from_rustup()
     }

--- a/prusti-launch/src/lib.rs
+++ b/prusti-launch/src/lib.rs
@@ -119,6 +119,13 @@ pub fn get_rust_toolchain_channel() -> String {
 
 /// Find Prusti's sysroot
 pub fn prusti_sysroot() -> Option<PathBuf> {
+    match env::var("PRUSTI_SYSROOT") {
+        Ok(prusti_sysroot) => Some(PathBuf::from(prusti_sysroot)),
+        Err(_) => get_sysroot_from_rustup()
+    }
+}
+
+fn get_sysroot_from_rustup() -> Option<PathBuf> {
     Command::new("rustup")
         .arg("run")
         .arg(get_rust_toolchain_channel())

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2021-04-13"
-components = [ "rustfmt", "rustc-dev", "llvm-tools-preview" ]
+components = [ "rustc-dev", "llvm-tools-preview" ]
+profile = "minimal"


### PR DESCRIPTION
This flake allows one to build Prusti through the Nix package manager
(https://nixos.org/), on NixOS or other distros with Nix installed,
as well as macOS.

Caveats:
- Currently the flake will be built from source every time, which takes
  a considerable amount of time. A cache setup through https://app.cachix.org/
  may be used to solve this problem (and can be setup as a CI workflow).
- As of 04/01/2021, rustfmt was not available in the nightly (as per
  https://rust-lang.github.io/rustup-components-history/). The
  `rust-toolchain` file was altered to default to a minimal profile,
  with optional components added explicitly. If this is unacceptable, an
  alternative must be found, as toolchain component unavailability in
  Nix is an error (aborts the build) and not a warning.
- Currently, Viper is simply downloaded from the official Nightly
  download link, as the Python script does. This causes a problem, as
  Nix builds must be hermetic and reproducible, and changes in the Viper
  nightly, which is unversioned, cause the SHA256 to change and abort
  the build. A better solution would be to compile Viper from source
  using a separate Nix expression or to download a version-pinned
  archive (if possible).
- Currently, Prusti is not agnostic to the Rust toolchain instalation
  method and expects `rustup` to be used. This was an issue on runtime
  for `prusti-launch`, which expects to find the Rust sysroot through
  `rustup`. This was altered by allowing an environment variable,
  `PRUSTI_SYSROOT`, to be set, pointing to the Rust sysroot in an
  environment-agnostic manner, which makes it compatible with the way
  the Rust toolchain is installed as a dependency in Nix (through
  https://github.com/oxalica/rust-overlay). The developer documentation
  regarding environment variables should probably be updated to account
  for this
  (https://viperproject.github.io/prusti-dev/dev-guide/development/build.html).
- Documentation should, similarly, be updated to provide instructions
  on installing and setting up a development environment through Nix.