### PR TITLE
Refactor array types encoding

### DIFF
--- a/prusti-viper/src/encoder/array_encoder.rs
+++ b/prusti-viper/src/encoder/array_encoder.rs
@@ -19,15 +19,22 @@ use prusti_common::{
     vir_local,
 };
 
-
+/// The result of `ArrayEncoder::encode_array_types`. Contains types, type predicates and length of the given array type.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct EncodedArrayTypes<'tcx> {
+    /// String to use as type predicate, e.g. Array$3$i32
     pub array_pred: String,
+    /// Array type, e.g. TypedRef(Array$3$i32)
     pub array_ty: vir::Type,
+    /// Element type, e.g. TypedRef(i32)
     pub elem_ty: vir::Type,
+    /// Type of an element if stored as a (pure) snapshot value, e.g. Int
     pub elem_value_ty: vir::Type,
+    /// The non-encoded element type as passed by rustc
     pub elem_ty_rs: ty::Ty<'tcx>,
+    /// The length of the array, e.g. 3
     pub array_len: usize,
+    /// The name of the lookup_pure function for this instance, e.g. "Array$3$i32$lookup_pure"
     pub lookup_pure_name: String,
 }
 
@@ -49,14 +56,22 @@ impl<'tcx> EncodedArrayTypes<'tcx> {
     }
 }
 
+/// The result of `ArrayEncoder::encode_slice_types`. Contains types and type predicates of the given array type.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct EncodedSliceTypes<'tcx> {
+    /// String to use as type predicate, e.g. Slice$i32
     pub slice_pred: String,
+    /// Slice type, e.g. TypedRef(Slice$i32)
     pub slice_ty: vir::Type,
+    /// Element type, e.g. TypedRef(i32)
     pub elem_ty: vir::Type,
+    /// Type of an element if stored as a (pure) snapshot value, e.g. Int
     pub elem_value_ty: vir::Type,
+    /// The non-encoded element type as passed by rustc
     pub elem_ty_rs: ty::Ty<'tcx>,
+    /// The name of the `lookup_pure` function for this instance, e.g. "Array$3$i32$lookup_pure"
     pub lookup_pure_name: String,
+    /// The name of the slice length function for this instance, e.g. "Slice$i32$len"
     pub slice_len_name: String,
 }
 

