### PR TITLE
Fixes for panics in encode_copy2

### DIFF
--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5291,6 +5291,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         self_ty: ty::Ty<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
+        let span = self.mir_encoder.get_span_of_location(location);
         let stmts = match self_ty.kind() {
             ty::TyKind::Bool
             | ty::TyKind::Int(_)
@@ -5313,7 +5314,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 Vec::new()
             }
             
-            ref x => unimplemented!("{:?}", x),
+            _ => {
+                return Err(SpannedEncodingError::unsupported(
+                    format!("copy operation for an unsupported type {:?}", self_ty.kind()),
+                    span
+                ));
+            }
         };
         Ok(stmts)
     }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5301,7 +5301,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
             ty::TyKind::Adt(_, _)
             | ty::TyKind::Tuple(_)
-            | ty::TyKind::Param(_) => {
+            | ty::TyKind::Param(_)
+            | ty::TyKind::Array(_, _) => {
                 self.encode_copy_snapshot_value(src, dst)?
             }
 
@@ -5311,7 +5312,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 debug!("warning: ty::TyKind::Closure not implemented yet");
                 Vec::new()
             }
-
+            
             ref x => unimplemented!("{:?}", x),
         };
         Ok(stmts)


### PR DESCRIPTION
This PR fixes the panics in `encode_copy2` by either performing the right action or returning an error