### PR TITLE
Update prusti-common to use edition 2018

### DIFF
--- a/prusti-common/Cargo.toml
+++ b/prusti-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "prusti-common"
 version = "0.1.0"
 authors = ["Julian Dunskus <julian.dunskus@gmail.com>"]
+edition = "2018"
 
 [lib]
 doctest = false # we have no doc tests

--- a/prusti-common/src/report/log.rs
+++ b/prusti-common/src/report/log.rs
@@ -6,7 +6,7 @@
 
 //! This module defines functions for log messages, meant for developers
 
-use config;
+use crate::config;
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;

--- a/prusti-common/src/report/user.rs
+++ b/prusti-common/src/report/user.rs
@@ -6,7 +6,7 @@
 
 //! This module defines functions for user output: the nice, clean, readable, polished output
 
-use config;
+use crate::config;
 
 /// Print to stderr a message that is only meant to be read by the user.
 /// The output goes to *stderr*, to be displayed in the "compiler output" area in rust-playground.

--- a/prusti-common/src/verification_context.rs
+++ b/prusti-common/src/verification_context.rs
@@ -4,9 +4,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use config;
+use crate::config;
 use std::{fs::create_dir_all, path::PathBuf};
-use verification_service::ViperBackendConfig;
+use crate::verification_service::ViperBackendConfig;
 use viper::{self, AstFactory, VerificationBackend, Viper};
 
 /// A verifier builder is an object that lives entire program's

--- a/prusti-common/src/verification_service.rs
+++ b/prusti-common/src/verification_service.rs
@@ -1,6 +1,6 @@
-use config;
+use crate::config;
 use viper::{self, VerificationBackend};
