### PR TITLE
Return empty vector for no mir funcs or constructors

### DIFF
--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -752,6 +752,10 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     pub fn encode_spec_funcs(&self, def_id: ProcedureDefId)
         -> SpannedEncodingResult<Vec<vir::FunctionIdentifier>>
     {
+        if !self.env().tcx().is_mir_available(def_id) || self.env().tcx().is_constructor(def_id) {
+            return Ok(Vec::new());
+        }
+
         if !self.spec_functions.borrow().contains_key(&def_id) {
             let procedure = self.env.get_procedure(def_id);
             let spec_func_encoder = SpecFunctionEncoder::new(self, &procedure);

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -753,7 +753,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         -> SpannedEncodingResult<Vec<vir::FunctionIdentifier>>
     {
         if !self.env().tcx().is_mir_available(def_id) || self.env().tcx().is_constructor(def_id) {
-            return Ok(Vec::new());
+            return Ok(vec![]);
         }
 
         if !self.spec_functions.borrow().contains_key(&def_id) {


### PR DESCRIPTION
This PR fixes the panic caused by the call to `mir_promoted` [here](https://github.com/viperproject/prusti-dev/blob/4d357da8e70c88d1d66c3c4a7da2eb5b4f935fae/prusti-interface/src/environment/procedure.rs#L40). The panic was caused by the functions with no mir present. Hence for these cases, an empty vector is returned before the panic point is reached.