### PR TITLE
Implement array initialization from repeat expressions

### DIFF
--- a/prusti-tests/tests/verify/pass/arrays/repeat-expr-initialization.rs
+++ b/prusti-tests/tests/verify/pass/arrays/repeat-expr-initialization.rs
@@ -1,0 +1,13 @@
+// this tests
+//
+// - repeat expressions [{const}; {count}], which look a little different in MIR than regular
+//   initializers like [1, 2, 3]
+// - bool as element type
+
+fn main() {
+    let a = [false; 3];
+
+    assert!(a[0] == false);
+    assert!(a[1] == false);
+    assert!(a[2] == false);
+}


### PR DESCRIPTION
These are slightly different in the MIR representation
(Rvalue::Aggregate for regular [1, 2, 3]-style initializers,
Rvalue::Repeat for [0; 3]-style repeat expressions).