### PR TITLE
Remove prefix from field name

### DIFF
--- a/prusti-tests/tests/verify/pass/quick/struct.rs
+++ b/prusti-tests/tests/verify/pass/quick/struct.rs
@@ -14,5 +14,10 @@ fn check_bar_fn(foo: &Foo) {
 fn check_rtype_fn(foo: &Foo) {
 }
 
+#[pure]
+fn rtype_same(foo1: &Foo, foo2: &Foo) -> bool {
+    foo1.r#type == foo2.r#type
+}
+
 fn main(){
 }

--- a/prusti-tests/tests/verify/pass/quick/struct.rs
+++ b/prusti-tests/tests/verify/pass/quick/struct.rs
@@ -1,0 +1,18 @@
+extern crate prusti_contracts;
+use prusti_contracts::*;
+
+struct Foo {
+    bar: i32,
+    r#type: i32
+}
+
+#[requires(foo.bar == 1)]
+fn check_bar_fn(foo: &Foo) {
+}
+
+#[requires(foo.r#type == 1)]
+fn check_rtype_fn(foo: &Foo) {
+}
+
+fn main(){
+}

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -477,7 +477,8 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     pub fn encode_struct_field(&self, field_name: &str, ty: ty::Ty<'tcx>)
     -> EncodingResult<vir::Field>
     {
-        let viper_field_name = format!("f${}", field_name);
+        // If the field name is a raw identifier, removing the leading prefix r#
+        let viper_field_name = format!("f${}", field_name.trim_start_matches("r#"));
         self.encode_raw_ref_field(viper_field_name, ty)
     }
 

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -107,6 +107,11 @@ pub struct Encoder<'v, 'tcx: 'v> {
 pub type SubstMap<'tcx> = HashMap<ty::Ty<'tcx>, ty::Ty<'tcx>>;
 pub type SubstStack<'tcx> = Vec<SubstMap<'tcx>>;
 
+// If the field name is an identifier, removing the leading prefix r#
+pub fn encode_field_name(field_name: &str) -> String {
+   format!("f${}", field_name.trim_start_matches("r#"))
+}
+
 impl<'v, 'tcx> Encoder<'v, 'tcx> {
     pub fn new(
         env: &'v Environment<'tcx>,
@@ -477,9 +482,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     pub fn encode_struct_field(&self, field_name: &str, ty: ty::Ty<'tcx>)
     -> EncodingResult<vir::Field>
     {
-        // If the field name is a raw identifier, removing the leading prefix r#
-        let viper_field_name = format!("f${}", field_name.trim_start_matches("r#"));
-        self.encode_raw_ref_field(viper_field_name, ty)
+        self.encode_raw_ref_field(encode_field_name(field_name), ty)
     }
 
     /// Creates a field that corresponds to the enum variant ``index``.

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -20,7 +20,7 @@ use vir_crate::polymorphic::{
     EnumVariantIndex, ExprIterator, ContainerOpKind, WithIdentifier,
     Type, Expr,
 };
-use crate::encoder::encoder::SubstMap;
+use crate::encoder::encoder::{SubstMap, encode_field_name};
 use crate::encoder::{
     Encoder,
     array_encoder::{EncodedArrayTypes, EncodedSliceTypes},
@@ -685,7 +685,7 @@ impl SnapshotEncoder {
                 for field in adt_def.all_fields() { // or adt_def.variants[0].fields ?
                     let field_ty = field.ty(tcx, subst);
                     fields.push(SnapshotField {
-                        name: format!("f${}", field.ident),
+                        name: encode_field_name(&field.ident.to_string()),
                         access: self.snap_app(encoder, Expr::field(
                             arg_expr.clone(),
                             encoder.encode_struct_field(&field.ident.to_string(), field_ty)?,
@@ -721,7 +721,7 @@ impl SnapshotEncoder {
                     for field in &variant.fields {
                         let field_ty = field.ty(tcx, subst);
                         fields.push(SnapshotField {
-                            name: format!("f${}", field.ident),
+                            name: encode_field_name(&field.ident.to_string()),
                             access: self.snap_app(encoder, Expr::field(
                                 field_base.clone(),
                                 encoder.encode_struct_field(&field.ident.to_string(), field_ty)?,


### PR DESCRIPTION
Rust allows raw identifiers in struct definitions, to encode fields that clash with reserved keywords. For example:

```rust
struct Foo {
    bar: i32,
    r#type: i32
}
```

However, the `#` is not valid in Viper, so referencing the field causes an error

`error: [Prusti internal error] consistency error in check_bar_fn: Consistency error: f$r#type is not a valid identifier`

This PR changes the encoding of the struct field to remove the `r#` prefix.

