### PR TITLE
Implement taking references into arrays

### DIFF
--- a/prusti-tests/tests/verify/pass/arrays/array-ref-shared.rs
+++ b/prusti-tests/tests/verify/pass/arrays/array-ref-shared.rs
@@ -1,0 +1,11 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+fn ref_array(a: [i32; 3]) {
+    let b = &a[0];
+    // it's a shared reference, so we can still access the original array during the lifetime of b
+    let a0 = a[0];
+    // the value behind the reference is what was in the original array
+    assert!(*b == a0);
+}


### PR DESCRIPTION
This enables code like
```
let b = &a[i];
```
where we don't just read from the array, but remember the reference