--- a/prusti-viper/src/encoder/array_encoder.rs
+++ b/prusti-viper/src/encoder/array_encoder.rs
@@ -12,6 +12,7 @@ use std::{
 use crate::encoder::{
     Encoder,
     errors::EncodingResult,
+    builtin_encoder::BuiltinFunctionKind,
 };
 use prusti_common::{
     vir,
@@ -22,21 +23,75 @@ use prusti_common::{
 pub struct EncodedArrayTypes<'tcx> {
     pub array_pred: String,
     pub array_ty: vir::Type,
-    pub elem_pred: String,
     pub elem_ty: vir::Type,
     pub elem_value_ty: vir::Type,
     pub elem_ty_rs: ty::Ty<'tcx>,
     pub array_len: usize,
+    pub lookup_pure_name: String,
 }
+
+impl<'tcx> EncodedArrayTypes<'tcx> {
+    pub fn encode_lookup_pure_call(&self, array: vir::Expr, idx: vir::Expr) -> vir::Expr {
+        vir::Expr::func_app(
+            self.lookup_pure_name.clone(),
+            vec![
+                array,
+                idx,
+            ],
+            vec![
+                vir_local!{ self: {self.array_ty.clone()} },
+                vir_local!{ idx: Int },
+            ],
+            self.elem_value_ty.clone(),
+            vir::Position::default(),
+        )
+    }
+}
+
 
 pub struct EncodedSliceTypes<'tcx> {
     pub slice_pred: String,
     pub slice_ty: vir::Type,
-    pub elem_pred: String,
     pub elem_ty: vir::Type,
     pub elem_value_ty: vir::Type,
     pub elem_ty_rs: ty::Ty<'tcx>,
+    pub lookup_pure_name: String,
+    pub slice_len_name: String,
 }
+
+impl<'tcx> EncodedSliceTypes<'tcx> {
+    pub fn encode_lookup_pure_call(&self, slice: vir::Expr, idx: vir::Expr) -> vir::Expr {
+        vir::Expr::func_app(
+            self.lookup_pure_name.clone(),
+            vec![
+                slice,
+                idx,
+            ],
+            vec![
+                vir_local!{ self: {self.slice_ty.clone()} },
+                vir_local!{ idx: Int },
+            ],
+            self.elem_value_ty.clone(),
+            vir::Position::default(),
+        )
+    }
+
+    pub fn encode_slice_len_call(&self, slice: vir::Expr) -> vir::Expr {
+        vir::Expr::func_app(
+            self.slice_len_name.clone(),
+            vec![
+                slice,
+            ],
+            vec![
+                vir_local!{ self: {self.slice_ty.clone()} },
+            ],
+            vir::Type::Int,
+            vir::Position::default(),
+        )
+    }
+}
+
+
 
 pub struct ArrayTypesEncoder {}
 
@@ -63,13 +118,31 @@ impl ArrayTypesEncoder {
         let elem_ty = encoder.encode_type(elem_ty_rs)?;
         let elem_value_ty = encoder.encode_snapshot_type(elem_ty_rs)?;
 
+        // lookup_pure
+        let lookup_pure_name = encoder.encode_builtin_function_use(
+            BuiltinFunctionKind::SliceLookupPure {
+                slice_ty_pred: slice_pred.clone(),
+                elem_ty_pred: elem_pred.clone(),
+                return_ty: elem_value_ty.clone(),
+            }
+        );
+
+        let slice_len_name = encoder.encode_builtin_function_use(
+            BuiltinFunctionKind::SliceLen {
+                slice_ty_pred: slice_pred.clone(),
+                elem_ty_pred: elem_pred,
+            }
+        );
+
+
         Ok(EncodedSliceTypes{
             slice_pred,
             slice_ty,
-            elem_pred,
             elem_ty,
             elem_value_ty,
             elem_ty_rs,
+            lookup_pure_name,
+            slice_len_name,
         })
     }
 
@@ -95,14 +168,24 @@ impl ArrayTypesEncoder {
         let array_len = encoder.const_eval_intlike(&len.val)?
             .to_u64().unwrap().try_into().unwrap();
 
+        // lookup_pure
+        let lookup_pure_name = encoder.encode_builtin_function_use(
+            BuiltinFunctionKind::ArrayLookupPure {
+                array_ty_pred: array_pred.clone(),
+                elem_ty_pred: elem_pred,
+                array_len,
+                return_ty: elem_value_ty.clone(),
+            }
+        );
+
         Ok(EncodedArrayTypes{
             array_pred,
             array_ty,
-            elem_pred,
             elem_ty,
             elem_value_ty,
             elem_ty_rs,
             array_len,
+            lookup_pure_name,
         })
     }
 }

--- a/prusti-viper/src/encoder/array_encoder.rs
+++ b/prusti-viper/src/encoder/array_encoder.rs
@@ -142,7 +142,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ArrayTypesEncoder<'tcx> {
             encoder.encode_snapshot_type(elem_ty_rs)?
         };
 
-        // lookup_pure
         let lookup_pure_name = encoder.encode_builtin_function_use(
             BuiltinFunctionKind::SliceLookupPure {
                 slice_ty_pred: slice_pred.clone(),
@@ -158,7 +157,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ArrayTypesEncoder<'tcx> {
             }
         );
 
