### PR TITLE
Improve error message for types missing structural equality

### DIFF
--- a/prusti-tests/tests/verify/ui/no-structural-eq.rs
+++ b/prusti-tests/tests/verify/ui/no-structural-eq.rs
@@ -1,0 +1,9 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+#[requires(a[0..2] == [0, 0])]
+pub fn foo(a: [i32; 5]) {
+    assert!(a[0] == 0);
+    assert!(a[1] == 0);
+}

--- a/prusti-tests/tests/verify/ui/no-structural-eq.stderr
+++ b/prusti-tests/tests/verify/ui/no-structural-eq.stderr
@@ -1,0 +1,8 @@
+error: [Prusti: invalid specification] cannot compare values of type &[i32] in specifications, as it has no structural equality
+ --> $DIR/no-structural-eq.rs:5:12
+  |
+5 | #[requires(a[0..2] == [0, 0])]
+  |            ^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Previously, the error was along the lines of "cannot call impure
function PartialEq::eq from specifications/pure code", which is
confusing for users, because equality is OK most of the time, and the
problem is comparing types without structural equality in
specifications, as missing structural equality likely means we can't
capture what makes two instances equal/different in snapshots.

also, maybe slices should be declared to have structural equality, but
that would likely require more changes as slices mostly occur behind
references, so some reference types would have it, while others don't..