### PR TITLE
Update Rustc version to 2021-07-17.

### DIFF
--- a/prusti-tests/tests/cargo_verify/failing_crate/output.stderr
+++ b/prusti-tests/tests/cargo_verify/failing_crate/output.stderr
@@ -12,8 +12,4 @@ note: the failing assertion is here
 3 | #[requires(x > 999)]
   |            ^^^^^^^
 
-error: aborting due to previous error
-
-error: could not compile `failing_crate`
-
-To learn more, run the command again with --verbose.
+error: could not compile `failing_crate` due to previous error

--- a/prusti-tests/tests/cargotest.rs
+++ b/prusti-tests/tests/cargotest.rs
@@ -65,11 +65,7 @@ fn simple_assert_false() {
   |
   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-[ERROR] aborting due to previous error
-
-[ERROR] could not compile `foo`
-
-To learn more, run the command again with --verbose.
+error: could not compile `foo` due to previous error
 ",
         )
         .run();

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-07-15"
+channel = "nightly-2021-07-17"
 components = [ "rustc-dev", "llvm-tools-preview" ]
 profile = "minimal"


### PR DESCRIPTION
Checking whether [the cargo workaround](https://github.com/rust-lang/cargo/pull/9695) fixes our network issues.