-        let encoded = EncodedSliceTypes{
+        let encoded = EncodedSliceTypes {
             slice_pred,
             slice_ty,
             elem_ty,
@@ -211,7 +210,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ArrayTypesEncoder<'tcx> {
         let array_len = encoder.const_eval_intlike(&len.val)?
             .to_u64().unwrap().try_into().unwrap();
 
-        // lookup_pure
         let lookup_pure_name = encoder.encode_builtin_function_use(
             BuiltinFunctionKind::ArrayLookupPure {
                 array_ty_pred: array_pred.clone(),
@@ -221,7 +219,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ArrayTypesEncoder<'tcx> {
             }
         );
 
-        let encoded = EncodedArrayTypes{
+        let encoded = EncodedArrayTypes {
             array_pred,
             array_ty,
             elem_ty,

--- a/prusti-viper/src/encoder/array_encoder.rs
+++ b/prusti-viper/src/encoder/array_encoder.rs
@@ -1,0 +1,108 @@
+// © 2021, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use rustc_middle::ty;
+use std::{
+    collections::HashMap,
+    convert::TryInto,
+};
+use crate::encoder::{
+    Encoder,
+    errors::EncodingResult,
+};
+use prusti_common::{
+    vir,
+    vir_local,
+};
+
+
+pub struct EncodedArrayTypes<'tcx> {
+    pub array_pred: String,
+    pub array_ty: vir::Type,
+    pub elem_pred: String,
+    pub elem_ty: vir::Type,
+    pub elem_value_ty: vir::Type,
+    pub elem_ty_rs: ty::Ty<'tcx>,
+    pub array_len: usize,
+}
+
+pub struct EncodedSliceTypes<'tcx> {
+    pub slice_pred: String,
+    pub slice_ty: vir::Type,
+    pub elem_pred: String,
+    pub elem_ty: vir::Type,
+    pub elem_value_ty: vir::Type,
+    pub elem_ty_rs: ty::Ty<'tcx>,
+}
+
+pub struct ArrayTypesEncoder {}
+
+impl ArrayTypesEncoder {
+    pub fn new() -> Self {
+        ArrayTypesEncoder {}
+    }
+
+    pub fn encode_slice_types<'p, 'v: 'p, 'tcx: 'v>(
+        &self,
+        encoder: &'p Encoder<'v, 'tcx>,
+        slice_ty: ty::Ty<'tcx>,
+    ) -> EncodingResult<EncodedSliceTypes<'tcx>> {
+        let slice_pred = encoder.encode_type_predicate_use(slice_ty)?;
+        let elem_ty_rs = if let ty::TyKind::Slice(elem_ty) = slice_ty.kind() {
+            elem_ty
+        } else {
+            unreachable!()
+        };
+
+        let elem_pred = encoder.encode_type_predicate_use(elem_ty_rs)?;
+
+        let slice_ty = encoder.encode_type(slice_ty)?;
+        let elem_ty = encoder.encode_type(elem_ty_rs)?;
+        let elem_value_ty = encoder.encode_snapshot_type(elem_ty_rs)?;
+
+        Ok(EncodedSliceTypes{
+            slice_pred,
+            slice_ty,
+            elem_pred,
+            elem_ty,
+            elem_value_ty,
+            elem_ty_rs,
+        })
+    }
+
+    pub fn encode_array_types<'p, 'v: 'p, 'tcx: 'v>(
+        &self,
+        encoder: &'p Encoder<'v, 'tcx>,
+        array_ty: ty::Ty<'tcx>,
+    ) -> EncodingResult<EncodedArrayTypes<'tcx>> {
+        // type predicates
+        let array_pred = encoder.encode_type_predicate_use(array_ty)?;
+        let (elem_ty_rs, len) = if let ty::TyKind::Array(elem_ty, len) = array_ty.kind() {
+            (elem_ty, len)
+        } else {
+            unreachable!()
+        };
+        let elem_pred = encoder.encode_type_predicate_use(elem_ty_rs)?;
+
+        // types
+        let array_ty = encoder.encode_type(array_ty)?;
+        let elem_ty = encoder.encode_type(elem_ty_rs)?;
+        let elem_value_ty = encoder.encode_snapshot_type(elem_ty_rs)?;
+
+        let array_len = encoder.const_eval_intlike(&len.val)?
+            .to_u64().unwrap().try_into().unwrap();
+
+        Ok(EncodedArrayTypes{
+            array_pred,
+            array_ty,
+            elem_pred,
+            elem_ty,
+            elem_value_ty,
+            elem_ty_rs,
+            array_len,
+        })
+    }
+}

