### PR TITLE
Introduce PlaceEncoding machinery

### DIFF
--- a/prusti-viper/src/encoder/initialisation.rs
+++ b/prusti-viper/src/encoder/initialisation.rs
@@ -63,7 +63,7 @@ fn convert_to_vir<'tcx, T: Eq + Hash + Clone>(
     for (loc, set) in map.iter() {
         let mut new_set = HashSet::new();
         for place in set.iter() {
-            let encoded_place = mir_encoder.encode_place(place)?.0;
+            let encoded_place = mir_encoder.encode_place(place)?.0.try_into_expr()?;
             new_set.insert(encoded_place);
         }
         result.insert(loc.clone(), new_set);

--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -58,6 +58,12 @@ impl PlaceEncoding {
     pub fn try_into_expr(self) -> EncodingResult<vir::Expr> {
         match self {
             PlaceEncoding::Expr(e) => Ok(e),
+            PlaceEncoding::FieldAccess { base, field } => {
+                Ok(base.try_into_expr()?.field(field))
+            },
+            PlaceEncoding::Variant { base, field } => {
+                Ok(vir::Expr::Variant(box base.try_into_expr()?, field, vir::Position::default()))
+            },
             other => Err(EncodingError::internal(format!("PlaceEncoding::try_into_expr called on non-expr '{:?}'", other))),
         }
     }

--- a/prusti-viper/src/encoder/mir_encoder/place_encoding.rs
+++ b/prusti-viper/src/encoder/mir_encoder/place_encoding.rs
@@ -1,0 +1,93 @@
+// © 2019-2020, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+use std::fmt::Display;
+
+use prusti_common::vir;
+
+use crate::encoder::{
+    Encoder,
+    errors::{EncodingError, EncodingResult},
+};
+
+
+/// Result of encoding a place
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum PlaceEncoding {
+    /// Just an expression, the most common case.
+    Expr(vir::Expr),
+    /// Field access expression
+    FieldAccess {
+        base: Box<PlaceEncoding>,
+        field: vir::Field,
+    },
+    /// Array access expression
+    ArrayAccess {
+        base: Box<PlaceEncoding>,
+        index: vir::Expr,
+        // TODO: prusti-common::src::vir::optimizations::purification has fn translate_type
+        array_elem_ty: vir::Type,
+        array_len: usize,
+    },
+    Variant {
+        base: Box<PlaceEncoding>,
+        field: vir::Field,
+    }
+}
+
+impl PlaceEncoding {
+    pub fn try_into_expr(self) -> EncodingResult<vir::Expr> {
+        match self {
+            PlaceEncoding::Expr(e) => Ok(e),
+            PlaceEncoding::FieldAccess { base, field } => {
+                Ok(base.try_into_expr()?.field(field))
+            },
+            PlaceEncoding::Variant { base, field } => {
+                Ok(vir::Expr::Variant(box base.try_into_expr()?, field, vir::Position::default()))
+            },
+            other => Err(EncodingError::internal(format!("PlaceEncoding::try_into_expr called on non-expr '{:?}'", other))),
+        }
+    }
+
+    pub fn field(self, field: vir::Field) -> Self {
+        PlaceEncoding::FieldAccess { base: box self, field }
+    }
+
+    pub fn get_type(&self) -> &vir::Type {
+        match self {
+            PlaceEncoding::Expr(ref e) => e.get_type(),
+            PlaceEncoding::FieldAccess { ref field, .. } => &field.typ,
+            PlaceEncoding::ArrayAccess { ref array_elem_ty, .. } => array_elem_ty,
+            PlaceEncoding::Variant { ref field, .. } => &field.typ,
+        }
+    }
+
+    pub fn variant(self, index: &str) -> Self {
+        // TODO: somewhat duplicate from vir::Expr::variant()
+        let field_name = format!("enum_{}", index);
+        let field = vir::Field::new(field_name, self.get_type().clone().variant(index));
+
+        PlaceEncoding::Variant { base: box self, field }
+    }
+}
+
+impl From<vir::Expr> for PlaceEncoding {
+    fn from(e: vir::Expr) -> Self {
+        PlaceEncoding::Expr(e)
+    }
+}
+
+impl Display for PlaceEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PlaceEncoding::Expr(e) => write!(f, "{}", e),
+            PlaceEncoding::FieldAccess { base, field } => write!(f, "{}.{}", base, field),
+            PlaceEncoding::ArrayAccess { base, index, .. } => write!(f, "{}[{}]", base, index),
+            PlaceEncoding::Variant { base, field } => write!(f, "{}[{}]", base, field),
+        }
+    }
+}

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1294,6 +1294,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let encode = |rhs_place| {
             // TODO: pre_stmts here as well..
             let (restored, pre_stmts, _, _) = self.encode_place(rhs_place).unwrap();
+            assert!(pre_stmts.is_empty(), "Unexpected encoding pre-statements: {:?}", pre_stmts);
             let ref_field = self.encoder.encode_value_field(expiring_ty);
             let expiring = expiring_base.clone().field(ref_field.clone());
             (expiring, restored, ref_field)
@@ -4067,7 +4068,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 }
                 // will panic if attempting to encode unsupported type
                 let (encoded_place, pre_stmts, ty, _) = self.encode_place(&mir_place).unwrap();
