### PR TITLE
Adding Unsupported variant to FoldUnfoldError for two phase borrow

### DIFF
--- a/prusti-tests/tests/verify/fail/unsupported/two_phase_borrow.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/two_phase_borrow.rs
@@ -1,6 +1,6 @@
 fn foo(a: &mut [i32], l: usize) {}
  
-fn bar(a: &mut [i32]) {  //~ ERROR two stage borrow is not supported
+fn bar(a: &mut [i32]) {  //~ ERROR two phase borrow is not supported
     foo(a, a.len());
 }
  

--- a/prusti-tests/tests/verify/fail/unsupported/two_phase_borrow.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/two_phase_borrow.rs
@@ -1,6 +1,6 @@
 fn foo(a: &mut [i32], l: usize) {}
  
-fn bar(a: &mut [i32]) {  //~ ERROR two phase borrow is not supported
+fn bar(a: &mut [i32]) {  //~ ERROR two-phase borrows are not supported
     foo(a, a.len());
 }
  

--- a/prusti-tests/tests/verify/fail/unsupported/two_stage_borrow.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/two_stage_borrow.rs
@@ -1,0 +1,7 @@
+fn foo(a: &mut [i32], l: usize) {}
+ 
+fn bar(a: &mut [i32]) {  //~ ERROR two stage borrow is not supported
+    foo(a, a.len());
+}
+ 
+fn main() {}

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -60,6 +60,8 @@ pub enum FoldUnfoldError {
     FailedToRemovePred(vir::Expr),
     /// The algorithm tried to lookup a never-seen-before label
     MissingLabel(String),
+    /// Unsupported feature
+    Unsupported(String),
 }
 
 impl From<PermAmountError> for FoldUnfoldError {

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -83,11 +83,9 @@ impl ApplyOnState for vir::Stmt {
                     assert!(rhs.get_type().is_ref());
 
                     // Check that the rhs contains no moved paths
-                    assert!(
-                        !state.is_prefix_of_some_moved(&rhs),
-                        "The rhs place of statement '{}' is currently moved-out or blocked due to a borrow",
-                        self
-                    );
+                    if state.is_prefix_of_some_moved(&rhs) {
+                        return Err(FoldUnfoldError::Unsupported("two stage borrow is not supported".to_string()));
+                    }
                     for prefix in rhs.all_proper_prefixes() {
                         assert!(!state.contains_pred(&prefix));
                     }

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -84,7 +84,7 @@ impl ApplyOnState for vir::Stmt {
 
                     // Check that the rhs contains no moved paths
                     if state.is_prefix_of_some_moved(&rhs) {
-                        return Err(FoldUnfoldError::Unsupported("two stage borrow is not supported".to_string()));
+                        return Err(FoldUnfoldError::Unsupported("two phase borrow is not supported".to_string()));
                     }
                     for prefix in rhs.all_proper_prefixes() {
                         assert!(!state.contains_pred(&prefix));

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -83,7 +83,7 @@ impl ApplyOnState for vir::Stmt {
                     assert!(rhs.get_type().is_ref());
 
                     // Check that the rhs contains no moved paths
-                    if state.is_prefix_of_some_moved(&rhs) {
+                    if state.is_prefix_of_some_moved(rhs) {
                         return Err(FoldUnfoldError::Unsupported("two-phase borrows are not supported".to_string()));
                     }
                     for prefix in rhs.all_proper_prefixes() {

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -84,7 +84,7 @@ impl ApplyOnState for vir::Stmt {
 
                     // Check that the rhs contains no moved paths
                     if state.is_prefix_of_some_moved(&rhs) {
-                        return Err(FoldUnfoldError::Unsupported("two phase borrow is not supported".to_string()));
+                        return Err(FoldUnfoldError::Unsupported("two-phase borrows are not supported".to_string()));
                     }
                     for prefix in rhs.all_proper_prefixes() {
                         assert!(!state.contains_pred(&prefix));

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -488,13 +488,21 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             method_pos,
         )
         .map_err(|foldunfold_error| {
-            SpannedEncodingError::internal(
-                format!(
-                    "generating fold-unfold Viper statements failed ({:?})",
-                    foldunfold_error
-                ),
-                mir_span,
-            )
+            match foldunfold_error {
+                foldunfold::FoldUnfoldError::Unsupported(msg) => {
+                    SpannedEncodingError::unsupported(msg, mir_span)
+                }
+                
+                _ => {
+                    SpannedEncodingError::internal(
+                        format!(
+                            "generating fold-unfold Viper statements failed ({:?})",
+                            foldunfold_error
+                        ),
+                        mir_span,
+                    )
+                }
+            }
         })?;
 
         // Fix variable declarations.

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -493,15 +493,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     SpannedEncodingError::unsupported(msg, mir_span)
                 }
                 
-                _ => {
-                    SpannedEncodingError::internal(
-                        format!(
-                            "generating fold-unfold Viper statements failed ({:?})",
-                            foldunfold_error
-                        ),
-                        mir_span,
-                    )
-                }
+                _ => SpannedEncodingError::internal(
+                    format!(
+                        "generating fold-unfold Viper statements failed ({:?})",
+                        foldunfold_error,
+                    ),
+                    mir_span,
+                ),
             }
         })?;
 


### PR DESCRIPTION
[Two phase borrows](https://rustc-dev-guide.rust-lang.org/borrow_check/two_phase_borrows.html) fail this [assert](https://github.com/viperproject/prusti-dev/blob/0627a49a81b82cf09057d14fd824b1df6d8ae861/prusti-viper/src/encoder/foldunfold/semantics.rs#L86-L90). This cannot be caught outside `foldunfold` as it uses the foldunfold state. Hence, this PR adds `Unsupported` variant to `FoldUnfoldError`, to report this error.