### PR TITLE
Return unsupported error for raw pointers

### DIFF
--- a/prusti-tests/tests/verify/fail/unsupported/rawptr.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/rawptr.rs
@@ -1,3 +1,7 @@
+fn foo(p: *const i32) {
+    let _ = p.is_null();    //~ ERROR raw pointers are not supported
+}
+
 fn main() {
     let _: *const i32 = std::ptr::null_mut();   //~ ERROR raw pointers are not supported
 }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -4850,23 +4850,30 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
             mir::Operand::Copy(ref place) => {
                 let (src, mut stmts, ty, _) = self.encode_place(place, ArrayAccessKind::Shared).with_span(span)?;
-                let encode_stmts = if self.mir_encoder.is_reference(ty) {
-                    let loan = self.polonius_info().get_loan_at_location(location);
-                    let ref_field = self.encoder.encode_value_field(ty).with_span(span)?;
-                    let mut stmts = self.prepare_assign_target(
-                        lhs.clone(),
-                        ref_field.clone(),
-                        location,
-                        vir::AssignKind::SharedBorrow(loan.into()),
-                    )?;
-                    stmts.push(vir::Stmt::Assign(
-                        lhs.clone().field(ref_field.clone()),
-                        src.field(ref_field),
-                        vir::AssignKind::SharedBorrow(loan.into()),
-                    ));
-                    stmts
-                } else {
-                    self.encode_copy2(src, lhs.clone(), ty, location)?
+                let encode_stmts = match ty.kind() {
+                    ty::TyKind::RawPtr(..) => {
+                        return Err(SpannedEncodingError::unsupported(
+                            "raw pointers are not supported",
+                            span,
+                        ));
+                    }
+                    ty::TyKind::Ref(..) => {
+                        let loan = self.polonius_info().get_loan_at_location(location);
+                        let ref_field = self.encoder.encode_value_field(ty).with_span(span)?;
+                        let mut stmts = self.prepare_assign_target(
+                            lhs.clone(),
+                            ref_field.clone(),
+                            location,
+                            vir::AssignKind::SharedBorrow(loan.into()),
+                        )?;
+                        stmts.push(vir::Stmt::Assign(
+                            lhs.clone().field(ref_field.clone()),
+                            src.field(ref_field),
+                            vir::AssignKind::SharedBorrow(loan.into()),
+                        ));
+                        stmts
+                    }
+                    _ => self.encode_copy2(src, lhs.clone(), ty, location)?,
                 };
 
                 stmts.extend(encode_stmts);


### PR DESCRIPTION
This PR fixes the panic caused by the call to [`get_loan_at_location`](https://github.com/viperproject/prusti-dev/blob/e728991acee17d6301dc3b5db610e797ce6632e4/prusti-viper/src/encoder/procedure_encoder.rs#L4854) in the case of raw pointers.