### PR TITLE
Add EBNF grammar to specification syntax section

### DIFF
--- a/dev-guide/src/macros.md
+++ b/dev-guide/src/macros.md
@@ -8,6 +8,19 @@ Prusti [specification syntax](https://viperproject.github.io/prusti-dev/user-gui
 
  - [`prusti-specs/src/specifications/preparser.rs`](https://github.com/viperproject/prusti-dev/blob/f3ce1acd3c38e9c60d94fbdd7ebc1fcbeb316067/prusti-specs/src/specifications/preparser.rs)
 
+The preparser accepts the following EBNF grammar:
+
+```ebnf
+prusti_expr ::= conjunction, [ "==>", prusti_expr ] ;
+conjunction ::= entailment, { "&&", entailment } ;
+entailment ::= primary | ? actual rust expression ?, [ "|=", [ "|", ? args as parsed by syn2 ?, "|" ], "[", { requires | ensures }, "]" ] ;
+primary ::= "(", prusti_expr, ")"
+          | "forall", "(", "|", ? one or more args as parsed by syn2 ?, "|", prusti_expr, [ ",", "triggers", "=", ? array as parsed by syn2 ? ] ")"
+          ;
+requires ::= "requires", "(", prusti_expr, ")" ;
+ensures ::= "ensures", "(", prusti_expr, ")" ;
+```
+
 ## Specification serialization
 
 Because procedural macros are executed in a separate, sandboxed process, it is not straight-forward to pass data from procedural macros to the rest of the [Prusti pipeline](pipeline/summary.md). Any collected data (e.g. parsed assertions) is therefore serialized and inserted into the processed HIR as attributes on dummy functions, where it can be picked up by a HIR visitor.

--- a/dev-guide/src/macros.md
+++ b/dev-guide/src/macros.md
@@ -11,9 +11,13 @@ Prusti [specification syntax](https://viperproject.github.io/prusti-dev/user-gui
 The preparser accepts the following EBNF grammar:
 
 ```ebnf
+assertion ::= prusti_expr ;
+pledge ::= pledge_lhs, ",", prusti_expr ;
+pledge_lhs ::= [ ? actual rust expression ?, "=>" ], prusti_expr ;
+ 
 prusti_expr ::= conjunction, [ "==>", prusti_expr ] ;
 conjunction ::= entailment, { "&&", entailment } ;
-entailment ::= primary | ? actual rust expression ?, [ "|=", [ "|", ? args as parsed by syn2 ?, "|" ], "[", { requires | ensures }, "]" ] ;
+entailment ::= primary | ? actual rust expression ?, [ "|=", [ "|", ? args as parsed by syn2 ?, "|" ], "[", [ ( requires | ensures ), { ",", ( requires | ensures ) } ], "]" ] ;
 primary ::= "(", prusti_expr, ")"
           | "forall", "(", "|", ? one or more args as parsed by syn2 ?, "|", prusti_expr, [ ",", "triggers", "=", ? array as parsed by syn2 ? ] ")"
           ;


### PR DESCRIPTION
This pull request copies the EBNF grammar accepted by the preparser from `prusti-specs/src/specifications/mod.rs` into the dev guide because the dev guide is a more easily viewable location.

This work is being done as part of a research internship with @Aurel300 and @alexanderjsummers.

This PR is related to #549 - that is a parser that implements this grammar. 