### PR TITLE
Cargo-prusti in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ target/
 log/
 tmp/
 viper_tools/
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 target/
 log/
 tmp/
+viper_tools/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,6 @@ dependencies = [
  "log 0.4.14",
  "prusti-common",
  "prusti-contracts",
- "prusti-contracts-internal",
  "prusti-interface",
  "prusti-specs",
  "prusti-viper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,6 @@ members = [
 	"jni-gen/systest",
 ]
 
-exclude = [
-    "prusti-contracts-test",
-]
-
 [profile.release]
 # Enable after fixing https://github.com/viperproject/prusti-dev/issues/383
 # lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,12 +69,12 @@ WORKDIR /root
 RUN cargo new good-example && \
     cd good-example && \
     sed -i '1s/^/use prusti_contracts::*;\n/;s/println.*$/assert!(true);/' src/main.rs && \
-    echo 'prusti-contracts = { path = "/opt/prusti-dev/prusti-contracts"}' >> Cargo.toml && \
+    echo 'prusti-contracts = { path = "/opt/prusti-dev/prusti-contracts" }' >> Cargo.toml && \
     cargo build && cargo clean && \
     cargo prusti && cargo clean
 RUN cargo new bad-example && \
     cd bad-example && \
     sed -i '1s/^/use prusti_contracts::*;\n/;s/println.*$/assert!(false);/' src/main.rs && \
-    echo 'prusti-contracts = { path = "/opt/prusti-dev/prusti-contracts"}' >> Cargo.toml && \
+    echo 'prusti-contracts = { path = "/opt/prusti-dev/prusti-contracts" }' >> Cargo.toml && \
     cargo build && cargo clean && \
     ! cargo prusti && cargo clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,22 +36,20 @@ ENV LD_LIBRARY_PATH $JAVA_HOME/lib/server/
 
 # Install Rust
 ADD rust-toolchain /tmp/rust-toolchain
-ENV RUSTUP_HOME /usr/local/rustup
-ENV CARGO_HOME /usr/local/cargo
 RUN CHANNEL=$(cat /tmp/rust-toolchain | grep channel | cut -d'"' -f2) && \
     echo "Rust toolchain: $CHANNEL" && \
     curl https://sh.rustup.rs -sSf \
         | sh -s -- -y --profile minimal --no-modify-path --default-toolchain "$CHANNEL"
-ENV PATH /usr/local/cargo/bin:$PATH
+ENV PATH /root/.cargo/bin:$PATH
 
 # Set up Prusti