-                // TODO: pre_stmts
+                assert!(pre_stmts.is_empty(), "Unexpected encoding pre-statements: {:?}", pre_stmts);
                 debug!("kind={:?} mir_place={:?} ty={:?}", kind, mir_place, ty);
                 match kind {
                     // Gives read permission to this node. It must not be a leaf node.
@@ -4098,8 +4099,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         if let Some(base) = utils::try_pop_deref(self.encoder.env().tcx(), mir_place)
                         {
                             // will panic if attempting to encode unsupported type
-                            let (_, _, ref_ty, _) = self.encode_place(&base).unwrap();
-                            // TODO: pre_stmts
+                            let (_, pre_stmts, ref_ty, _) = self.encode_place(&base).unwrap();
+                            assert!(pre_stmts.is_empty(), "Unexpected encoding pre-statements: {:?}", pre_stmts);
                             match ref_ty.kind() {
                                 ty::TyKind::RawPtr(ty::TypeAndMut { mutbl, .. })
                                 | ty::TyKind::Ref(_, _, mutbl) => {
@@ -4162,7 +4163,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                                         // variables.
                                         let (encoded_child, pre_stmts, _, _) =
                                             self.encode_place(&child_place).unwrap(); // will panic if attempting to encode unsupported type
-                                        // TODO: pre_stmts
+                                        assert!(pre_stmts.is_empty(), "Unexpected encoding pre-statements: {:?}", pre_stmts);
                                         equalities.push(self.construct_value_preserving_equality(
                                             loop_head,
                                             &encoded_child,

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -487,11 +487,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
             let downcasts = self.mir_encoder.get_downcasts_at_location(location);
             // Reverse `downcasts` because the encoding works backward
             for (place, variant_idx) in downcasts.into_iter().rev() {
-                let (encoded_place, place_ty, _) = self.mir_encoder.encode_projection(
+                let (encoded_place, place_ty, _) = self.encode_projection(
                     place.local,
                     &place.projection[..],
                 ).with_span(span)?;
-                let encoded_place = encoded_place.try_into_expr().with_span(span)?;
                 let variant_field = if let ty::TyKind::Adt(adt_def, _subst) = place_ty.kind() {
                     let variant_name = &adt_def.variants[variant_idx].ident.as_str();
                     self.encoder.encode_enum_variant_field(variant_name)
@@ -505,6 +504,25 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
             }
         }
         Ok(())
+    }
+
+    fn encode_place(
+        &self,
+        place: &mir::Place<'tcx>,
+    ) -> EncodingResult<(vir::Expr, ty::Ty<'tcx>, Option<usize>)> {
+        let (encoded_place, ty, variant_idx) = self.mir_encoder().encode_place(place)?;
+        // TODO: actual encoding of array access here
+        Ok((encoded_place.try_into_expr()?, ty, variant_idx))
+    }
+
+    fn encode_projection(
+        &self,
+        local: mir::Local,
+        projection: &[mir::PlaceElem<'tcx>],
+    ) -> EncodingResult<(vir::Expr, ty::Ty<'tcx>, Option<usize>)> {
+        let (encoded_place, ty, variant_idx) = self.mir_encoder.encode_projection(local, projection)?;
+        // TODO: actual encoding of e.g. array access here
+        Ok((encoded_place.try_into_expr()?, ty, variant_idx))
     }
 }
 
@@ -741,10 +759,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
                     let state = if destination.is_some() {
                         let (ref lhs_place, target_block) = destination.as_ref().unwrap();
-                        let (encoded_lhs, ty, _) = self.mir_encoder.encode_place(lhs_place)
+                        let (encoded_lhs, ty, _) = self.encode_place(lhs_place)
                             .with_span(span)
                             .run_if_err(cleanup)?;
-                        let encoded_lhs = encoded_lhs.try_into_expr().unwrap();
                         let lhs_value = self.encoder.encode_value_expr(encoded_lhs.clone(), ty);
                         let encoded_args: Vec<vir::Expr> = args
                             .iter()
@@ -1003,8 +1020,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
             }
 
             mir::StatementKind::Assign(box (ref lhs, ref rhs)) => {
-                let (encoded_lhs, ty, _) = self.mir_encoder.encode_place(lhs).unwrap();
-                let encoded_lhs = encoded_lhs.try_into_expr().unwrap();
+                let (encoded_lhs, ty, _) = self.encode_place(lhs).unwrap();
 
                 if !state.use_place(&encoded_lhs) {
                     // If the lhs is not mentioned in our state, do nothing
@@ -1223,8 +1239,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     &mir::Rvalue::NullaryOp(_op, ref _op_ty) => unimplemented!(),
 
                     &mir::Rvalue::Discriminant(ref src) => {
-                        let (encoded_src, src_ty, _) = self.mir_encoder.encode_place(src).unwrap();
-                        let encoded_src = encoded_src.try_into_expr().unwrap();
+                        let (encoded_src, src_ty, _) = self.encode_place(src).unwrap();
                         match src_ty.kind() {
                             ty::TyKind::Adt(ref adt_def, _) if !adt_def.is_box() => {
                                 let num_variants = adt_def.variants.len();
@@ -1266,7 +1281,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     | &mir::Rvalue::Ref(_, mir::BorrowKind::Mut { .. }, ref place)
                     | &mir::Rvalue::Ref(_, mir::BorrowKind::Shared, ref place) => {
                         // will panic if attempting to encode unsupported type
-                        let encoded_place = self.mir_encoder.encode_place(place).unwrap().0.try_into_expr().unwrap();
+                        let encoded_place = self.encode_place(place).unwrap().0;
                         let encoded_ref = match encoded_place {
                             vir::Expr::Field(
                                 box ref base,

--- a/prusti-viper/src/encoder/spec_encoder.rs
+++ b/prusti-viper/src/encoder/spec_encoder.rs
@@ -423,15 +423,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
         let should_closure_be_dereferenced = inner_mir_encoder.can_be_dereferenced(closure_ty);
         let (deref_closure_var, _deref_closure_ty) = if should_closure_be_dereferenced {
             let res = inner_mir_encoder
-                .encode_deref(PlaceEncoding::Expr(closure_var.clone().into()), closure_ty)
+                .encode_deref(closure_var.clone().into(), closure_ty)
                 .with_span(outer_span)?;
             (res.0, res.1)
         } else {
-            (PlaceEncoding::Expr(closure_var.clone().into()), *closure_ty)
+            (closure_var.clone().into(), *closure_ty)
         };
         trace!("closure_ty: {:?}", closure_ty);
         trace!("deref_closure_var: {:?}", deref_closure_var);
-        let deref_closure_var = deref_closure_var.try_into_expr().with_span(outer_span)?;
 
         let captured_tys = captured_operand_tys;
         trace!("captured_tys: {:?}", captured_tys);


### PR DESCRIPTION
This will be used for encoding array accesses. This PR includes just the machinery, no actual array encoding, but makes sure to keep all code working while using the new type.

The reasoning for the `PlaceEncoding` type is
 - we encode array code using an abstract predicate like `Array$4$i32(self: Ref)` and specify behaviour using an abstract pure function like `Array$4$i32$lookup_pure(self: Ref, index: Int): Int`. This way we don't always have a `vir::Expr` to return like for field accesses.
 - We need to encode array accesses differently for pure functions/procedures, so the `MirEncoder` returns a `PlaceEncoding::ArrayAccess` for them, and `PureFunctionEncoder` and `ProcedureEncoder` handle them accordingly
 - `PlaceEncoding::Field` and `PlaceEncoding::Variant` exist just like for `vir::Expr` with the same intent. As MIR handles deref, array indexing, field access all as a list of projections, we need to be able to mix them, so we duplicate them in `PlaceEncoding` and map them back to the respective `vir::Expr` variants when we translate the ArrayAccess.