-use vir::Program;
+use crate::vir::Program;
 
 pub trait VerificationService {
     fn verify(&self, request: VerificationRequest) -> viper::VerificationResult;

--- a/prusti-common/src/vir/ast/bodyless_method.rs
+++ b/prusti-common/src/vir/ast/bodyless_method.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use vir::ast::*;
+use crate::vir::ast::*;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/prusti-common/src/vir/ast/domain.rs
+++ b/prusti-common/src/vir/ast/domain.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fmt;
-use vir::ast::*;
+use crate::vir::ast::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Domain {

--- a/prusti-common/src/vir/ast/expr.rs
+++ b/prusti-common/src/vir/ast/expr.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::super::borrows::Borrow;
-use vir::ast::*;
+use crate::vir::ast::*;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash::{Hash, Hasher};

--- a/prusti-common/src/vir/ast/expr_transformers.rs
+++ b/prusti-common/src/vir/ast/expr_transformers.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::super::borrows::Borrow;
-use vir::ast::*;
+use crate::vir::ast::*;
 
 impl Expr {
     /// Apply the closure to all places in the expression.

--- a/prusti-common/src/vir/ast/function.rs
+++ b/prusti-common/src/vir/ast/function.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use vir::ast::*;
+use crate::vir::ast::*;
 use std::collections::HashMap;
 use std::fmt;
 

--- a/prusti-common/src/vir/ast/predicate.rs
+++ b/prusti-common/src/vir/ast/predicate.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use vir::ast::*;
+use crate::vir::ast::*;
 use std::fmt;
 use std::collections::HashSet;
 

--- a/prusti-common/src/vir/ast/stmt.rs
+++ b/prusti-common/src/vir/ast/stmt.rs
@@ -6,7 +6,7 @@
 
 use super::super::borrows::{Borrow, DAG as ReborrowingDAG};
 use super::super::cfg::CfgBlockIndex;
-use vir::ast::*;
+use crate::vir::ast::*;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/prusti-common/src/vir/ast/trigger.rs
+++ b/prusti-common/src/vir/ast/trigger.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use vir::ast::*;
+use crate::vir::ast::*;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/prusti-common/src/vir/cfg/assigned_vars.rs
+++ b/prusti-common/src/vir/cfg/assigned_vars.rs
@@ -4,9 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use vir::{CfgMethod, CfgBlock, CfgBlockIndex};
+use crate::vir::{self, CfgMethod, CfgBlock, CfgBlockIndex};
 use std::collections::HashSet;
-use vir;
 
 pub fn collect_assigned_vars(
     method: &CfgMethod,

--- a/prusti-common/src/vir/cfg/display.rs
+++ b/prusti-common/src/vir/cfg/display.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fmt;
-use vir::cfg::method::*;
+use crate::vir::cfg::method::*;
 
 impl fmt::Display for CfgMethod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/prusti-common/src/vir/cfg/method.rs
+++ b/prusti-common/src/vir/cfg/method.rs
@@ -8,8 +8,10 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::iter::FromIterator;
 use uuid::Uuid;
-use vir::ast::*;
-use vir::gather_labels::gather_labels;
+use crate::vir::{
+    ast::*,
+    gather_labels::gather_labels,
+};
 
 pub(super) const RETURN_LABEL: &str = "end_of_method";
 

--- a/prusti-common/src/vir/cfg/to_graphviz.rs
+++ b/prusti-common/src/vir/cfg/to_graphviz.rs
@@ -4,9 +4,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use config;
+use crate::config;
 use std::io::Write;
-use vir::{self, cfg::method::*};
+use crate::vir::{self, cfg::method::*};
 
 fn escape_html<S: ToString>(s: S) -> String {
     s.to_string()

--- a/prusti-common/src/vir/cfg/to_viper.rs
+++ b/prusti-common/src/vir/cfg/to_viper.rs
@@ -4,10 +4,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use config;
+use crate::config;
 use std::collections::HashMap;
 use viper::{self, AstFactory};
-use vir::{
+use crate::vir::{
     ast::Position,
     cfg::method::*,
     to_viper::{ToViper, ToViperDecl},

--- a/prusti-common/src/vir/cfg/visitor.rs
+++ b/prusti-common/src/vir/cfg/visitor.rs
@@ -4,9 +4,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use vir::ast::*;
-use vir::cfg::method::*;
-use utils::to_string::ToString;
+use crate::vir::{
+    ast::*,
+    cfg::method::*,
+};
+use crate::utils::to_string::ToString;
 use std::fmt::Debug;
 
 pub trait CheckNoOpAction {

--- a/prusti-common/src/vir/conversions.rs
+++ b/prusti-common/src/vir/conversions.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use vir::ast::*;
+use crate::vir::ast::*;
 
 impl From<LocalVar> for Expr {
     fn from(local_var: LocalVar) -> Self {

--- a/prusti-common/src/vir/gather_labels.rs
+++ b/prusti-common/src/vir/gather_labels.rs
@@ -1,5 +1,4 @@
-use vir::StmtWalker;
-use vir::ast;
+use crate::vir::{ast, StmtWalker};
 
 pub(super) fn gather_labels(stmt: &ast::Stmt) -> Vec<String> {
     let mut gather_labels = GatherLabels::default();

--- a/prusti-common/src/vir/optimizations/folding/expressions.rs
+++ b/prusti-common/src/vir/optimizations/folding/expressions.rs
@@ -21,7 +21,7 @@ use super::super::super::{ast, borrows, cfg};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::mem;
-use vir::FallibleExprFolder;
+use crate::vir::FallibleExprFolder;
 
 
 pub trait FoldingOptimizer {
@@ -286,7 +286,7 @@ fn merge_requirements_and_unfoldings2(
 ) -> (RequirementSet, UnfoldingMap, Box<ast::Expr>, Box<ast::Expr>) {
 
     trace!("[enter] merge_requirements_and_unfoldings");
-    use utils::to_string::ToString;
+    use crate::utils::to_string::ToString;
     trace!("reqs: {}", first_requirements.iter().to_sorted_multiline_string());
     trace!("unfoldings: {}", first_unfoldings.keys().to_sorted_multiline_string());
     trace!("reqs: {}", second_requirements.iter().to_sorted_multiline_string());

--- a/prusti-common/src/vir/optimizations/methods/assert_remover.rs
+++ b/prusti-common/src/vir/optimizations/methods/assert_remover.rs
@@ -6,8 +6,7 @@
 
 //! Optimization that removes unused temporary variables.
 
-use vir::cfg;
-use vir::{Const, Expr, Stmt};
+use crate::vir::{cfg, Const, Expr, Stmt};
 
 /// Remove trivial assertions:
 /// * `assert true`

--- a/prusti-common/src/vir/optimizations/methods/cfg_cleaner.rs
+++ b/prusti-common/src/vir/optimizations/methods/cfg_cleaner.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use vir::{self, cfg};
+use crate::vir::{self, cfg};
 
 /// Merge consequitive basic blocks that are joined by only one edge.
 pub fn clean_cfg(mut method: cfg::CfgMethod) -> cfg::CfgMethod {

--- a/prusti-common/src/vir/optimizations/methods/empty_if_remover.rs
+++ b/prusti-common/src/vir/optimizations/methods/empty_if_remover.rs
@@ -8,8 +8,7 @@
 
 use std::slice;
 
-use vir::cfg;
-use vir::Stmt;
+use crate::vir::{cfg, Stmt};
 
 /// Remove empty if statements:
 /// * `if (...) {}`

--- a/prusti-common/src/vir/optimizations/methods/purifier.rs
+++ b/prusti-common/src/vir/optimizations/methods/purifier.rs
@@ -11,7 +11,7 @@
 
 use super::super::super::ast;
 use super::super::super::cfg;
-use config;
+use crate::config;
 use std::collections::{HashMap, HashSet};
 use std::{self, mem};
 

--- a/prusti-common/src/vir/optimizations/mod.rs
+++ b/prusti-common/src/vir/optimizations/mod.rs
@@ -6,9 +6,8 @@
 
 //! A module that contains various VIR optimizations.
 
-use config::optimizations;
-use vir::{CfgMethod, Program};
-use crate::config::{self, Optimizations};
+use crate::vir::{CfgMethod, Program};
+use crate::config::{self, optimizations, Optimizations};
 
 pub mod folding;
 pub mod functions;

--- a/prusti-common/src/vir/program.rs
+++ b/prusti-common/src/vir/program.rs
@@ -1,4 +1,4 @@
-use vir::{ast::*, cfg::CfgMethod};
+use crate::vir::{ast::*, cfg::CfgMethod};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Program {

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -4,9 +4,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use config;
+use crate::config;
 use viper::{self, AstFactory};
-use vir::{ast::*, borrows::borrow_id, Program};
+use crate::vir::{ast::*, borrows::borrow_id, Program};
 
 pub trait ToViper<'v, T> {
     fn to_viper(&self, ast: &AstFactory<'v>) -> T;

--- a/prusti-common/src/vir/utils.rs
+++ b/prusti-common/src/vir/utils.rs
@@ -6,7 +6,7 @@
 
 //! Various utility methods for working with VIR.
 
-use vir::{
+use crate::vir::{
     self, cfg, CfgMethod, ExprFolder, ExprWalker, FallibleStmtFolder, Function, StmtFolder,
     StmtWalker,
 };


### PR DESCRIPTION
Fix paths to be unambiguous within the crate