-ADD . /tmp/prusti-dev
-RUN cd /tmp/prusti-dev && \
+ADD . /opt/prusti-dev
+RUN cd /opt/prusti-dev && \
     ./x.py setup && \
     rm -rf /var/lib/apt/lists/*
 
 # Build and install Prusti
-RUN cd /tmp/prusti-dev && \
+RUN cd /opt/prusti-dev && \
     ./x.py build --release && \
     mkdir -p /usr/local/prusti/deps/ && \
 	cp -r viper_tools/ /usr/local/prusti/ && \
@@ -63,16 +61,20 @@ RUN cd /tmp/prusti-dev && \
     cp target/release/cargo-prusti /usr/local/prusti/ && \
     cp target/release/libprusti_contracts.rlib /usr/local/prusti/ && \
     cp target/release/deps/libprusti_contracts_internal-* /usr/local/prusti/deps/ && \
-    rm -rf /tmp/prusti-dev
+    rm -rf target
 ENV PATH "/usr/local/prusti/:${PATH}"
 
-# Create a new user
-RUN useradd -ms /bin/bash user
-USER user
-WORKDIR /home/user
-
-# Check on a simple crate that Prusti works
-RUN cargo new example && \
-    cd example && \
+# Check on a few crates that Prusti works
+WORKDIR /root
+RUN cargo new good-example && \
+    cd good-example && \
     sed -i '1s/^/use prusti_contracts::*;\n/;s/println.*$/assert!(true);/' src/main.rs && \
-    cargo prusti
+    echo 'prusti-contracts = { path = "/opt/prusti-dev/prusti-contracts"}' >> Cargo.toml && \
+    cargo build && cargo clean && \
+    cargo prusti && cargo clean
+RUN cargo new bad-example && \
+    cd bad-example && \
+    sed -i '1s/^/use prusti_contracts::*;\n/;s/println.*$/assert!(false);/' src/main.rs && \
+    echo 'prusti-contracts = { path = "/opt/prusti-dev/prusti-contracts"}' >> Cargo.toml && \
+    cargo build && cargo clean && \
+    ! cargo prusti && cargo clean

--- a/prusti-contracts-test/Cargo.toml
+++ b/prusti-contracts-test/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2018"
 
 [dependencies]
 prusti-contracts = { path = "../prusti-contracts" }
+
+# Declare that this crate is not part of a workspace
+[workspace]

--- a/prusti/Cargo.toml
+++ b/prusti/Cargo.toml
@@ -13,7 +13,6 @@ doctest = false # and no doc tests
 [dependencies]
 env_logger = "0.8.2"
 prusti-contracts = { path = "../prusti-contracts", features = ["prusti"] }
-prusti-contracts-internal = { path = "../prusti-contracts-internal" }
 prusti-specs = { path = "../prusti-specs" }
 prusti-interface = { path = "../prusti-interface" }
 prusti-viper = { path = "../prusti-viper" }

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -119,7 +119,7 @@ fn init_loggers() {
     rustc_driver::init_rustc_env_logger();
 }
 
-const PRUSTI_PACKAGES: &'static [&'static str] = &[
+const PRUSTI_PACKAGES: [&str; 4] = [
     "prusti-contracts-internal",
     "prusti-contracts-impl",
     "prusti-contracts",

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -119,17 +119,25 @@ fn init_loggers() {
     rustc_driver::init_rustc_env_logger();
 }
 
+const PRUSTI_PACKAGES: &'static [&'static str] = &[
+    "prusti_contracts_internal",
+    "prusti_contracts_impl",
+    "prusti_contracts",
+    "prusti_specs",
+];
+
 fn main() {
     // We assume that prusti-rustc already removed the first "rustc" argument
     // added by RUSTC_WRAPPER and all command line arguments -P<arg>=<val>
     // have been filtered out.
     let mut rustc_args = config::get_filtered_args();
 
-    // If the environment asks us to actually be rustc, or if lints have been disabled, then
-    // run `rustc` instead of Prusti.
+    // If the environment asks us to actually be rustc, or if lints have been disabled (which
+    // indicates that an upstream dependency is being compiled), then run `rustc` instead of Prusti.
     let prusti_be_rustc = config::be_rustc();
     let are_lints_disabled = arg_value(&rustc_args, "--cap-lints", |val| val == "allow").is_some();
-    if prusti_be_rustc || are_lints_disabled {
+    let is_prusti_package = env::var("CARGO_PKG_NAME").map(|name| PRUSTI_PACKAGES.contains(&name.as_str())).unwrap_or(false);
+    if prusti_be_rustc || are_lints_disabled || is_prusti_package {
         rustc_driver::main();
     }
 

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -120,10 +120,10 @@ fn init_loggers() {
 }
 
 const PRUSTI_PACKAGES: &'static [&'static str] = &[
-    "prusti_contracts_internal",
-    "prusti_contracts_impl",
-    "prusti_contracts",
-    "prusti_specs",
+    "prusti-contracts-internal",
+    "prusti-contracts-impl",
+    "prusti-contracts",
+    "prusti-specs",
 ];
 
 fn main() {


### PR DESCRIPTION
This PR:
* Adds Prusti's source code to the Docker image, such that crates can depend on `prusti-contracts = { path = "/opt/prusti-dev/prusti-contracts" }`.
* Adds a new check to `prusti-driver` to skip the verification of `prusti-contracts`, which `cargo check` considers to be a local dependency.