### PR TITLE
Encode statements in the block even if there is a panic

### DIFF
--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -151,36 +151,6 @@ impl<'tcx> Procedure<'tcx> {
         self.reachable_basic_blocks.contains(&bbi)
     }
 
-    pub fn is_panic_block(&self, bbi: BasicBlockIndex) -> bool {
-        if let TerminatorKind::Call {
-            args: ref _args,
-            destination: ref _destination,
-            func:
-                mir::Operand::Constant(box mir::Constant {
-                    literal: mir::ConstantKind::Ty(
-                        ty::Const {
-                            ty,
-                            ..
-                        },
-                    ),
-                    ..
-                }),
-            ..
-        } = self.mir[bbi].terminator().kind {
-            if let ty::TyKind::FnDef(def_id, ..) = ty.kind() {
-                // let func_proc_name = self.tcx.absolute_item_path_str(def_id);
-                let func_proc_name = self.tcx.def_path_str(*def_id);
-                &func_proc_name == "std::rt::begin_panic"
-                    || &func_proc_name == "core::panicking::panic"
-                    || &func_proc_name == "core::panicking::panic_fmt"
-            } else {
-                false
-            }
-        } else {
-            false
-        }
-    }
-
     pub fn successors(&self, bbi: BasicBlockIndex) -> &[BasicBlockIndex] {
         self.real_edges.successors(bbi)
     }

--- a/prusti-tests/tests/verify/fail/incorrect/panic.rs
+++ b/prusti-tests/tests/verify/fail/incorrect/panic.rs
@@ -1,0 +1,14 @@
+enum AnyClientState {
+    Tendermint(u32)
+}
+
+fn prepare_client(client_state: &AnyClientState) -> Result<u32, u64> {
+    let r = match client_state {
+        AnyClientState::Tendermint(cs) => cs,
+        _ =>  return Err(0)
+    };
+    panic!() //~ ERROR panic!(..) statement might be reachable
+}
+
+fn main() {
+}

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1010,14 +1010,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         debug_assert!(!self.procedure.is_spec_block(bbi));
         let bb_data = &self.mir.basic_blocks()[bbi];
         let statements: &Vec<mir::Statement<'tcx>> = &bb_data.statements;
-        let is_panic_block = self.procedure.is_panic_block(bbi);
         for stmt_index in 0..statements.len() {
             trace!("Encode statement {:?}:{}", bbi, stmt_index);
             let location = mir::Location {
                 block: bbi,
                 statement_index: stmt_index,
             };
-            if !is_panic_block {
+            {
                 let (stmts, opt_succ) = self.encode_statement_at(location)?;
                 debug_assert!(opt_succ.is_none());
                 self.cfg_method.add_stmts(cfg_block, stmts);


### PR DESCRIPTION
The following function would cause Prusti to crash:

```rust
fn prepare_client(client_state: &AnyClientState) -> Result<u32, u64> {
    let r = match client_state {
        AnyClientState::Tendermint(cs) => cs,
        _ =>  return Err(0)
    };
    panic!()
}
```

I think the reason is that the behaviour of `encode_block_statements` is to not encode the statements if the block ends in `panic!()`. However, that doesn't seem sound, considering it is possible for the control flow to return explicitly with a `return` statement (in fact the `panic!()` may never be reachable).

This removes the panic check and always encodes the statements instead.