### PR TITLE
Improve snapshots of argumentless enums

### DIFF
--- a/prusti-common/src/vir/ast/expr.rs
+++ b/prusti-common/src/vir/ast/expr.rs
@@ -452,6 +452,7 @@ impl Expr {
     }
 
     pub fn forall(vars: Vec<LocalVar>, triggers: Vec<Trigger>, body: Expr) -> Self {
+        assert!(!vars.is_empty(), "A quantifier must have at least one variable.");
         Expr::ForAll(vars, triggers, box body, Position::default())
     }
 

--- a/prusti-viper/src/encoder/type_encoder.rs
+++ b/prusti-viper/src/encoder/type_encoder.rs
@@ -484,7 +484,8 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
             }
 
             ty::TyKind::Param(param_ty) => {
-                format!("__TYPARAM__${}$__", param_ty.name.as_str())
+                // make sure to avoid "$T$" used internally in Silicon
+                format!("__TYPARAM__$_{}$__", param_ty.name.as_str())
             }
 
             ty::TyKind::Projection(ty::ProjectionTy { item_def_id, substs }) => {


### PR DESCRIPTION
- Fix var-less quantifiers in the injectivity and constructor axioms.
- Omit injectivity axioms for argumentless variants.

Closes #562