### PR TITLE
Update dependencies (nightly-2021-09-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.1.0"
 dependencies = [
  "compiletest_rs",
  "log 0.4.14",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_json",
 ]
 
@@ -143,7 +143,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.130",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.127",
+ "serde 1.0.130",
 ]
 
 [[package]]
@@ -226,19 +226,19 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cargo-test-macro"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/cargo.git#ddf9adba1afb4654edba09ca2b62a59979fcd895"
+source = "git+https://github.com/rust-lang/cargo.git#72aee9e8152268d54bb6e23c03d6f2148c5747d1"
 
 [[package]]
 name = "cargo-test-support"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/cargo.git#ddf9adba1afb4654edba09ca2b62a59979fcd895"
+source = "git+https://github.com/rust-lang/cargo.git#72aee9e8152268d54bb6e23c03d6f2148c5747d1"
 dependencies = [
  "anyhow",
  "cargo-test-macro",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "cargo-util"
 version = "0.1.1"
-source = "git+https://github.com/rust-lang/cargo.git#ddf9adba1afb4654edba09ca2b62a59979fcd895"
+source = "git+https://github.com/rust-lang/cargo.git#72aee9e8152268d54bb6e23c03d6f2148c5747d1"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 dependencies = [
  "jobserver",
 ]
@@ -361,11 +361,11 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
+checksum = "a909e4d93292cd8e9c42e189f61681eff9d67b6541f96b8a1a737f23737bd001"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "memchr",
 ]
 
@@ -402,7 +402,7 @@ dependencies = [
  "miow 0.3.7",
  "regex",
  "rustfix",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_derive",
  "serde_json",
  "tester",
@@ -418,7 +418,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -446,7 +446,7 @@ dependencies = [
  "idna 0.1.5",
  "log 0.4.14",
  "publicsuffix",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_json",
  "time",
  "try_from",
@@ -592,7 +592,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.130",
 ]
 
 [[package]]
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -835,9 +835,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-cpupool"
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
@@ -864,15 +864,15 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg 1.0.1",
  "futures-core",
@@ -1040,7 +1040,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "itoa",
 ]
