### PR TITLE
Exhausted pattern match

### DIFF
--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -143,7 +143,96 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                 ));
             }
 
-            ref x => unimplemented!("{:?}", x),
+            ty::TyKind::Float(_) => {
+                return Err(EncodingError::unsupported(
+                    "float type is not supported"
+                ));
+            }
+
+            ty::TyKind::Foreign(_) => {
+                return Err(EncodingError::unsupported(
+                    "foreign function interface is not supported"
+                ));
+            }
+
+            ty::TyKind::Str => {
+                return Err(EncodingError::unsupported(
+                    "strings are not supported"
+                ));
+            }
+
+            ty::TyKind::Slice(_) => {
+                return Err(EncodingError::unsupported(
+                    "array slices are not supported"
+                ));
+            }
+
+            ty::TyKind::FnPtr(_) => {
+                return Err(EncodingError::unsupported(
+                    "function pointers are not supported"
+                ));
+            }
+
+            ty::TyKind::Dynamic(..) => {
+                return Err(EncodingError::unsupported(
+                    "trait objects are not supported"
+                ));
+            }
+
+            ty::TyKind::Generator(..)
+            | ty::TyKind::GeneratorWitness(..) => {
+                return Err(EncodingError::unsupported(
+                    "generators are not supported"
+                ));
+            }
+
+            ty::TyKind::Never => {
+                return Err(EncodingError::unsupported(
+                    "never type is not supported"
+                ));
+            }
+
+            ty::TyKind::Projection(_) => {
+                return Err(EncodingError::unsupported(
+                    "projections are not supported"
+                ));
+            }
+
+            ty::TyKind::Opaque(_, _) => {
+                return Err(EncodingError::unsupported(
+                    "opaque types not supported"
+                ));
+            }
+
+            ty::TyKind::Param(_) => {
+                return Err(EncodingError::unsupported(
+                    "type parameters in arrays are not supported"
+                ));
+            }
+
+            ty::TyKind::Bound(_, _) => {
+                return Err(EncodingError::unsupported(
+                    "bound type variables are not supported"
+                ));
+            }
+
+            ty::TyKind::Placeholder(_) => {
+                return Err(EncodingError::unsupported(
+                    "placeholder types are not supported"
+                ));
+            }
+
+            ty::TyKind::Infer(_) => {
+                return Err(EncodingError::unsupported(
+                    "inference types are not supported"
+                ));
+            }
+
+            ty::TyKind::Error(_) => {
+                return Err(EncodingError::unsupported(
+                    "error type is not supported"
+                ));
+            }
         })
     }
 


### PR DESCRIPTION
Exhausted the pattern match in `TypeEncoder::encode_value_field` and returning unsupported error from the newly added patterns. Fixes the unimplemented panic caused [here](https://github.com/viperproject/prusti-dev/blob/539d505bb27ce829bbcaf63e0c66f08311037719/prusti-viper/src/encoder/type_encoder.rs#L146)