### PR TITLE
Tykind to string function

### DIFF
--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -188,7 +188,7 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                         (encoded_projection, field_ty, None)
                     }
 
-                    ref x => {
+                    x => {
                         return Err(EncodingError::internal(
                             format!("{} has no fields", utils::ty_to_string(x))
                         ));

--- a/prusti-viper/src/utils/mod.rs
+++ b/prusti-viper/src/utils/mod.rs
@@ -4,5 +4,38 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use rustc_middle::ty;
+
 pub mod to_string;
 pub mod type_visitor;
+
+pub fn ty_to_string(typ: &ty::TyKind) -> String {
+    (match typ {
+        &ty::TyKind::Bool => "bool type",
+        &ty::TyKind::Char => "char type",
+        &ty::TyKind::Int(_) => "int type",
+        &ty::TyKind::Uint(_) => "uint type",
+        &ty::TyKind::Float(_) => "float type",
+        &ty::TyKind::Adt(_, _) => "algebraic data type",
+        &ty::TyKind::Foreign(_) => "foreign function interface",
+        &ty::TyKind::Str => "string",
+        &ty::TyKind::Array(..) => "array",
+        &ty::TyKind::Slice(_) => "array slice",
+        &ty::TyKind::RawPtr(_) => "raw pointer",
+        &ty::TyKind::Ref(..) => "reference",
+        &ty::TyKind::FnDef(_, _) => "function defintion",
+        &ty::TyKind::FnPtr(_) => "function pointer",
+        &ty::TyKind::Dynamic(..) => "trait object",
+        &ty::TyKind::Closure(_, _) => "closures",
+        &ty::TyKind::Generator(..) | &ty::TyKind::GeneratorWitness(..) => "generator",
+        &ty::TyKind::Never => "never type",
+        &ty::TyKind::Tuple(_) => "tuple",
+        &ty::TyKind::Projection(_) => "projection",
+        &ty::TyKind::Opaque(_, _) => "opaque type",
+        &ty::TyKind::Param(_) => "type parameter",
+        &ty::TyKind::Bound(_, _) => "bound type variable",
+        &ty::TyKind::Placeholder(_) => "placeholder type",
+        &ty::TyKind::Infer(_) => "inference type",
+        &ty::TyKind::Error(_) => "error type",
+    }).to_string()
+}


### PR DESCRIPTION
This PR adds a new function to convert `ty::TyKind` to `String` for easy error generation. Also, this PR replaces two panics with an internal error message using this new added function.