### PR TITLE
Exhausting pattern match

### DIFF
--- a/prusti-tests/tests/verify/fail/unsupported/rawptr.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/rawptr.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _: *const i32 = std::ptr::null_mut();   //~ ERROR raw pointers are not supported
+}

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1316,8 +1316,20 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     )).with_span(span);
                 }
             }
-            ref rhs => {
-                unimplemented!("encoding of '{:?}'", rhs);
+            &mir::Rvalue::Cast(mir::CastKind::Pointer(_), _, _) => {
+                return Err(EncodingError::unsupported(
+                    "raw pointers are not supported"
+                )).with_span(span);
+            }
+            &mir::Rvalue::AddressOf(_, _) => {
+                return Err(EncodingError::unsupported(
+                    "raw addresses of expressions or casting a reference to a raw pointer are not supported"
+                )).with_span(span);
+            }
+            &mir::Rvalue::ThreadLocalRef(_) => {
+                return Err(EncodingError::unsupported(
+                    "references to thread-local storage are not supported"
+                )).with_span(span);
             }
         })
     }


### PR DESCRIPTION
This PR fixes [this panic](https://github.com/viperproject/prusti-dev/blob/4a1afbf818953e919edf17a469287789db7a3315/prusti-viper/src/encoder/procedure_encoder.rs#L1320) by exhausting the pattern match and returning errors from the newly added cases