### PR TITLE
Improve Clippy diff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Check and report Clippy errors
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           cargo install cargo-diff-tools
           if rustup component add clippy
@@ -52,7 +51,7 @@ jobs:
             # See https://github.com/pytorch/pytorch/blob/49adac65c4228b9fe7ede4e6f99fe9e1ccdc3e16/.github/workflows/clang_format.yml
             git remote add upstream https://github.com/viperproject/prusti-dev
             git fetch upstream "$GITHUB_BASE_REF"
-            python x.py exec cargo-clippy-diff --output=github $(git merge-base $BASE_SHA $HEAD_SHA) $HEAD_SHA
+            python x.py exec cargo-clippy-diff --output=github $BASE_SHA HEAD
           fi
       - name: Run "quick" cargo tests
         run: python x.py test --all --verbose quick

--- a/prusti-tests/tests/verify/pass/shared-borrows/unused-ref-fields.rs
+++ b/prusti-tests/tests/verify/pass/shared-borrows/unused-ref-fields.rs
@@ -1,0 +1,18 @@
+use prusti_contracts::*;
+
+struct T<'a> {
+    f: u32,
+    g: &'a u32,
+    h: *const u32,
+    i: Vec<u32>,
+    j: String,
+    k: &'a [T<'a>],
+}
+
+#[requires(x.f == 123)]
+#[ensures(result == 123)]
+fn test(x: &T) -> u32 {
+    x.f
+}
+
+fn main() {}


### PR DESCRIPTION
* Include all PR changes in the diff used to filter Clippy warnings.
* Add a test with unused reference typed fields, which we started to support at some point.
