### PR TITLE
Extract toolchain from the new rust-toolchain format

### DIFF
--- a/test-crates/compile-crates.sh
+++ b/test-crates/compile-crates.sh
@@ -40,7 +40,7 @@ export RUSTFLAGS="-Zborrowck=mir -Zpolonius -Znll-facts -Zidentify-regions -Zdum
 export POLONIUS_ALGORITHM="Naive"
 export RUST_BACKTRACE=1
 
-export RUSTUP_TOOLCHAIN="$(cat "$DIR/../rust-toolchain")"
+export RUSTUP_TOOLCHAIN="$(sed -n 's/channel.*"\(.*\)".*$/\1/p' "$DIR/../rust-toolchain")"
 info "Using RUSTUP_TOOLCHAIN=$RUSTUP_TOOLCHAIN"
 
 ls -d "$CRATE_DOWNLOAD_DIR"/*/ | while read crate_path; do

--- a/test-crates/verify-crates.sh
+++ b/test-crates/verify-crates.sh
@@ -65,7 +65,7 @@ export RUSTFLAGS="-Awarnings" # "-C overflow-check=yes"
 export RUST_BACKTRACE=1
 export PRUSTI_FULL_COMPILATION=true
 
-export RUSTUP_TOOLCHAIN="$(cat "$DIR/../rust-toolchain")"
+export RUSTUP_TOOLCHAIN="$(sed -n 's/channel.*"\(.*\)".*$/\1/p' "$DIR/../rust-toolchain")"
 info "Using RUSTUP_TOOLCHAIN=$RUSTUP_TOOLCHAIN"
 
 cat "$CRATES_LIST_PATH" | while read crate_name; do


### PR DESCRIPTION
This PR fixes the error in assigning `RUSTUP_TOOLCHAIN` using the new format of `rust-toolchain`. The script now extracts the toolchain from the line `channel = <toolchain>`.