### PR TITLE
Make it easier to read the generated VIR code

### DIFF
--- a/vir/build.rs
+++ b/vir/build.rs
@@ -1,15 +1,20 @@
-use quote::quote;
-use std::{env, io::Write, path::Path};
-use vir_gen::define_vir;
-use std::process::{Command, Stdio};
 use proc_macro2::TokenStream;
+use quote::quote;
+use std::{
+    env,
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
+use vir_gen::define_vir;
 
 /// Try to pretty-print a tokenstream by piping it through `rustfmt`.
 fn pretty_print_tokenstream(tokens: &TokenStream) -> Option<Vec<u8>> {
     let mut child = Command::new("rustfmt")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .spawn().ok()?;
+        .spawn()
+        .ok()?;
     {
         let stdin = child.stdin.as_mut()?;
         stdin.write_all(tokens.to_string().as_bytes()).ok()?;

--- a/vir/src/lib.rs
+++ b/vir/src/lib.rs
@@ -14,6 +14,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate serde;
 
+#[rustfmt::skip]
 #[path = "../gen/vir_gen.rs"]
 mod gen;
 pub use gen::*;

--- a/vir/src/lib.rs
+++ b/vir/src/lib.rs
@@ -14,11 +14,9 @@ extern crate lazy_static;
 #[macro_use]
 extern crate serde;
 
-// https://github.com/rust-analyzer/rust-analyzer/issues/1964
-//
-// To enable autocompletion of the generated code, please add
-// `"rust-analyzer.cargo.loadOutDirsFromCheck": true` to your VS Code settings.
-include!(concat!(env!("OUT_DIR"), "/vir_gen.rs"));
+#[path = "../gen/vir_gen.rs"]
+mod gen;
+pub use gen::*;
 
 pub mod converter;
 pub mod legacy;


### PR DESCRIPTION
The generated code is piped through `rustfmt` and it's then included using `#[path = "../gen/vir_gen.rs"]`, which is recognized by CLion. Is it also understood by rust-analyzer?