--- a/prusti-viper/src/encoder/builtin_encoder.rs
+++ b/prusti-viper/src/encoder/builtin_encoder.rs
@@ -21,20 +21,20 @@ pub enum BuiltinFunctionKind {
     Unreachable(vir::Type),
     /// type
     Undefined(vir::Type),
-    /// array lookup pure function, e.g. Array$4$u32$lookup_pure
+    /// array lookup pure function
     ArrayLookupPure {
         array_ty_pred: String,
         elem_ty_pred: String,
         array_len: usize,
         return_ty: vir::Type,
     },
-    /// lookup_pure function for slices, e.g. Slice$i32$lookup_pure
+    /// lookup_pure function for slices
     SliceLookupPure {
         slice_ty_pred: String,
         elem_ty_pred: String,
         return_ty: vir::Type,
     },
-    /// abstract length function for slices, e.g. Slice$u32$len
+    /// abstract length function for slices
     SliceLen {
         slice_ty_pred: String,
         elem_ty_pred: String,
@@ -94,15 +94,9 @@ impl BuiltinEncoder {
             // TODO: do Domain and Snapshot make sense here?
             BuiltinFunctionKind::Undefined(vir::Type::Domain(_)) => "builtin$undef_doman".to_string(),
             BuiltinFunctionKind::Undefined(vir::Type::Snapshot(_)) => "builtin$undef_snap".to_string(),
-            BuiltinFunctionKind::ArrayLookupPure { elem_ty_pred, array_len, .. } => {
-                format!("Array${}${}$lookup_pure", array_len, elem_ty_pred)
-            }
-            BuiltinFunctionKind::SliceLookupPure { elem_ty_pred, .. } => {
-                format!("Slice${}$lookup_pure", elem_ty_pred)
-            }
-            BuiltinFunctionKind::SliceLen { elem_ty_pred, .. } => {
-                format!("Slice${}$len", elem_ty_pred)
-            }
+            BuiltinFunctionKind::ArrayLookupPure { .. }
+            | BuiltinFunctionKind::SliceLookupPure { .. } => "lookup_pure".to_string(),
+            BuiltinFunctionKind::SliceLen { .. } => "Slice$len".to_string(),
         }
     }
 

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -1402,15 +1402,21 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     pub fn encode_array_types(
         &self,
         array_ty: ty::Ty<'tcx>,
+        pre_encoded_elem_snap_ty: Option<vir::Type>,
     ) -> EncodingResult<EncodedArrayTypes<'tcx>> {
-        self.array_types_encoder.borrow_mut().encode_array_types(self, array_ty)
+        self.array_types_encoder
+            .borrow_mut()
+            .encode_array_types(self, array_ty, pre_encoded_elem_snap_ty)
     }
 
     pub fn encode_slice_types(
         &self,
         slice_ty: ty::Ty<'tcx>,
+        pre_encoded_elem_snap_ty: Option<vir::Type>,
     ) -> EncodingResult<EncodedSliceTypes<'tcx>> {
-        self.array_types_encoder.borrow_mut().encode_slice_types(self, slice_ty)
+        self.array_types_encoder
+            .borrow_mut()
+            .encode_slice_types(self, slice_ty, pre_encoded_elem_snap_ty)
     }
 }
 

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -1402,21 +1402,19 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     pub fn encode_array_types(
         &self,
         array_ty: ty::Ty<'tcx>,
-        pre_encoded_elem_snap_ty: Option<vir::Type>,
     ) -> EncodingResult<EncodedArrayTypes<'tcx>> {
         self.array_types_encoder
             .borrow_mut()
-            .encode_array_types(self, array_ty, pre_encoded_elem_snap_ty)
+            .encode_array_types(self, array_ty)
     }
 
     pub fn encode_slice_types(
         &self,
         slice_ty: ty::Ty<'tcx>,
-        pre_encoded_elem_snap_ty: Option<vir::Type>,
     ) -> EncodingResult<EncodedSliceTypes<'tcx>> {
         self.array_types_encoder
             .borrow_mut()
-            .encode_slice_types(self, slice_ty, pre_encoded_elem_snap_ty)
+            .encode_slice_types(self, slice_ty)
     }
 }
 

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -101,7 +101,7 @@ pub struct Encoder<'v, 'tcx: 'v> {
     fields: RefCell<HashMap<String, vir::Field>>,
     snapshot_encoder: RefCell<SnapshotEncoder>,
     mirror_encoder: RefCell<MirrorEncoder>,
-    array_types_encoder: RefCell<ArrayTypesEncoder>,
+    array_types_encoder: RefCell<ArrayTypesEncoder<'tcx>>,
     closures_collector: RefCell<SpecsClosuresCollector<'tcx>>,
     encoding_queue: RefCell<Vec<(ProcedureDefId, Vec<(ty::Ty<'tcx>, ty::Ty<'tcx>)>)>>,
     vir_program_before_foldunfold_writer: RefCell<Box<dyn Write>>,

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -58,6 +58,7 @@ use crate::encoder::mirror_function_encoder;
 use crate::encoder::mirror_function_encoder::MirrorEncoder;
 use crate::encoder::snapshot::encoder::SnapshotEncoder;
 use crate::encoder::purifier;
