### PR TITLE
Interpret numbers as decimal

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -25,7 +25,7 @@ jobs:
           echo "The latest usable version of rustc is $NIGHTLY_VERSION"
           sed -i 's/^channel\s*=.*$/channel = "'"$NIGHTLY_VERSION"'"/' rust-toolchain
           declare -a DEVELOPERS=(Aurel300 fpoli vakaras)
-          UPDATE_NUMBER=$(( $(date +%m) * 2 + ($(date +%d) / 15) - 2 ))
+          UPDATE_NUMBER=$(( 10#$(date +%m) * 2 + (10#$(date +%d) / 15) - 2 ))
           DEVELOPER="${DEVELOPERS[ $UPDATE_NUMBER % ${#DEVELOPERS[@]} ]}"
           echo "The assigned developer is $DEVELOPER"
           OUTDATED_DEPENDENCIES="$(cargo outdated --root-deps-only --workspace)"


### PR DESCRIPTION
Apparently, `$(( .. ))` interprets numbers starting with `0` as octals 🤯

See https://stackoverflow.com/questions/21049822/value-too-great-for-base-error-token-is-09

This should fix cases like https://github.com/viperproject/prusti-dev/pull/638.