@@ -1059,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "humantime"
@@ -1140,7 +1140,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52fb664a32d8c1f30a4693137066dd1c3bd67c8edc544281ec3d7cdc8230ed32"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.130",
 ]
 
 [[package]]
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jni"
@@ -1217,18 +1217,18 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ca711fd837261e14ec9e674f092cbb931d3fa1482b017ae59328ddc6f3212b"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libgit2-sys"
@@ -1355,9 +1355,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
@@ -1642,9 +1642,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1662,9 +1662,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -1788,9 +1788,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -1821,7 +1821,7 @@ dependencies = [
  "log 0.4.14",
  "prusti-utils",
  "regex",
- "serde 1.0.127",
+ "serde 1.0.130",
  "uuid 0.8.2",
  "viper",
  "vir",
@@ -1868,7 +1868,7 @@ dependencies = [
  "prusti-utils",
  "regex",
  "rustc-hash",
- "serde 1.0.127",
+ "serde 1.0.130",
  "vir",
 ]
 
@@ -1879,7 +1879,7 @@ dependencies = [
  "ctrlc",
  "glob",
  "nix 0.22.1",
- "serde 1.0.127",
+ "serde 1.0.130",
  "toml",
  "walkdir",
 ]
@@ -1897,7 +1897,7 @@ dependencies = [
  "num_cpus",
  "prusti-common",
  "reqwest",
- "serde 1.0.127",
+ "serde 1.0.130",
  "tokio 0.1.22",
  "viper",
  "warp",
@@ -1910,7 +1910,7 @@ dependencies = [
  "proc-macro2",
  "prusti-utils",
  "quote",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_json",
  "syn",
  "uuid 0.8.2",
@@ -1944,7 +1944,7 @@ dependencies = [
  "prusti-server",
  "prusti-specs",
  "regex",
- "serde 1.0.127",
+ "serde 1.0.130",
  "viper",
  "vir",
 ]
@@ -2298,7 +2298,7 @@ dependencies = [
  "mime 0.3.16",
  "mime_guess 2.0.3",
  "native-tls",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_json",
  "serde_urlencoded 0.5.5",
  "time",
@@ -2335,9 +2335,9 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"
@@ -2362,7 +2362,7 @@ checksum = "f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e"
 dependencies = [
  "anyhow",
  "log 0.4.14",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_json",
 ]
 
@@ -2387,9 +2387,9 @@ checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "rustwide"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d992b62e3d6559d0ef9fdd666d59942037dadca58c0625c896fc223e31ab3"
+checksum = "fad1c7516d4138e9f7bf4b0f56d41585f5aa1ba57dce6df34b4e90ba9db7d18b"
 dependencies = [
  "attohttpc",
  "base64 0.13.0",
@@ -2406,12 +2406,12 @@ dependencies = [
  "percent-encoding 2.1.0",
  "remove_dir_all 0.7.0",
  "scopeguard",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_json",
  "tar",
  "tempfile",
  "thiserror",
- "tokio 1.10.0",
+ "tokio 1.11.0",
  "tokio-stream",
  "toml",
  "walkdir",
@@ -2486,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.3.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2517,9 +2517,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -2538,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2549,13 +2549,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.130",
 ]
 
 [[package]]
@@ -2566,7 +2566,7 @@ checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.127",
+ "serde 1.0.130",
  "url 1.7.2",
 ]
 
@@ -2578,7 +2578,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.127",
+ "serde 1.0.130",
  "url 2.2.2",
 ]
 
@@ -2659,9 +2659,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2759,7 +2759,7 @@ dependencies = [
  "prusti",
  "prusti-launch",
  "rustwide",
- "serde 1.0.127",
+ "serde 1.0.130",
  "toml",
 ]
 
@@ -2787,18 +2787,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2856,12 +2856,12 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg 1.0.1",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "libc",
  "memchr",
  "mio 0.7.13",
@@ -2963,7 +2963,7 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio 1.10.0",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -3058,7 +3058,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.130",
 ]
 
 [[package]]
@@ -3084,7 +3084,7 @@ checksum = "5bdaf2a1d317f3d58b44b31c7f6436b9b9acafe7bddfeace50897c2b804d7792"
 dependencies = [
  "glob",
  "lazy_static",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_json",
  "termcolor",
  "toml",
@@ -3177,9 +3177,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2475a6781e9bc546e7b64f4013d2f4032c8c6a40fcffd7c6f4ee734a890972ab"
+checksum = "3131cd6cb18488da91da1d10ed31e966f453c06b65bf010d35638456976a3fd7"
 dependencies = [
  "base64 0.13.0",
  "chunked_transfer",
@@ -3242,7 +3242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
- "serde 1.0.127",
+ "serde 1.0.130",
 ]
 
 [[package]]
@@ -3279,7 +3279,7 @@ dependencies = [
  "jni",
  "lazy_static",
  "log 0.4.14",
- "serde 1.0.127",
+ "serde 1.0.130",
  "uuid 0.8.2",
  "viper-sys",
 ]
@@ -3309,7 +3309,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "serde 1.0.127",
+ "serde 1.0.130",
  "syn",
  "thiserror",
  "uuid 0.8.2",
@@ -3364,7 +3364,7 @@ dependencies = [
  "mime_guess 2.0.3",
  "multipart",
  "scoped-tls",
- "serde 1.0.127",
+ "serde 1.0.130",
  "serde_json",
  "serde_urlencoded 0.6.1",
  "tokio 0.1.22",
@@ -3388,9 +3388,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3398,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3413,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3423,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3436,15 +3436,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/prusti-tests/tests/parse/ui/predicates.stdout
+++ b/prusti-tests/tests/parse/ui/predicates.stdout
@@ -41,20 +41,21 @@ fn prusti_pred_item_pred1_$(NUM_UUID)(a: bool) {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn pred1(a: bool) -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::spec_only]
@@ -91,20 +92,21 @@ fn prusti_pred_item_pred2_$(NUM_UUID)(a: bool) {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn pred2(a: bool) -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::spec_only]
@@ -145,20 +147,21 @@ fn prusti_pred_item_forall_implication_$(NUM_UUID)() {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn forall_implication() -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::spec_only]
@@ -186,20 +189,21 @@ fn prusti_pred_item_exists_implication_$(NUM_UUID)() {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn exists_implication() -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 fn main() { }
 Procedure(ProcedureSpecification { pres: [Assertion { kind: Expr(Expression { spec_id: SpecificationId($(UUID)), id: ExpressionId(101), expr: DefId(0:10 ~ predicates[$(CRATE_ID)]::prusti_pre_item_use_pred1_$(NUM_UUID)::{closure#0}) }) }], posts: [], pledges: [], predicate_body: None, pure: false, trusted: false })

--- a/prusti-tests/tests/verify/ui/predicate.stdout
+++ b/prusti-tests/tests/verify/ui/predicate.stdout
@@ -48,20 +48,21 @@ fn prusti_pred_item_true_p1_$(NUM_UUID)() {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn true_p1() -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::spec_only]
@@ -85,20 +86,21 @@ fn prusti_pred_item_true_p2_$(NUM_UUID)() {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn true_p2() -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::spec_only]
@@ -122,20 +124,21 @@ fn prusti_pred_item_forall_identity_$(NUM_UUID)() {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn forall_identity() -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::spec_only]
@@ -163,20 +166,21 @@ fn prusti_pred_item_exists_identity_$(NUM_UUID)() {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn exists_identity() -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::spec_only]
@@ -244,20 +248,21 @@ fn prusti_pred_item_false_p_$(NUM_UUID)() {
 #[prusti::trusted]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 fn false_p() -> bool {
-    ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(&["not implemented: "],
-                                                                &match (&::core::fmt::Arguments::new_v1(&["predicate"],
-                                                                                                        &match ()
-                                                                                                             {
-                                                                                                             ()
-                                                                                                             =>
-                                                                                                             [],
-                                                                                                         }),)
-                                                                     {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                   ::core::fmt::Display::fmt)],
-                                                                 }))
+    ::core::panicking::panic_fmt(match match (&match match () { () => [], } {
+                                                   ref args => unsafe {
+                                                       ::core::fmt::Arguments::new_v1(&["predicate"],
+                                                                                      args)
+                                                   }
+                                               },) {
+                                           (arg0,) =>
+                                           [::core::fmt::ArgumentV1::new(arg0,
+                                                                         ::core::fmt::Display::fmt)],
+                                       } {
+                                     ref args => unsafe {
+                                         ::core::fmt::Arguments::new_v1(&["not implemented: "],
+                                                                        args)
+                                     }
+                                 })
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::spec_only]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-08-19"
+channel = "nightly-2021-09-01"
 components = [ "rustc-dev", "llvm-tools-preview" ]
 profile = "minimal"

--- a/test-crates/Cargo.toml
+++ b/test-crates/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 prusti-launch = { path = "../prusti-launch" }
 prusti = { path = "../prusti" }
 color-backtrace = "0.5"
-rustwide = "0.13.1"
+rustwide = "0.14.0"
 env_logger = "0.9"
 log = "0.4.14"
 csv = "1.1.5"


### PR DESCRIPTION
* [x] Update rustc version to `nightly-2021-09-01`.
* [x] Manualy update outdated dependencies (see the list below).
* [x] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ cargo outdated --root-deps-only --workspace

analysis
================
Name        Project  Compat  Latest   Kind    Platform
----        -------  ------  ------   ----    --------
serde       1.0.127  ---     1.0.130  Normal  ---
serde_json  1.0.66   ---     1.0.67   Normal  ---

prusti-common
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
serde  1.0.127  ---     1.0.130  Normal  ---

viper
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
serde  1.0.127  ---     1.0.130  Normal  ---

viper-sys
================
Name  Project  Compat  Latest  Kind   Platform
----  -------  ------  ------  ----   --------
ureq  2.1.1    ---     2.2.0   Build  ---

vir
================
Name         Project  Compat  Latest   Kind    Platform
----         -------  ------  ------   ----    --------
proc-macro2  1.0.28   ---     1.0.29   Normal  ---
serde        1.0.127  ---     1.0.130  Normal  ---
syn          1.0.74   ---     1.0.75   Normal  ---
thiserror    1.0.26   ---     1.0.28   Normal  ---

vir-gen
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.28   ---     1.0.29  Normal  ---
syn          1.0.74   ---     1.0.75  Normal  ---

prusti-contracts-impl
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.28   ---     1.0.29  Normal  ---

prusti-specs
================
Name         Project  Compat  Latest   Kind    Platform
----         -------  ------  ------   ----    --------
proc-macro2  1.0.28   ---     1.0.29   Normal  ---
serde        1.0.127  ---     1.0.130  Normal  ---
serde_json   1.0.66   ---     1.0.67   Normal  ---
syn          1.0.74   ---     1.0.75   Normal  ---

prusti-contracts-internal
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.28   ---     1.0.29  Normal  ---

prusti-interface
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
serde  1.0.127  ---     1.0.130  Normal  ---

prusti-viper
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
serde  1.0.127  ---     1.0.130  Normal  ---

prusti-server
================
Name     Project  Compat  Latest   Kind    Platform
----     -------  ------  ------   ----    --------
futures  0.1.31   ---     0.3.17   Normal  ---
reqwest  0.9.24   ---     0.11.4   Normal  ---
serde    1.0.127  ---     1.0.130  Normal  ---
tokio    0.1.22   ---     1.11.0   Normal  ---
warp     0.1.23   ---     0.3.1    Normal  ---

prusti-launch
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
serde  1.0.127  ---     1.0.130  Normal  ---

test-crates
================
Name      Project  Compat  Latest   Kind    Platform
----      -------  ------  ------   ----    --------
rustwide  0.13.1   ---     0.14.0   Normal  ---
serde     1.0.127  ---     1.0.130  Normal  ---

systest
================
Name  Project  Compat  Latest  Kind   Platform
----  -------  ------  ------  ----   --------
ureq  2.1.1    ---     2.2.0   Build  ---
```
</details>

@fpoli could you take care of this?