+use crate::encoder::array_encoder::{ArrayTypesEncoder, EncodedArrayTypes, EncodedSliceTypes};
 
 #[must_use]
 pub struct CleanupTyMapStack<'a, 'tcx> {
@@ -100,6 +101,7 @@ pub struct Encoder<'v, 'tcx: 'v> {
     fields: RefCell<HashMap<String, vir::Field>>,
     snapshot_encoder: RefCell<SnapshotEncoder>,
     mirror_encoder: RefCell<MirrorEncoder>,
+    array_types_encoder: RefCell<ArrayTypesEncoder>,
     closures_collector: RefCell<SpecsClosuresCollector<'tcx>>,
     encoding_queue: RefCell<Vec<(ProcedureDefId, Vec<(ty::Ty<'tcx>, ty::Ty<'tcx>)>)>>,
     vir_program_before_foldunfold_writer: RefCell<Box<dyn Write>>,
@@ -165,6 +167,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             typaram_repl: RefCell::new(Vec::new()),
             snapshot_encoder: RefCell::new(SnapshotEncoder::new()),
             mirror_encoder: RefCell::new(MirrorEncoder::new()),
+            array_types_encoder: RefCell::new(ArrayTypesEncoder::new()),
             encoding_errors_counter: RefCell::new(0),
             name_interner: RefCell::new(NameInterner::new()),
             current_proc: RefCell::new(None),
@@ -1394,6 +1397,20 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             }
         };
         result
+    }
+
+    pub fn encode_array_types(
+        &self,
+        array_ty: ty::Ty<'tcx>,
+    ) -> EncodingResult<EncodedArrayTypes<'tcx>> {
+        self.array_types_encoder.borrow_mut().encode_array_types(self, array_ty)
+    }
+
+    pub fn encode_slice_types(
+        &self,
+        slice_ty: ty::Ty<'tcx>,
+    ) -> EncodingResult<EncodedSliceTypes<'tcx>> {
+        self.array_types_encoder.borrow_mut().encode_slice_types(self, slice_ty)
     }
 }
 

--- a/prusti-viper/src/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mod.rs
@@ -31,3 +31,4 @@ mod utils;
 mod snapshot;
 mod mirror_function_encoder;
 mod purifier;
+mod array_encoder;

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2211,24 +2211,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let slice_ty_ref = self.mir_encoder.get_operand_ty(&args[0]);
         let slice_ty = if let ty::TyKind::Ref(_, slice_ty, _) = slice_ty_ref.kind() { slice_ty } else { unreachable!() };
         let st = self.encoder.encode_slice_types(slice_ty).with_span(span)?;
-        let slice_len_name = self.encoder.encode_builtin_function_use(
-            BuiltinFunctionKind::SliceLen {
-                slice_ty_pred: st.slice_pred.clone(),
-                elem_ty_pred: st.elem_pred,
-            }
-        );
 
-        let rhs = vir::Expr::func_app(
-            slice_len_name,
-            vec![
-                slice_operand,
-            ],
-            vec![
-                vir::LocalVar::new("self", st.slice_ty),
-            ],
-            vir::Type::Int,
-            vir::Position::default(),
-        );
+        let rhs = st.encode_slice_len_call(slice_operand);
 
         let (encoded_lhs, encode_stmts, ty, _) = self.encode_place(&destination.as_ref().unwrap().0)
             .with_span(span)?;
@@ -4998,18 +4982,15 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         );
         let span = self.mir_encoder.get_span_of_location(location);
         let (encoded_place, mut stmts, place_ty, ..) = self.encode_place(place).with_span(span)?;
