### PR TITLE
Move cargo-prusti's output to target/verify

### DIFF
--- a/prusti-common/src/verification_context.rs
+++ b/prusti-common/src/verification_context.rs
@@ -77,6 +77,11 @@ impl<'v> VerificationContext<'v> {
             }
         } else {
             report_path = None;
+            if backend_config.backend == VerificationBackend::Silicon {
+                verifier_args.extend(vec![
+                    "--disableTempDirectory".to_string(),
+                ]);
+            }
         }
 
         self.verification_ctx.new_verifier_with_args(

--- a/prusti-common/src/verification_context.rs
+++ b/prusti-common/src/verification_context.rs
@@ -56,36 +56,33 @@ impl<'v> VerificationContext<'v> {
         backend_config: &ViperBackendConfig,
     ) -> viper::Verifier<viper::state::Started> {
         let mut verifier_args: Vec<String> = backend_config.verifier_args.clone();
-        let log_path: PathBuf = PathBuf::from(config::log_dir()).join("viper_tmp");
-        create_dir_all(&log_path).unwrap();
-        let report_path: PathBuf = log_path.join("report.csv");
-        let log_dir_str = log_path.to_str().unwrap();
-        match backend_config.backend {
-            VerificationBackend::Silicon => verifier_args.extend(vec![
-                "--tempDirectory".to_string(),
-                log_dir_str.to_string(),
-            ]),
-            VerificationBackend::Carbon => verifier_args.extend(vec![
-                "--boogieOpt".to_string(),
-                format!("/logPrefix {}", log_dir_str),
-            ]),
-        }
+        let report_path: Option<PathBuf>;
         if config::dump_debug_info() {
+            let log_path: PathBuf = PathBuf::from(config::log_dir()).join("viper_tmp");
+            create_dir_all(&log_path).unwrap();
+            report_path = Some(log_path.join("report.csv"));
+            let log_dir_str = log_path.to_str().unwrap();
             match backend_config.backend {
                 VerificationBackend::Silicon => verifier_args.extend(vec![
+                    "--tempDirectory".to_string(),
+                    log_dir_str.to_string(),
                     "--printMethodCFGs".to_string(),
                     //"--printTranslatedProgram".to_string(),
                 ]),
-                VerificationBackend::Carbon => verifier_args.extend::<Vec<_>>(vec![
+                VerificationBackend::Carbon => verifier_args.extend(vec![
+                    "--boogieOpt".to_string(),
+                    format!("/logPrefix {}", log_dir_str),
                     //"--print".to_string(), "./log/boogie_program/program.bpl".to_string(),
                 ]),
             }
+        } else {
+            report_path = None;
         }
 
         self.verification_ctx.new_verifier_with_args(
             backend_config.backend,
             verifier_args,
-            Some(report_path),
+            report_path,
         )
     }
 

--- a/prusti-launch/src/bin/cargo-prusti.rs
+++ b/prusti-launch/src/bin/cargo-prusti.rs
@@ -34,9 +34,11 @@ where
         .arg("check")
         .args(clean_args)
         .env("RUST_TOOLCHAIN", get_rust_toolchain_channel())
+        .env("RUSTC_WRAPPER", prusti_rustc_path)
+        .env("CARGO_TARGET_DIR", "target/verify")
         .env("PRUSTI_QUIET", "true")
         .env("PRUSTI_FULL_COMPILATION", "true")
-        .env("RUSTC_WRAPPER", prusti_rustc_path)
+        .env("PRUSTI_LOG_DIR", "target/verify/log")
         .status()
         .expect("could not run cargo");
 

--- a/prusti-launch/src/bin/cargo-prusti.rs
+++ b/prusti-launch/src/bin/cargo-prusti.rs
@@ -29,19 +29,21 @@ where
     let clean_args = args.skip_while(|x| x == "prusti");
 
     let cargo_path = std::env::var("CARGO_PATH").unwrap_or_else(|_| "cargo".to_string());
-
-    let original_target =
+    let original_cargo_target =
         std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    let cargo_target = format!("{}/verify", original_cargo_target);
+    let prusti_log_dir =
+        std::env::var("PRUSTI_LOG_DIR").unwrap_or_else(|_| format!("{}/log", cargo_target));
 
     let exit_status = Command::new(cargo_path)
         .arg("check")
         .args(clean_args)
         .env("RUST_TOOLCHAIN", get_rust_toolchain_channel())
         .env("RUSTC_WRAPPER", prusti_rustc_path)
-        .env("CARGO_TARGET_DIR", format!("{}/verify", original_target))
+        .env("CARGO_TARGET_DIR", cargo_target)
         .env("PRUSTI_QUIET", "true")
         .env("PRUSTI_FULL_COMPILATION", "true")
-        .env("PRUSTI_LOG_DIR", format!("{}/verify/log", original_target))
+        .env("PRUSTI_LOG_DIR", prusti_log_dir)
         .status()
         .expect("could not run cargo");
 

--- a/prusti-launch/src/bin/cargo-prusti.rs
+++ b/prusti-launch/src/bin/cargo-prusti.rs
@@ -30,15 +30,17 @@ where
 
     let cargo_path = std::env::var("CARGO_PATH").unwrap_or_else(|_| "cargo".to_string());
 
+    let original_target = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+
     let exit_status = Command::new(cargo_path)
         .arg("check")
         .args(clean_args)
         .env("RUST_TOOLCHAIN", get_rust_toolchain_channel())
         .env("RUSTC_WRAPPER", prusti_rustc_path)
-        .env("CARGO_TARGET_DIR", "target/verify")
+        .env("CARGO_TARGET_DIR", format!("{}/verify", original_target))
         .env("PRUSTI_QUIET", "true")
         .env("PRUSTI_FULL_COMPILATION", "true")
-        .env("PRUSTI_LOG_DIR", "target/verify/log")
+        .env("PRUSTI_LOG_DIR", format!("{}/verify/log", original_target))
         .status()
         .expect("could not run cargo");
 

--- a/prusti-launch/src/bin/cargo-prusti.rs
+++ b/prusti-launch/src/bin/cargo-prusti.rs
@@ -30,7 +30,8 @@ where
 
     let cargo_path = std::env::var("CARGO_PATH").unwrap_or_else(|_| "cargo".to_string());
 
-    let original_target = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    let original_target =
+        std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
 
     let exit_status = Command::new(cargo_path)
         .arg("check")

--- a/prusti-tests/tests/cargotest.rs
+++ b/prusti-tests/tests/cargotest.rs
@@ -92,6 +92,9 @@ fn test_local_project<T: Into<PathBuf>>(project_name: T) {
         let path = entry.path();
         let file_name = path.as_path().file_name()
             .unwrap_or_else(|| panic!("Failed to obtain the name of {}", path.display()));
+        if file_name == "target" {
+            continue;
+        }
         if path.is_dir() {
             project_builder = project_builder.symlink_dir(path.as_path(), Path::new(file_name));
         } else {
@@ -120,9 +123,9 @@ fn test_local_project<T: Into<PathBuf>>(project_name: T) {
         );
     }
 
-    // Fetch dependencies
+    // Fetch dependencies using the same target folder of cargo-prusti
     let project = project_builder.build();
-    project.process("cargo").arg("build").run();
+    project.process("cargo").arg("build").env("CARGO_TARGET_DIR", "target/verify").run();
 
     // Set the expected exit status, stdout and stderr
     let mut test_builder = project.process(cargo_prusti_path());

--- a/prusti-tests/tests/compiletest.rs
+++ b/prusti-tests/tests/compiletest.rs
@@ -111,11 +111,6 @@ fn run_prusti_tests(group_name: &str, filter: &Option<String>, rustc_flags: Opti
         config.src_base = path;
         run_tests(&config);
     }
-
-    // Delete the nll-facts directory to avoid running out of hard drive
-    // space. Ignore any errors that may occur.
-    let _ = std::fs::remove_dir_all("nll-facts");
-    let _ = std::fs::remove_dir_all("log/nll-facts");
 }
 
 fn run_no_verification(group_name: &str, filter: &Option<String>) {

--- a/prusti-viper/src/lib.rs
+++ b/prusti-viper/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(rustc_private)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
+#![feature(bool_to_option)]
 
 #![allow(unused_imports)]
 #![deny(unused_must_use)]

--- a/prusti-viper/src/verifier.rs
+++ b/prusti-viper/src/verifier.rs
@@ -162,7 +162,9 @@ impl<'v, 'tcx> Verifier<'v, 'tcx> {
         let mut stopwatch = Stopwatch::start("prusti-viper", "encoding to Viper");
 
         // Dump the configuration
-        log::report("config", "prusti", config::dump());
+        if config::dump_debug_info() {
+            log::report("config", "prusti", config::dump());
+        }
 
         for &proc_id in &task.procedures {
             let proc_name = self.env.get_absolute_item_name(proc_id);


### PR DESCRIPTION
This allows to `cargo build` using a rustc version different from the nightly one used by Prusti, otherwise users get errors like the following

    error[E0514]: found crate `cfg_if` compiled by an incompatible version of rustc"