### PR TITLE
Replaced unreachable panic with error

### DIFF
--- a/prusti-interface/src/environment/borrowck/regions.rs
+++ b/prusti-interface/src/environment/borrowck/regions.rs
@@ -84,9 +84,28 @@ impl PlaceRegions {
                         not supported".to_string()
                     ));
                 }
-                x => {
+                mir::ProjectionElem::Index(_) => {
                     return Err(PlaceRegionsError::Unsupported(
-                        format!("determining the region of projection {:?} is not supported", x)
+                        "determining the region of array indexing is \
+                        not supported".to_string()
+                    ));
+                }
+                mir::ProjectionElem::ConstantIndex{..} => {
+                    return Err(PlaceRegionsError::Unsupported(
+                        "determining the region of constant indexing is \
+                        not supported".to_string()
+                    ));
+                }
+                mir::ProjectionElem::Subslice{..} => {
+                    return Err(PlaceRegionsError::Unsupported(
+                        "determining the region of a subslice is \
+                        not supported".to_string()
+                    ));
+                }
+                mir::ProjectionElem::Downcast(_, _) => {
+                    return Err(PlaceRegionsError::Unsupported(
+                        "determining the region of a downcast is \
+                        not supported".to_string()
                     ));
                 }
             })

--- a/prusti-interface/src/environment/borrowck/regions.rs
+++ b/prusti-interface/src/environment/borrowck/regions.rs
@@ -79,31 +79,31 @@ impl PlaceRegions {
             .map(|elem| match elem {
                 mir::ProjectionElem::Field(f, _) => Ok(f.index()),
                 mir::ProjectionElem::Deref => {
-                    return Err(PlaceRegionsError::Unsupported(
+                    Err(PlaceRegionsError::Unsupported(
                         "determining the region of a dereferentiation is \
                         not supported".to_string()
                     ));
                 }
                 mir::ProjectionElem::Index(_) => {
-                    return Err(PlaceRegionsError::Unsupported(
+                    Err(PlaceRegionsError::Unsupported(
                         "determining the region of array indexing is \
                         not supported".to_string()
                     ));
                 }
                 mir::ProjectionElem::ConstantIndex{..} => {
-                    return Err(PlaceRegionsError::Unsupported(
+                    Err(PlaceRegionsError::Unsupported(
                         "determining the region of constant indexing is \
                         not supported".to_string()
                     ));
                 }
                 mir::ProjectionElem::Subslice{..} => {
-                    return Err(PlaceRegionsError::Unsupported(
+                    Err(PlaceRegionsError::Unsupported(
                         "determining the region of a subslice is \
                         not supported".to_string()
                     ));
                 }
                 mir::ProjectionElem::Downcast(_, _) => {
-                    return Err(PlaceRegionsError::Unsupported(
+                    Err(PlaceRegionsError::Unsupported(
                         "determining the region of a downcast is \
                         not supported".to_string()
                     ));

--- a/prusti-interface/src/environment/borrowck/regions.rs
+++ b/prusti-interface/src/environment/borrowck/regions.rs
@@ -84,7 +84,11 @@ impl PlaceRegions {
                         not supported".to_string()
                     ));
                 }
-                x => unreachable!("{:?}", x),
+                x => {
+                    return Err(PlaceRegionsError::Unsupported(
+                        format!("determining the region of projection {:?} is not supported", x)
+                    ));
+                }
             })
             .collect::<Result<_, _>>()?;
         Ok((place.local, indices))

--- a/prusti-interface/src/environment/borrowck/regions.rs
+++ b/prusti-interface/src/environment/borrowck/regions.rs
@@ -82,31 +82,31 @@ impl PlaceRegions {
                     Err(PlaceRegionsError::Unsupported(
                         "determining the region of a dereferentiation is \
                         not supported".to_string()
-                    ));
+                    ))
                 }
                 mir::ProjectionElem::Index(_) => {
                     Err(PlaceRegionsError::Unsupported(
                         "determining the region of array indexing is \
                         not supported".to_string()
-                    ));
+                    ))
                 }
                 mir::ProjectionElem::ConstantIndex{..} => {
                     Err(PlaceRegionsError::Unsupported(
                         "determining the region of constant indexing is \
                         not supported".to_string()
-                    ));
+                    ))
                 }
                 mir::ProjectionElem::Subslice{..} => {
                     Err(PlaceRegionsError::Unsupported(
                         "determining the region of a subslice is \
                         not supported".to_string()
-                    ));
+                    ))
                 }
                 mir::ProjectionElem::Downcast(_, _) => {
                     Err(PlaceRegionsError::Unsupported(
                         "determining the region of a downcast is \
                         not supported".to_string()
-                    ));
+                    ))
                 }
             })
             .collect::<Result<_, _>>()?;

--- a/prusti-tests/tests/verify/fail/unsupported/region_of_proj.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/region_of_proj.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("Hi");
+    let mut t = [0];
+    t[0] = 1;   //~ ERROR determining the region of projection Index(_14) is not supported
+}

--- a/prusti-tests/tests/verify/fail/unsupported/region_of_proj.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/region_of_proj.rs
@@ -1,5 +1,5 @@
 fn main() {
     println!("Hi");
     let mut t = [0];
-    t[0] = 1;   //~ ERROR determining the region of projection Index(_14) is not supported
+    t[0] = 1;   //~ ERROR determining the region of array indexing is not supported
 }


### PR DESCRIPTION
Inexplicable unreachable panic triggered by this:
```
fn main() {
    println!("Hi");
    let mut t = [0];
    t[0] = 1;
}
```

Replaced panic by a generic error message