### PR TITLE
Fixed missing support for `#![no_std]` crates in some places

### DIFF
--- a/prusti-specs/src/extern_spec_rewriter.rs
+++ b/prusti-specs/src/extern_spec_rewriter.rs
@@ -231,7 +231,7 @@ pub fn generate_new_struct(item: &syn::ItemImpl) -> syn::Result<syn::ItemStruct>
     // Add `PhantomData` markers for each type parameter to silence errors
     // about unused type parameters.
     for param in generics.params.iter() {
-        let field = format!("std::marker::PhantomData<{}>,", param.to_token_stream().to_string());
+        let field = format!("core::marker::PhantomData<{}>,", param.to_token_stream().to_string());
         fields_str.push_str(&field);
     }
 

--- a/prusti-tests/tests/verify/pass/equality/nostd.rs
+++ b/prusti-tests/tests/verify/pass/equality/nostd.rs
@@ -1,0 +1,27 @@
+//! This is a regression test for the following error messages in `#![no_std]` crates:
+//! [Prusti: invalid specification] use of impure function "core::cmp::PartialEq::eq" in pure code is not allowed
+//! [Prusti: invalid specification] use of impure function "core::cmp::PartialEq::ne" in pure code is not allowed
+
+#![no_std]
+
+use prusti_contracts::*;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct A(usize);
+
+#[pure]
+#[requires(left == right)]
+fn eq(left: A, right: A) -> bool {
+    left == right
+}
+
+#[pure]
+#[requires(left != right)]
+fn ne(left: A, right: A) -> bool{
+    left != right
+}
+
+fn main() {
+    assert!(eq(A(0), A(0)));
+    assert!(ne(A(1), A(0)));
+}

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2146,7 +2146,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                             }
                         }
 
-                        "std::boxed::Box::<T>::new" => {
+                        "std::boxed::Box::<T>::new"
+                        | "alloc::boxed::Box::<T>::new" => {
                             // This is the initialization of a box
                             // args[0]: value to put in the box
                             assert_eq!(args.len(), 1);
@@ -2226,7 +2227,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                             );
                         }
 
-                        "std::ops::Fn::call" => {
+                        "std::ops::Fn::call"
+                        | "core::ops::Fn::call" => {
                             let cl_type: ty::Ty = substs[0].expect_ty();
                             match cl_type.kind() {
                                 ty::TyKind::Closure(cl_def_id, _) => {

--- a/prusti-viper/src/encoder/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/pure_functions/interpreter.rs
@@ -453,6 +453,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                             }
 
                             "std::cmp::PartialEq::eq"
+                            | "core::cmp::PartialEq::eq"
                                 if self.encoder.has_structural_eq_impl(
                                     self.mir_encoder.get_operand_ty(&args[0]),
                                 ) =>
@@ -468,6 +469,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                             }
 
                             "std::cmp::PartialEq::ne"
+                            | "core::cmp::PartialEq::ne"
                                 if self.encoder.has_structural_eq_impl(
                                     self.mir_encoder.get_operand_ty(&args[0]),
                                 ) =>
@@ -499,7 +501,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 state
                             }
 
-                            "std::ops::Index::index" => {
+                            "std::ops::Index::index"
+                            | "core::ops::Index::index" => {
                                 assert_eq!(args.len(), 2);
                                 trace!("slice::index(args={:?}, encoded_args={:?}, ty={:?}, lhs_value={:?})", args, encoded_args, ty, lhs_value);
 
@@ -514,7 +517,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 let encoded_idx = &encoded_args[1];
 
                                 let (start, end) = match &*idx_ident {
-                                    "std::ops::Range" => {
+                                    "std::ops::Range"
+                                    | "core::ops::Range" => {
                                         // there's fields like _5.f$start.val_int on `encoded_idx`, it just feels hacky to
                                         // manually re-do them here when we probably just encoded the type and the
                                         // construction of the fields..

--- a/prusti-viper/src/encoder/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/pure_functions/interpreter.rs
@@ -452,8 +452,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 state
                             }
 
-                            "std::cmp::PartialEq::eq"
-                            | "core::cmp::PartialEq::eq"
+                            "std::cmp::PartialEq::eq" | "core::cmp::PartialEq::eq"
                                 if self.encoder.has_structural_eq_impl(
                                     self.mir_encoder.get_operand_ty(&args[0]),
                                 ) =>
@@ -468,8 +467,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 state
                             }
 
-                            "std::cmp::PartialEq::ne"
-                            | "core::cmp::PartialEq::ne"
+                            "std::cmp::PartialEq::ne" | "core::cmp::PartialEq::ne"
                                 if self.encoder.has_structural_eq_impl(
                                     self.mir_encoder.get_operand_ty(&args[0]),
                                 ) =>
@@ -501,8 +499,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 state
                             }
 
-                            "std::ops::Index::index"
-                            | "core::ops::Index::index" => {
+                            "std::ops::Index::index" | "core::ops::Index::index" => {
                                 assert_eq!(args.len(), 2);
                                 trace!("slice::index(args={:?}, encoded_args={:?}, ty={:?}, lhs_value={:?})", args, encoded_args, ty, lhs_value);
 


### PR DESCRIPTION
Hi! I'm currently kicking the tires on Prusti in a `#![no_std]` crate. I ran into an error message `[Prusti: invalid specification] use of impure function "core::cmp::PartialEq::eq" in pure code is not allowed` when trying to perform a structural equality check in a Prusti contract. I started digging around the Prusti codebase a bit once I realized this error was not happening without the `#![no_std]` attribute applied at the crate level. There I noticed that in some places the codebase does anticipate certain methods being in both the Rust standard library and the Rust core library, but it was missing a check for this in other places. I did a quick audit of the code base to see if there were any other places and found some other cases, too. I fixed all the occurrences that I could find and added a regression test for  `core::cmp::PartialEq::{eq,ne}`.

By the way, thank you for building such a marvelous tool! I'm enjoying it a great deal and I'm heavily impressed with all the cool features it already offers. This is my first PR for Prusti!