### PR TITLE
Caching CI Builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,6 @@ jobs:
           java-version: '15'
       - name: Set up the environment
         run: python x.py setup
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo --release
         run: python x.py build --release --all --verbose
       - name: Run cargo tests --release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy
 
-on:
-  push:
-    branches: 'master'
+on: [push, workflow_dispatch]
+  # push:
+  #   branches: 'master'
 
 env:
   RUST_BACKTRACE: 1
@@ -28,6 +28,8 @@ jobs:
           java-version: '15'
       - name: Set up the environment
         run: python x.py setup
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo --release
         run: python x.py build --release --all --verbose
       - name: Run cargo tests --release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy
 
-on: [push, workflow_dispatch]
-  # push:
-  #   branches: 'master'
+on:
+  push:
+    branches: 'master'
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/test-on-crates.yml
+++ b/.github/workflows/test-on-crates.yml
@@ -22,6 +22,8 @@ jobs:
           java-version: '15'
       - name: Set up the environment
         run: python x.py setup
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo --release
         run: python x.py build --release --all --verbose
       - name: Test Prusti on a collection of crates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,13 +32,7 @@ jobs:
       - name: Set up the environment
         run: python x.py setup
       - name: Cache cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock', 'rust-toolchain') }}
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
         run: python x.py build --all --verbose
       - name: Run "quick" cargo tests
@@ -64,13 +58,7 @@ jobs:
       - name: Set up the environment
         run: python x.py setup
       - name: Cache cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock', 'rust-toolchain') }}
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
         run: python x.py build --all --verbose
       - name: Check and report Clippy errors
@@ -103,13 +91,7 @@ jobs:
       - name: Set up the environment
         run: python x.py setup
       - name: Cache cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock', 'rust-toolchain') }}
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
         run: python x.py build --all --verbose
       - name: Check and report formatting warnings
@@ -157,13 +139,7 @@ jobs:
       - name: Set up the environment
         run: python x.py setup
       - name: Cache cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock', 'rust-toolchain') }}
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
         run: python x.py build --all --verbose
       - name: Run "quick" cargo tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,6 +180,8 @@ jobs:
           java-version: '15'
       - name: Set up the environment
         run: python x.py setup
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
         run: python x.py build --all --verbose
       - name: Run cargo tests


### PR DESCRIPTION
This PR was opened to address issue #665 regarding caching CI builds.

From material online, it seems to me that the [`Swatinemt/rust-cache`](https://github.com/marketplace/actions/rust-cache) action is frequently used for Rust projects and is the best option. I've used `rust-cache@v1.3.0` as it is a stable release, whereas `rust-cache@v1` points to the master branch. 

One potential problem I see here is that the [action job](https://github.com/marketplace/actions/rust-cache#cache-details) is part of the key. Currently, if a key is specified this is *in addition to* the automatic keys, however, in the future there may be an API option for overriding the key, in which case the GitHub Action job could be removed from the key. To my understanding, this means that between different jobs (e.g. building and testing) there will be a cache miss when theoretically they could use the same cached build. 

A few simple timings I gathered:

| OS          | Build Cache Miss | Build Cache Hit |
| ------------ | ----------------------- | --------------------- |
| Ubuntu    | 11m 19s               | 4m 13s              |
| Windows | 23m 48s               | 7m 11s              |
| Mac         | 17m 31s              | 5m 31s               |    