### PR TITLE
Allow interpolating type in vir_local! macro

### DIFF
--- a/prusti-common/src/vir/vir_macro.rs
+++ b/prusti-common/src/vir/vir_macro.rs
@@ -2,11 +2,12 @@
 macro_rules! vir_type {
     (Int) => {$crate::vir::Type::Int};
     (Bool) => {$crate::vir::Type::Bool};
+    ({$ty:expr}) => { $ty }
 }
 
 #[macro_export]
 macro_rules! vir_local {
-    ($name: ident : $type: ident) => {
+    ($name:ident : $type:tt) => {
         $crate::vir::LocalVar {
             name: stringify!($name).to_string(),
             typ: $crate::vir_type!($type)
@@ -106,7 +107,7 @@ macro_rules! vir {
         $crate::vir::Expr::magic_wand(vir!($lhs), vir!($rhs), $borrow)
     };
 
-    (forall $($name: ident : $type: ident),+ :: {$($triggers: tt),*} $body: tt) => {
+    (forall $($name: ident : $type: tt),+ :: {$($triggers: tt),*} $body: tt) => {
         $crate::vir::Expr::forall(
             vec![$($crate::vir_local!($name: $type)),+],
             vec![$(Trigger::new(vec![vir!($triggers)])),*],

--- a/prusti-viper/src/encoder/builtin_encoder.rs
+++ b/prusti-viper/src/encoder/builtin_encoder.rs
@@ -60,7 +60,7 @@ impl BuiltinEncoder {
         vir::BodylessMethod {
             name: self.encode_builtin_method_name(method),
             formal_args: vec![],
-            formal_returns: vec![vir::LocalVar::new("ret", return_type)],
+            formal_returns: vec![vir_local!{ ret: {return_type} }],
         }
     }
 
@@ -105,7 +105,7 @@ impl BuiltinEncoder {
                 body: None,
             },
             BuiltinFunctionKind::ArrayLookupPure { array_ty_pred, array_len, return_ty, .. } => {
-                let self_var = vir::LocalVar::new("self", vir::Type::TypedRef(array_ty_pred.clone()));
+                let self_var = vir_local!{ self: {vir::Type::TypedRef(array_ty_pred.clone())} };
                 let idx_var = vir_local!{ idx: Int };
 
                 vir::Function {
@@ -171,10 +171,7 @@ impl BuiltinEncoder {
             let f = snapshot::valid_func_for_type(t);
             functions.push(f.clone());
 
-            let forall_arg = vir::LocalVar {
-                name: "self".to_owned(),
-                typ: t.clone(),
-            };
+            let forall_arg = vir_local!{ self: {t.clone()} };
             let function_app =
                 vir::Expr::domain_func_app(f.clone(), vec![vir::Expr::local(forall_arg.clone())]);
             let body = vir::Expr::forall(

--- a/prusti-viper/src/encoder/memory_eq_encoder.rs
+++ b/prusti-viper/src/encoder/memory_eq_encoder.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use rustc_middle::ty;
 use rustc_middle::mir;
 use rustc_span::MultiSpan;
-use prusti_common::vir;
+use prusti_common::{vir, vir_local};
 use prusti_common::vir::ExprIterator;
 use crate::encoder::Encoder;
 use crate::encoder::type_encoder::compute_discriminant_values;
@@ -51,8 +51,8 @@ impl MemoryEqEncoder {
         if !self.memory_eq_funcs.contains_key(&name) {
             self.encode_memory_eq_func(encoder, name.clone(), self_ty)?
         }
-        let first_local_var = vir::LocalVar::new("self", typ.clone());
-        let second_local_var = vir::LocalVar::new("other", typ);
+        let first_local_var = vir_local!{ self: {typ.clone()} };
+        let second_local_var = vir_local!{ other: {typ} };
         Ok(vir::Expr::FuncApp(
             name,
             vec![first, second],
@@ -77,8 +77,8 @@ impl MemoryEqEncoder {
         // will panic if attempting to encode unsupported type
         let type_name = encoder.encode_type_predicate_use(self_ty).unwrap();
         let typ = vir::Type::TypedRef(type_name.clone());
-        let first_local_var = vir::LocalVar::new("self", typ.clone());
-        let second_local_var = vir::LocalVar::new("other", typ);
+        let first_local_var = vir_local!{ self: {typ.clone()} };
+        let second_local_var = vir_local!{ other: {typ} };
         let precondition = vec![
             vir::Expr::predicate_access_predicate(
                 type_name.clone(),
@@ -303,8 +303,8 @@ impl MemoryEqEncoder {
                 subst
             )?;
         }
-        let first_local_var = vir::LocalVar::new("self", typ.clone());
-        let second_local_var = vir::LocalVar::new("other", typ);
+        let first_local_var = vir_local!{ self: {typ.clone()} };
+        let second_local_var = vir_local!{ other: {typ} };
         Ok(vir::Expr::FuncApp(
             name,
             vec![first, second],
@@ -329,8 +329,8 @@ impl MemoryEqEncoder {
         self.memory_eq_funcs.insert(name.clone(), None);
         let tcx = encoder.env().tcx();
         let type_name = typ.name();
-        let first_local_var = vir::LocalVar::new("self", typ.clone());
-        let second_local_var = vir::LocalVar::new("other", typ);
+        let first_local_var = vir_local!{ self: {typ.clone()} };
+        let second_local_var = vir_local!{ other: {typ} };
         let precondition = vec![
             vir::Expr::predicate_access_predicate(
                 type_name.clone(),

--- a/prusti-viper/src/encoder/pure_function_encoder.rs
+++ b/prusti-viper/src/encoder/pure_function_encoder.rs
@@ -18,7 +18,7 @@ use crate::encoder::mir_interpreter::{
 use crate::encoder::snapshot;
 use crate::encoder::Encoder;
 use crate::encoder::snapshot_spec_patcher::SnapshotSpecPatcher;
-use prusti_common::vir;
+use prusti_common::{vir, vir_local};
 use prusti_common::vir::ExprIterator;
 use prusti_common::config;
 use prusti_interface::specs::typed;
@@ -210,7 +210,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             self.mir.span,
             ErrorCtxt::PureFunctionPostconditionValueRangeOfResult,
         );
-        let pure_fn_return_variable = vir::LocalVar::new("__result", return_type.clone());
+        let pure_fn_return_variable = vir_local!{ __result: {return_type.clone()} };
         // Add value range of the arguments and return value to the pre/postconditions
         if config::check_overflows() {
             let return_bounds: Vec<_> = self
@@ -390,8 +390,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             .register(self.mir.span, ErrorCtxt::GenericExpression);
 
         // Fix return variable
-        let pure_fn_return_variable =
-            vir::LocalVar::new("__result", self.encode_function_return_type()?);
+        let pure_fn_return_variable = vir_local!{ __result: {self.encode_function_return_type()?} };
 
         let post = post.replace_place(&encoded_return.into(), &pure_fn_return_variable.into())
             .set_default_pos(postcondition_pos);
@@ -616,7 +615,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 assert!(states.is_empty());
                 trace!("Return type: {:?}", self.mir.return_ty());
                 let return_type = self.encoder.encode_type(self.mir.return_ty()).with_span(span)?;
-                let return_var = vir::LocalVar::new("_0", return_type);
+                let return_var = vir_local!{ _0: {return_type} };
                 MultiExprBackwardInterpreterState::new_single(
                     self.encoder.encode_value_expr(
                         vir::Expr::local(return_var.into()),

--- a/prusti-viper/src/encoder/snapshot/mod.rs
+++ b/prusti-viper/src/encoder/snapshot/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use log::{info, warn};
-use prusti_common::vir;
+use prusti_common::{vir, vir_local};
 
 pub use self::purifier::{AssertPurifier, ExprPurifier};
 
@@ -31,7 +31,7 @@ pub fn mirror_function_caller_call(mirror_fn: vir::DomainFunc, args: Vec<vir::Ex
 pub fn encode_variant_func(domain_name: String) -> vir::DomainFunc
 {
     let snap_type = vir::Type::Domain(domain_name.to_string());
-    let arg = vir::LocalVar::new("self", snap_type);
+    let arg = vir_local!{ self: {snap_type} };
     vir::DomainFunc {
         name: SNAPSHOT_VARIANT.to_string(),
         formal_args: vec![arg],
@@ -62,10 +62,7 @@ pub fn encode_field_domain_func(
 
     vir::DomainFunc {
         name: format!("{}$field${}", field_domain_name, field_name), //TODO get the right name
-        formal_args: vec![vir::LocalVar {
-            name: "self".to_string(),
-            typ: vir::Type::Domain(domain_name.to_string()),
-        }],
+        formal_args: vec![vir_local!{ self: {vir::Type::Domain(domain_name.to_string())} }],
         return_type,
         unique: false,
         domain_name: domain_name.to_string(),
@@ -74,16 +71,10 @@ pub fn encode_field_domain_func(
 
 pub fn encode_unfold_witness(domain_name: String) -> vir::DomainFunc {
     let self_type = vir::Type::Domain(domain_name.clone());
-    let self_arg = vir::LocalVar {
-        name: "self".to_string(),
-        typ: self_type,
-    };
+    let self_arg = vir_local!{ self: {self_type} };
 
     let nat_type = vir::Type::Domain(NAT_DOMAIN_NAME.to_owned());
-    let nat_arg = vir::LocalVar {
-        name: "count".to_string(),
-        typ: nat_type,
-    };
+    let nat_arg = vir_local!{ count: {nat_type} };
 
     vir::DomainFunc {
         name: format!("{}$UnfoldWitness", domain_name),
@@ -109,10 +100,7 @@ pub fn valid_func_for_type(typ: &vir::Type) -> vir::DomainFunc {
         vir::Type::TypedRef(_) => unreachable!(),
     };
 
-    let self_arg = vir::LocalVar {
-        name: "self".to_string(),
-        typ: arg_typ,
-    };
+    let self_arg = vir_local!{ self: {arg_typ} };
     let df = vir::DomainFunc {
         name: format!("{}$valid", domain_name),
         formal_args: vec![self_arg],
@@ -126,10 +114,7 @@ pub fn valid_func_for_type(typ: &vir::Type) -> vir::DomainFunc {
 
 /// Returns the LocalVar that is the Nat argument used in axiomatized functions
 pub fn encode_nat_argument() -> vir::LocalVar {
-    vir::LocalVar {
-        name: "count".to_string(),
-        typ: vir::Type::Domain(NAT_DOMAIN_NAME.to_owned()),
-    }
+    vir_local!{ count: {vir::Type::Domain(NAT_DOMAIN_NAME.to_owned())} }
 }
 
 /// Returns the arguments for the axiomatized version of a function but does not yet include the Nat argument

--- a/prusti-viper/src/encoder/snapshot/purifier.rs
+++ b/prusti-viper/src/encoder/snapshot/purifier.rs
@@ -3,9 +3,13 @@ use crate::encoder::{
     snapshot_encoder::{Snapshot, SnapshotEncoder},
 };
 use log::{debug, info, trace};
-use prusti_common::vir::{
-    self, Expr, ExprFolder, FallibleExprFolder, Field, LocalVar, PermAmount, Position, Type,
-    WithIdentifier,
+use prusti_common::{
+    vir,
+    vir_local,
+    vir::{
+        Expr, ExprFolder, FallibleExprFolder, Field, LocalVar,
+        PermAmount, Position, Type, WithIdentifier,
+    },
 };
 use std::collections::HashMap;
 
@@ -84,7 +88,7 @@ impl<'a> FallibleExprFolder for ExprPurifier<'a> {
                 "discriminant" => {
                     let domain_name = receiver_domain;
                     let snap_type = vir::Type::Domain(domain_name.to_string());
-                    let arg = vir::LocalVar::new("self", snap_type);
+                    let arg = vir_local!{ self: {snap_type} };
                     let domain_func = vir::DomainFunc {
                         name: "variant$".to_string(), //TODO use constant
                         formal_args: vec![arg],

--- a/prusti-viper/src/encoder/snapshot_encoder.rs
+++ b/prusti-viper/src/encoder/snapshot_encoder.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use prusti_common::vir;
+use prusti_common::{vir, vir_local};
 use crate::encoder::Encoder;
 use rustc_middle::ty;
 use prusti_common::vir::{PermAmount, EnumVariantIndex};
@@ -547,7 +547,7 @@ impl<'p, 'v, 'r: 'v, 'a: 'r, 'tcx: 'a> SnapshotEncoder<'p, 'v, 'tcx> {
     fn encode_valid_axiom(&self, _cons_func: vir::DomainFunc) -> EncodingResult<vir::DomainAxiom> {
         let domain_name = self.encode_domain_name();
 
-        let self_var = vir::LocalVar::new("self", vir::Type::Domain(domain_name.to_string()));
+        let self_var = vir_local!{ self: {vir::Type::Domain(domain_name.to_string())} };
 
         let valid_func_apps = true.into(); //TODO actually check the validity of the fields.
 
@@ -1002,10 +1002,7 @@ impl<'s, 'v: 's, 'tcx: 'v> SnapshotAdtEncoder<'s, 'v, 'tcx> {
     fn encode_valid_axiom(&self) -> EncodingResult<vir::DomainAxiom> {
         let domain_name = self.snapshot_encoder.encode_domain_name();
 
-        let self_var = vir::LocalVar::new(
-            "self",
-            vir::Type::Domain(domain_name.to_string()),
-        );
+        let self_var = vir_local!{ self: {vir::Type::Domain(domain_name.to_string())} };
 
         let valid_func_apps: vir::Expr = if self.adt_def.is_struct() {
             let all_fields : Vec<_> = self.adt_def.all_fields().collect();

--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -8,8 +8,12 @@ use crate::encoder::foldunfold;
 use crate::encoder::utils::range_extract;
 use crate::encoder::utils::PlusOne;
 use crate::encoder::Encoder;
-use prusti_common::vir::{self, ExprIterator, ExprFolder};
-use prusti_common::config;
+use prusti_common::{
+    config,
+    vir,
+    vir_local,
+    vir::{ExprIterator, ExprFolder},
+};
 // use prusti_interface::specifications::*;
 // use rustc::middle::const_val::ConstVal;
 use rustc_middle::ty;
@@ -563,8 +567,7 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
         debug!("[enter] encode_invariant_def({:?})", self.ty);
 
         let predicate_name = self.encoder.encode_type_predicate_use(self.ty)?;
-        let self_local_var =
-            vir::LocalVar::new("self", vir::Type::TypedRef(predicate_name.clone()));
+        let self_local_var = vir_local!{ self: {vir::Type::TypedRef(predicate_name.clone())} };
 
         let invariant_name = self.encoder.encode_type_invariant_use(self.ty)?;
 

--- a/viper-sys/tests/verify_empty_program.rs
+++ b/viper-sys/tests/verify_empty_program.rs
@@ -6,7 +6,7 @@ extern crate log;
 extern crate viper_sys;
 
 use jni::{objects::JObject, InitArgsBuilder, JNIVersion, JavaVM};
-use std::{convert::From, env, fs};
+use std::{env, fs};
 use viper_sys::{get_system_out, wrappers::*};
 
 #[test]


### PR DESCRIPTION
This makes the macro usable in a lot more cases, where the variable name
is a string literal, but the type is some computed expression.