### PR TITLE
Work around AssertKind::description panicing for BoundsCheck

### DIFF
--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2194,7 +2194,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 let assert_msg = if let AssertKind::BoundsCheck{ .. } = msg {
                     // Use the debug impl for BoundsCheck, as it is supposed to be handled before
                     // calling display() according to the docs
-                    // TODO: use fmt_assert_args once #BUGNR is merged
+                    // TODO: use fmt_assert_args once https://github.com/rust-lang/rust/pull/84392 is merged
                     format!("{:?}", msg)
                 } else {
                     msg.description().to_string()

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -932,7 +932,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 let assert_msg = if let mir::AssertKind::BoundsCheck{ .. } = msg {
                     // Use the debug impl for BoundsCheck, as it is supposed to be handled before
                     // calling display() according to the docs
-                    // TODO: use fmt_assert_args once #BUGNR is merged
+                    // TODO: use fmt_assert_args once https://github.com/rust-lang/rust/pull/84392 is merged
                     format!("{:?}", msg)
                 } else {
                     msg.description().to_string()

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -929,9 +929,17 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     vir::Expr::not(cond_val)
                 };
 
+                let assert_msg = if let mir::AssertKind::BoundsCheck{ .. } = msg {
+                    // Use the debug impl for BoundsCheck, as it is supposed to be handled before
+                    // calling display() according to the docs
+                    // TODO: use fmt_assert_args once #BUGNR is merged
+                    format!("{:?}", msg)
+                } else {
+                    msg.description().to_string()
+                };
                 let pos = self.encoder.error_manager().register(
                     term.source_info.span,
-                    ErrorCtxt::PureFunctionAssertTerminator(msg.description().to_string()),
+                    ErrorCtxt::PureFunctionAssertTerminator(assert_msg),
                 );
 
                 MultiExprBackwardInterpreterState::new(


### PR DESCRIPTION
AssertKind::BoundsCheck panics on calling AssertKind::display, and the
docs say that the caller is supposed to handle those earlier[0]. So we
use fmt_assert_args instead, which can handle BoundsCheck.

[0] https://doc.rust-lang.org/stable/nightly-rustc/rustc_middle/mir/enum.AssertKind.html#impl