### PR TITLE
Remove unnecessary assert

### DIFF
--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -258,11 +258,7 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
         base_ty: ty::Ty<'tcx>,
     ) -> EncodingResult<(vir::Expr, ty::Ty<'tcx>, Option<usize>)> {
         trace!("encode_deref {} {}", encoded_base, base_ty);
-        assert!(
-            self.can_be_dereferenced(base_ty),
-            "Type {:?} can not be dereferenced",
-            base_ty
-        );
+
         Ok(match base_ty.kind() {
             ty::TyKind::RawPtr(ty::TypeAndMut { ty, .. })
             | ty::TyKind::Ref(_, ty, _) => {
@@ -292,7 +288,11 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                 };
                 (access, base_ty.boxed_ty(), None)
             }
-            ref x => unimplemented!("{:?}", x),
+            ref x => {
+                return Err(EncodingError::internal(
+                    format!("Type {:?} can not be dereferenced", x)
+                ));
+            }
         })
     }
 


### PR DESCRIPTION
This PR removes the assert as the cases which pass it are covered in the pattern match below. Returning an internal error in the general case instead of unimplemented panic.