-        let ty_name = self.encoder.encode_type_predicate_use(place_ty)
-            .with_span(span)?;
         match place_ty.kind() {
-            ty::TyKind::Array(_, ref ty_len) => {
+            ty::TyKind::Array(..) => {
                 // extract the length from the array type
-                let len = self.encoder.const_eval_intlike(&ty_len.val).unwrap()
-                    .to_u64().unwrap();
+                let at = self.encoder.encode_array_types(place_ty).with_span(span)?;
 
                 stmts.extend(
                     self.encode_copy_value_assign(
                         encoded_lhs,
-                        len.into(),
+                        at.array_len.into(),
                         dst_ty,
                         location,
                     )?
@@ -5019,34 +5000,16 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 let st = self.encoder.encode_slice_types(place_ty)
                         .with_span(span)?;
 
-                // encode Slice$<elem_ty>$len
-                let slice_len = self.encoder.encode_builtin_function_use(
-                    BuiltinFunctionKind::SliceLen {
-                        slice_ty_pred: st.slice_pred.clone(),
-                        elem_ty_pred: st.elem_pred,
-                    }
-                );
-
                 stmts.push(vir::Stmt::Assert(
                     vir::Expr::predicate_access_predicate(
-                        st.slice_pred,
+                        st.slice_pred.clone(),
                         encoded_place.clone(),
                         vir::PermAmount::Read,
                     ),
                     vir::Position::default(),
                 ));
 
-                let rhs = vir::Expr::func_app(
-                    slice_len,
-                    vec![
-                        encoded_place,
-                    ],
-                    vec![
-                        vir::LocalVar::new_typed_ref("self", ty_name)
-                    ],
-                    vir::Type::Int,
-                    vir::Position::default(),
-                );
+                let rhs = st.encode_slice_len_call(encoded_place);
 
                 stmts.extend(
                     self.encode_copy_value_assign(
@@ -5076,14 +5039,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
         let span = self.mir_encoder.get_span_of_location(location);
         let at = self.encoder.encode_array_types(ty).with_span(span)?;
-        let lookup_pure = self.encoder.encode_builtin_function_use(
-            BuiltinFunctionKind::ArrayLookupPure {
-                array_ty_pred: at.array_pred,
-                elem_ty_pred: at.elem_pred,
-                array_len: at.array_len,
-                return_ty: at.elem_value_ty.clone(),
-            }
-        );
 
         let encoded_operand = self.mir_encoder.encode_operand_expr(operand)
             .with_span(span)?;
@@ -5093,25 +5048,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let mut stmts = self.encode_havoc_and_allocation(&encoded_lhs);
         for i in 0..len {
             let idx = vir::Expr::from(i);
-            let lookup_pure_call = vir::Expr::func_app(
-                lookup_pure.clone(),
-                vec![
-                    encoded_lhs.clone(),
-                    idx,
-                ],
-                vec![
-                    vir::LocalVar::new(
-                        String::from("self"),
-                        at.array_ty.clone(),
-                    ),
-                    vir::LocalVar::new(
-                        String::from("idx"),
-                        vir::Type::Int,
-                    ),
-                ],
-                at.elem_value_ty.clone(),
-                vir::Position::default(),
-            );
+            let lookup_pure_call = at.encode_lookup_pure_call(encoded_lhs.clone(), idx);
 
             stmts.push(vir::Stmt::Inhale(vir!{ [lookup_pure_call] == [encoded_operand] }));
         }
@@ -5424,36 +5361,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             mir::AggregateKind::Array(..) => {
                 let at = self.encoder.encode_array_types(ty).with_span(span)?;
 
-                // TODO: move lookup_pure into encode_array_types as well?
-                let lookup_pure = self.encoder.encode_builtin_function_use(
-                    BuiltinFunctionKind::ArrayLookupPure {
-                        array_ty_pred: at.array_pred,
-                        elem_ty_pred: at.elem_pred,
-                        array_len: at.array_len,
-                        return_ty: at.elem_value_ty.clone(),
-                    }
-                );
-
                 for (idx, operand) in operands.iter().enumerate() {
-                    let lookup_pure_call = vir::Expr::func_app(
-                        lookup_pure.clone(),
-                        vec![
-                            dst.clone(),
-                            idx.into(),
-                        ],
-                        vec![
-                            vir::LocalVar::new(
-                                String::from("self"),
-                                at.array_ty.clone(),
-                            ),
-                            vir::LocalVar::new(
-                                String::from("idx"),
-                                vir::Type::Int,
-                            ),
-                        ],
-                        at.elem_value_ty.clone(),
-                        vir::Position::default(),
-                    );
+                    let lookup_pure_call = at.encode_lookup_pure_call(dst.clone(), idx.into());
 
                     let encoded_operand = self.mir_encoder.encode_operand_expr(operand)
                         .with_span(span)?;
@@ -5544,16 +5453,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             PlaceEncoding::ArrayAccess { base, index, rust_array_ty, .. } => {
                 let at = self.encoder.encode_array_types(rust_array_ty)?;
 
-                let lookup_pure = self.encoder.encode_builtin_function_use(
-                    BuiltinFunctionKind::ArrayLookupPure {
-                        array_ty_pred: at.array_pred,
-                        elem_ty_pred: at.elem_pred,
-                        array_len: at.array_len,
-                        return_ty: at.elem_value_ty.clone(),
-                    }
-                );
-
-                let lookup_res: vir::Expr = self.cfg_method.add_fresh_local_var(at.elem_ty).into();
+                let lookup_res: vir::Expr = self.cfg_method.add_fresh_local_var(at.elem_ty.clone()).into();
 
                 // encode val_field for the array element type
                 let val_field = self.encoder.encode_value_field(at.elem_ty_rs);
@@ -5565,24 +5465,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
                 let (encoded_base_expr, mut stmts) = self.postprocess_place_encoding(*base)?;
                 stmts.extend(self.encode_havoc_and_allocation(&lookup_res));
-                let lookup_pure_call = vir::Expr::func_app(
-                    lookup_pure,
-                    vec![
-                        encoded_base_expr,
-                        index.field(val_int_field),
-                    ],
-                    vec![
-                        vir::LocalVar::new(
-                            String::from("self"),
-                            at.array_ty,
-                        ),
-                        vir::LocalVar::new(
-                            String::from("idx"),
-                            vir::Type::Int,
-                        ),
-                    ],
-                    at.elem_value_ty,
-                    vir::Position::default(),
+                let lookup_pure_call = at.encode_lookup_pure_call(
+                    encoded_base_expr,
+                    index.field(val_int_field),
                 );
                 stmts.push(vir::Stmt::Inhale(vir!{ [ lookup_pure_call ] == [ lookup_res_val_field ] }));
 
@@ -5596,15 +5481,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             PlaceEncoding::SliceAccess { base, index, rust_slice_ty, .. } => {
                 let st = self.encoder.encode_slice_types(rust_slice_ty)?;
 
-                let lookup_pure = self.encoder.encode_builtin_function_use(
-                    BuiltinFunctionKind::SliceLookupPure {
-                        slice_ty_pred: st.slice_pred,
-                        elem_ty_pred: st.elem_pred,
-                        return_ty: st.elem_value_ty.clone(),
-                    }
-                );
-
-                let res = vir::Expr::local(self.cfg_method.add_fresh_local_var(st.elem_ty));
+                let res = vir::Expr::local(self.cfg_method.add_fresh_local_var(st.elem_ty.clone()));
                 let val_field = self.encoder.encode_value_field(st.elem_ty_rs);
                 let res_val_field = res.clone().field(val_field);
 
@@ -5614,21 +5491,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 let usize_ty = self.encoder.env().tcx().mk_ty(ty::TyKind::Uint(ty::UintTy::Usize));
                 let idx_val_field = self.encoder.encode_value_field(usize_ty);
 
-                let lookup_pure_call = vir::Expr::func_app(
-                    lookup_pure,
-                    vec![
-                        encoded_base_expr,
-                        index.field(idx_val_field),
-                    ],
-                    vec![
-                        vir::LocalVar::new(
-                            String::from("self"),
-                            st.slice_ty,
-                        ),
-                        vir_local!{ idx: Int },
-                    ],
-                    st.elem_value_ty,
-                    vir::Position::default(),
+                let lookup_pure_call = st.encode_lookup_pure_call(
+                    encoded_base_expr,
+                    index.field(idx_val_field),
                 );
 
                 stmts.push(vir::Stmt::Inhale(vir!{ [lookup_pure_call] == [res_val_field] }));

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2210,7 +2210,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
         let slice_ty_ref = self.mir_encoder.get_operand_ty(&args[0]);
         let slice_ty = if let ty::TyKind::Ref(_, slice_ty, _) = slice_ty_ref.kind() { slice_ty } else { unreachable!() };
-        let st = self.encoder.encode_slice_types(slice_ty).with_span(span)?;
+        let st = self.encoder.encode_slice_types(slice_ty, None).with_span(span)?;
 
         let rhs = st.encode_slice_len_call(slice_operand);
 
@@ -4985,7 +4985,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         match place_ty.kind() {
             ty::TyKind::Array(..) => {
                 // extract the length from the array type
-                let at = self.encoder.encode_array_types(place_ty).with_span(span)?;
+                let at = self.encoder.encode_array_types(place_ty, None).with_span(span)?;
 
                 stmts.extend(
                     self.encode_copy_value_assign(
@@ -4997,7 +4997,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 );
             },
             ty::TyKind::Slice(..) => {
-                let st = self.encoder.encode_slice_types(place_ty)
+                let st = self.encoder.encode_slice_types(place_ty, None)
                         .with_span(span)?;
 
                 stmts.push(vir::Stmt::Assert(
@@ -5038,7 +5038,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
         let span = self.mir_encoder.get_span_of_location(location);
-        let at = self.encoder.encode_array_types(ty).with_span(span)?;
+        let at = self.encoder.encode_array_types(ty, None).with_span(span)?;
 
         let encoded_operand = self.mir_encoder.encode_operand_expr(operand)
             .with_span(span)?;
@@ -5359,7 +5359,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             }
 
             mir::AggregateKind::Array(..) => {
-                let at = self.encoder.encode_array_types(ty).with_span(span)?;
+                let at = self.encoder.encode_array_types(ty, None).with_span(span)?;
 
                 for (idx, operand) in operands.iter().enumerate() {
                     let lookup_pure_call = at.encode_lookup_pure_call(dst.clone(), idx.into());
@@ -5451,7 +5451,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 (expr.field(field), stmts)
             }
             PlaceEncoding::ArrayAccess { base, index, rust_array_ty, .. } => {
-                let at = self.encoder.encode_array_types(rust_array_ty)?;
+                let at = self.encoder.encode_array_types(rust_array_ty, None)?;
 
                 let lookup_res: vir::Expr = self.cfg_method.add_fresh_local_var(at.elem_ty.clone()).into();
 
@@ -5479,7 +5479,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 (vir::Expr::Variant(box expr, field, vir::Position::default()), stmts)
             }
             PlaceEncoding::SliceAccess { base, index, rust_slice_ty, .. } => {
-                let st = self.encoder.encode_slice_types(rust_slice_ty)?;
+                let st = self.encoder.encode_slice_types(rust_slice_ty, None)?;
 
                 let res = vir::Expr::local(self.cfg_method.add_fresh_local_var(st.elem_ty.clone()));
                 let val_field = self.encoder.encode_value_field(st.elem_ty_rs);

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2210,7 +2210,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
         let slice_ty_ref = self.mir_encoder.get_operand_ty(&args[0]);
         let slice_ty = if let ty::TyKind::Ref(_, slice_ty, _) = slice_ty_ref.kind() { slice_ty } else { unreachable!() };
-        let slice_types = self.encoder.encode_slice_types(slice_ty, None).with_span(span)?;
+        let slice_types = self.encoder.encode_slice_types(slice_ty).with_span(span)?;
 
         let rhs = slice_types.encode_slice_len_call(slice_operand);
 
@@ -4985,7 +4985,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         match place_ty.kind() {
             ty::TyKind::Array(..) => {
                 // extract the length from the array type
-                let array_types = self.encoder.encode_array_types(place_ty, None).with_span(span)?;
+                let array_types = self.encoder.encode_array_types(place_ty).with_span(span)?;
 
                 stmts.extend(
                     self.encode_copy_value_assign(
@@ -4997,7 +4997,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 );
             },
             ty::TyKind::Slice(..) => {
-                let slice_types = self.encoder.encode_slice_types(place_ty, None)
+                let slice_types = self.encoder.encode_slice_types(place_ty)
                         .with_span(span)?;
 
                 stmts.push(vir::Stmt::Assert(
@@ -5038,7 +5038,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
         let span = self.mir_encoder.get_span_of_location(location);
-        let array_types = self.encoder.encode_array_types(ty, None).with_span(span)?;
+        let array_types = self.encoder.encode_array_types(ty).with_span(span)?;
 
         let encoded_operand = self.mir_encoder.encode_operand_expr(operand)
             .with_span(span)?;
@@ -5359,7 +5359,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             }
 
             mir::AggregateKind::Array(..) => {
-                let array_types = self.encoder.encode_array_types(ty, None).with_span(span)?;
+                let array_types = self.encoder.encode_array_types(ty).with_span(span)?;
 
                 for (idx, operand) in operands.iter().enumerate() {
                     let lookup_pure_call = array_types.encode_lookup_pure_call(dst.clone(), idx.into());
@@ -5451,7 +5451,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 (expr.field(field), stmts)
             }
             PlaceEncoding::ArrayAccess { base, index, rust_array_ty, .. } => {
-                let array_types = self.encoder.encode_array_types(rust_array_ty, None)?;
+                let array_types = self.encoder.encode_array_types(rust_array_ty)?;
 
                 let lookup_res: vir::Expr = self.cfg_method.add_fresh_local_var(array_types.elem_ty.clone()).into();
 
@@ -5479,7 +5479,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 (vir::Expr::Variant(box expr, field, vir::Position::default()), stmts)
             }
             PlaceEncoding::SliceAccess { base, index, rust_slice_ty, .. } => {
-                let slice_types = self.encoder.encode_slice_types(rust_slice_ty, None)?;
+                let slice_types = self.encoder.encode_slice_types(rust_slice_ty)?;
 
                 let res = vir::Expr::local(self.cfg_method.add_fresh_local_var(slice_types.elem_ty.clone()));
                 let val_field = self.encoder.encode_value_field(slice_types.elem_ty_rs);


### PR DESCRIPTION
 - Moved to `Encoder` so it can be used from pure function encoder as well.
 - Moved encoding of `lookup_pure` calls onto the `EncodedArrayTypes` and `EncodedSliceTypes` structs to avoid repeating it everywhere.