### PR TITLE
Disable overflow checks in test-crates

### DIFF
--- a/prusti-tests/tests/compiletest.rs
+++ b/prusti-tests/tests/compiletest.rs
@@ -147,10 +147,6 @@ fn run_verification_no_overflow(group_name: &str, filter: &Option<String>) {
 }
 
 fn run_verification_overflow(group_name: &str, filter: &Option<String>) {
-    let _temporary_env_vars = (
-        TemporaryEnvVar::set("PRUSTI_CHECK_OVERFLOWS", "true"),
-    );
-
     run_verification_base(group_name, filter);
 }
 

--- a/test-crates/src/main.rs
+++ b/test-crates/src/main.rs
@@ -243,6 +243,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .env("RUST_BACKTRACE", "1")
                         .env("PRUSTI_ASSERT_TIMEOUT", "60000")
                         .env("PRUSTI_CHECK_PANICS", "false")
+                        .env("PRUSTI_CHECK_OVERFLOWS", "false")
                         // Do not report errors for unsupported language features
                         .env("PRUSTI_SKIP_UNSUPPORTED_FEATURES", "true")
                         .env("PRUSTI_LOG_DIR", "/tmp/prusti_log")


### PR DESCRIPTION
This is probably the cause why @ani003 found verification errors while running test-crates in https://github.com/viperproject/prusti-dev/pull/609.
