### PR TITLE
Add rust-std to rust-toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "nightly-2021-09-01"
-components = [ "rustc-dev", "llvm-tools-preview" ]
+components = [ "rustc-dev", "llvm-tools-preview", "rust-std" ]
 profile = "minimal"


### PR DESCRIPTION
I needed this component with a fresh installation on M1 Mac. Resolves #667