### PR TITLE
Add unsupported error function to TypeVisitor

### DIFF
--- a/prusti-tests/tests/verify/fail/unsupported/higher_ranked_type.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/higher_ranked_type.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = (0..1).filter(|_| true); //~ ERROR higher-ranked lifetimes and types are not supported
+}

--- a/prusti-viper/src/encoder/borrows.rs
+++ b/prusti-viper/src/encoder/borrows.rs
@@ -328,6 +328,10 @@ impl<'tcx> TypeVisitor<'tcx> for BorrowInfoCollectingVisitor<'tcx> {
         self.tcx
     }
 
+    fn unsupported<S: ToString>(&self, msg: S) -> Self::Error {
+        EncodingError::unsupported(msg.to_string())
+    }
+
     fn visit_field(
         &mut self,
         index: usize,

--- a/prusti-viper/src/utils/type_visitor.rs
+++ b/prusti-viper/src/utils/type_visitor.rs
@@ -17,6 +17,8 @@ pub trait TypeVisitor<'tcx>: Sized {
 
     fn tcx(&self) -> TyCtxt<'tcx>;
 
+    fn unsupported<S: ToString>(&self, _msg: S) -> Self::Error;
+
     fn visit_ty(&mut self, ty: Ty<'tcx>) -> Result<(), Self::Error> {
         trace!("visit_ty({:?})", ty);
         self.visit_sty(ty.kind())?;

--- a/prusti-viper/src/utils/type_visitor.rs
+++ b/prusti-viper/src/utils/type_visitor.rs
@@ -283,16 +283,9 @@ pub fn walk_closure<'tcx, E, V: TypeVisitor<'tcx, Error = E>>(
     let cl_substs = substs.as_closure();
     // TODO: when are there bound typevars? can type visitor deal with generics?
     let fn_sig =
-        match cl_substs.sig().no_bound_vars() {
-            None => {
-                return Err(visitor.unsupported(
-                    "higher-ranked lifetimes and types are not supported"
-                ))
-            }
-
-            Some(x) => x
-        };
-
+        cl_substs.sig()
+                 .no_bound_vars()
+                 .ok_or_else(|| visitor.unsupported("higher-ranked lifetimes and types are not supported"))?; 
     for ty in fn_sig.inputs() {
         visitor.visit_ty(ty)?;
     }


### PR DESCRIPTION
This PR adds `unsupported` function to `TypeVisitor` trait. Also fixes the panic caused [here](https://github.com/viperproject/prusti-dev/blob/02732f22ec0a9afb5438bbd9626309c87125cf87/prusti-viper/src/utils/type_visitor.rs#L286)