### PR TITLE
Fix panic caused by constant tuples

### DIFF
--- a/prusti-tests/tests/verify/fail/unsupported/const_tuple.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/const_tuple.rs
@@ -1,0 +1,7 @@
+// Testcase to check for constant tuples
+
+const C: (i32, i32) = (0, 0);
+
+fn main() {
+    let _ = C.0;  //~ERROR the encoding of this reference copy has not been implemented
+}

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -4902,38 +4902,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         stmts
                     }
                 }
-
-                // FIXME: Delete the code below.
-                // match literal {
-                //     mir::Literal::Value { value } => {
-                //         let const_val = self.encoder.encode_const_expr(value);
-                //         // Initialize value of lhs
-                //         stmts.push(vir::Stmt::Assign(
-                //             lhs.clone().field(field),
-                //             const_val,
-                //             vir::AssignKind::Copy,
-                //         ));
-                //     }
-                //     mir::Literal::Promoted { index } => {
-                //         trace!("promoted constant literal {:?}: {:?}", index, ty);
-                //         trace!("{:?}", self.mir.promoted[*index].basic_blocks());
-                //         trace!(
-                //             "{:?}",
-                //             self.mir.promoted[*index]
-                //                 .basic_blocks()
-                //                 .into_iter()
-                //                 .next()
-                //                 .unwrap()
-                //                 .statements[0]
-                //         );
-                //         // TODO: call eval_const
-                //         debug!(
-                //             "Encoding of promoted constant literal '{:?}: {:?}' is incomplete",
-                //             index, ty
-                //         );
-                //         // Workaround: do not initialize values
-                //     }
-                // }
             }
         };
         debug!(

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -4879,36 +4879,28 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     mir::ConstantKind::Ty(ty::Const { ty, val }) => (ty, *val),
                     mir::ConstantKind::Val(val, ty) => (ty, ty::ConstKind::Value(*val)),
                 };
-                if let ty::TyKind::Tuple(elements) = ty.kind() {
-                    // FIXME: This is most likley completely wrong. We need to
-                    // implement proper support for handling constants of
-                    // non-primitive types.
-                    if !elements.is_empty() {
-                        unimplemented!("Only ZSTs are currently supported, got: {:?}", elements);
+                match ty.kind() {
+                    ty::TyKind::Tuple(elements) if elements.is_empty() => Vec::new(),
+                    _ => {
+                        let field = self.encoder.encode_value_field(ty).with_span(span)?;
+                        let mut stmts = self.prepare_assign_target(
+                            lhs.clone(),
+                            field.clone(),
+                            location,
+                            vir::AssignKind::Copy,
+                        )?;
+                        // Initialize the constant
+                        let const_val = self.encoder
+                            .encode_const_expr(*ty, &val)
+                            .with_span(span)?;
+                        // Initialize value of lhs
+                        stmts.push(vir::Stmt::Assign(
+                            lhs.clone().field(field),
+                            const_val,
+                            vir::AssignKind::Copy,
+                        ));
+                        stmts
                     }
-                    // Since we have a ZST, we do not need to do anything to
-                    // encode it.
-                    Vec::new()
-                } else {
-                    // We expect to have a constant of a primitive type here.
-                    let field = self.encoder.encode_value_field(ty).with_span(span)?;
-                    let mut stmts = self.prepare_assign_target(
-                        lhs.clone(),
-                        field.clone(),
-                        location,
-                        vir::AssignKind::Copy,
-                    )?;
-                    // Initialize the constant
-                    let const_val = self.encoder
-                        .encode_const_expr(*ty, &val)
-                        .with_span(span)?;
-                    // Initialize value of lhs
-                    stmts.push(vir::Stmt::Assign(
-                        lhs.clone().field(field),
-                        const_val,
-                        vir::AssignKind::Copy,
-                    ));
-                    stmts
                 }
 
                 // FIXME: Delete the code below.


### PR DESCRIPTION
This PR fixes panic caused by the below program by matching the case with the proper branch
```
const C: (i32, i32) = (0, 0);

fn main() {
    let _ = C.0;
}
```