### PR TITLE
Fix logging

### DIFF
--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -116,7 +116,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     ) -> Self {
         let source_path = env.source_path();
         let source_filename = source_path.file_name().unwrap().to_str().unwrap();
-        let vir_program_before_foldunfold_writer = config::dump_debug_info().then_some(
+        let vir_program_before_foldunfold_writer = config::dump_debug_info().then_some(()).map(|_|
             RefCell::new(
                 log::build_writer(
                     "vir_program_before_foldunfold",
@@ -126,14 +126,14 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
                 .unwrap(),
             )
         );
-        let vir_program_before_viper_writer = config::dump_debug_info().then_some(
+        let vir_program_before_viper_writer = config::dump_debug_info().then_some(()).map(|_|
             RefCell::new(
                 log::build_writer(
                     "vir_program_before_viper",
                     format!("{}.vir", source_filename),
                 )
-                .ok()
-                .unwrap(),
+                    .ok()
+                    .unwrap(),
             )
         );
 
@@ -821,6 +821,13 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             for predicate in predicates {
                 self.log_vir_program_before_viper(predicate.to_string());
                 let predicate_name = predicate.name();
+                if config::dump_debug_info() {
+                    log::report(
+                        "vir_predicates",
+                        format!("{}.vir", predicate_name),
+                        predicate.to_string(),
+                    );
+                }
                 self.type_predicates
                     .borrow_mut()
                     .insert(predicate_name.to_string(), predicate);

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -40,7 +40,7 @@ use lazy_static::lazy_static;
 use log::info;
 use prusti_common::{config, report::user};
 use rustc_interface::interface::try_print_query_stack;
-use std::{borrow::Cow, env, panic};
+use std::{borrow::Cow, env, panic, path::PathBuf};
 
 /// Link to report Prusti bugs
 const BUG_REPORT_URL: &str = "https://github.com/viperproject/prusti-dev/issues/new";
@@ -184,6 +184,13 @@ fn main() {
         }
 
         if config::dump_debug_info() {
+            rustc_args.push(format!(
+                "-Zdump-mir-dir={}",
+                PathBuf::from(config::log_dir())
+                    .join("mir")
+                    .to_str()
+                    .expect("failed to configure dump-mir-dir")
+            ));
             rustc_args.push("-Zdump-mir=all".to_owned());
             rustc_args.push("-Zdump-mir-graphviz".to_owned());
         }


### PR DESCRIPTION
This PR moves the `mir_dump` into in Prusti's `log` folder and it makes sure that no log folder is generated unless `dump_debug_info` is enabled.