### PR TITLE
Clean up expiring borrows

### DIFF
--- a/prusti-viper/src/encoder/errors/encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/encoding_error.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use rustc_span::MultiSpan;
-use log::trace;
+use log::debug;
 use crate::encoder::errors::SpannedEncodingError;
 use crate::encoder::errors::EncodingErrorKind;
 use backtrace::Backtrace;
@@ -22,19 +22,19 @@ pub type EncodingResult<T> = Result<T, EncodingError>;
 impl EncodingError {
     /// Usage of an unsupported Rust feature (e.g. dereferencing raw pointers)
     pub fn unsupported<M: ToString>(message: M) -> Self {
-        trace!("Constructing unsupported error at:\n{:?}", Backtrace::new());
+        debug!("Constructing unsupported error at:\n{:?}", Backtrace::new());
         EncodingError::Positionless(EncodingErrorKind::unsupported(message))
     }
 
     /// An incorrect usage of Prusti (e.g. call an impure function in a contract)
     pub fn incorrect<M: ToString>(message: M) -> Self {
-        trace!("Constructing incorrect error at:\n{:?}", Backtrace::new());
+        debug!("Constructing incorrect error at:\n{:?}", Backtrace::new());
         EncodingError::Positionless(EncodingErrorKind::incorrect(message))
     }
 
     /// An internal error of Prusti (e.g. failure of the fold-unfold)
     pub fn internal<M: ToString>(message: M) -> Self {
-        trace!("Constructing internal error at:\n{:?}", Backtrace::new());
+        debug!("Constructing internal error at:\n{:?}", Backtrace::new());
         EncodingError::Positionless(EncodingErrorKind::internal(message))
     }
 

--- a/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
@@ -5,9 +5,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use rustc_span::MultiSpan;
+use log::debug;
 use prusti_interface::PrustiError;
 use crate::encoder::errors::EncodingError;
 use crate::encoder::errors::EncodingErrorKind;
+use backtrace::Backtrace;
 
 /// An error in the encoding with information regarding the source code span that caused it.
 #[derive(Clone, Debug)]
@@ -44,6 +46,7 @@ impl SpannedEncodingError {
 
     /// Usage of an unsupported Rust feature (e.g. dereferencing raw pointers)
     pub fn unsupported<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
+        debug!("Constructing unsupported error at:\n{:?}", Backtrace::new());
         SpannedEncodingError::new(
             EncodingErrorKind::unsupported(message),
             span
@@ -52,6 +55,7 @@ impl SpannedEncodingError {
 
     /// An incorrect usage of Prusti (e.g. call an impure function in a contract)
     pub fn incorrect<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
+        debug!("Constructing incorrect error at:\n{:?}", Backtrace::new());
         SpannedEncodingError::new(
             EncodingErrorKind::incorrect(message),
             span
@@ -60,6 +64,7 @@ impl SpannedEncodingError {
 
     /// An internal error of Prusti (e.g. failure of the fold-unfold)
     pub fn internal<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
+        debug!("Constructing internal error at:\n{:?}", Backtrace::new());
         SpannedEncodingError::new(
             EncodingErrorKind::internal(message),
             span

--- a/prusti-viper/src/encoder/foldunfold/borrows.rs
+++ b/prusti-viper/src/encoder/foldunfold/borrows.rs
@@ -72,7 +72,13 @@ impl<'a> CFG<'a> {
                 graph,
                 "<tr><td>borrow:</td><td>{:?}<br/>{}</td></tr>",
                 block.node.borrow,
-                block.node.stmts.iter().map(|s| escape_html(s.to_string())).collect::<Vec<_>>().join("<br/>"),
+                block
+                    .node
+                    .stmts
+                    .iter()
+                    .map(|s| escape_html(s.to_string()))
+                    .collect::<Vec<_>>()
+                    .join("<br/>"),
             )?;
             for (i, stmt) in block.statements.iter().enumerate() {
                 write!(

--- a/prusti-viper/src/encoder/foldunfold/borrows.rs
+++ b/prusti-viper/src/encoder/foldunfold/borrows.rs
@@ -70,8 +70,9 @@ impl<'a> CFG<'a> {
             write!(graph, "<table>")?;
             write!(
                 graph,
-                "<tr><td>borrow:</td><td>{:?}</td></tr>",
-                block.node.borrow
+                "<tr><td>borrow:</td><td>{:?}<br/>{}</td></tr>",
+                block.node.borrow,
+                block.node.stmts.iter().map(|s| escape_html(s.to_string())).collect::<Vec<_>>().join("<br/>"),
             )?;
             for (i, stmt) in block.statements.iter().enumerate() {
                 write!(

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -358,142 +358,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
         );
         nearest_block.unwrap().0
     }
-
-    /// Restore `Write` permissions that were converted to `Read` due to borrowing.
-    fn restore_write_permissions(
-        &self,
-        borrow: vir::borrows::Borrow,
-        pctxt: &mut PathCtxt,
-    ) -> Result<Vec<vir::Stmt>, FoldUnfoldError> {
-        trace!("[enter] restore_write_permissions({:?})", borrow);
-        let mut stmts = Vec::new();
-        for access in pctxt.log().get_converted_to_read_places(borrow) {
-            trace!("restore_write_permissions access={}", access);
-            let perm = match access {
-                vir::Expr::PredicateAccessPredicate(vir::PredicateAccessPredicate {
-                    box ref argument,
-                    permission,
-                    ..
-                }) => {
-                    assert!(permission == vir::PermAmount::Remaining);
-                    Perm::pred(argument.clone(), vir::PermAmount::Read)
-                }
-                vir::Expr::FieldAccessPredicate(vir::FieldAccessPredicate {
-                    box ref base,
-                    permission,
-                    ..
-                }) => {
-                    assert!(permission == vir::PermAmount::Remaining);
-                    Perm::acc(base.clone(), vir::PermAmount::Read)
-                }
-                x => unreachable!("{:?}", x),
-            };
-            stmts.extend(
-                pctxt
-                    .obtain_permissions(vec![perm])?
-                    .iter()
-                    .map(|a| a.to_stmt()),
-            );
-            let inhale_stmt = vir::Stmt::Inhale(vir::Inhale { expr: access });
-            pctxt.apply_stmt(&inhale_stmt)?;
-            stmts.push(inhale_stmt);
-        }
-
-        // Log borrow expiration
-        pctxt.log_mut().log_borrow_expiration(borrow);
-
-        trace!(
-            "[exit] restore_write_permissions({:?}) = {}",
-            borrow,
-            vir::stmts_to_str(&stmts)
-        );
-        Ok(stmts)
-    }
-
-    /// Wrap `_1.val_ref.f.g.` into `old[label](_1.val_ref).f.g`. This is needed
-    /// to make `_1.val_ref` reachable inside a package statement of a magic wand.
-    fn patch_places(&self, stmts: &[vir::Stmt], maybe_label: Option<&str>) -> Vec<vir::Stmt> {
-        if let Some(label) = maybe_label {
-            struct PlacePatcher<'a> {
-                label: &'a str,
-            }
-            impl<'a> vir::ExprFolder for PlacePatcher<'a> {
-                fn fold(&mut self, e: vir::Expr) -> vir::Expr {
-                    match e {
-                        vir::Expr::Field(vir::FieldExpr {
-                            base: box vir::Expr::Local(_),
-                            ..
-                        }) => e.old(self.label),
-                        _ => vir::default_fold_expr(self, e),
-                    }
-                }
-                fn fold_labelled_old(&mut self, labelled_old: vir::LabelledOld) -> vir::Expr {
-                    // Do not replace places that are already old.
-                    vir::Expr::LabelledOld(labelled_old)
-                }
-            }
-            fn patch_expr(label: &str, expr: &vir::Expr) -> vir::Expr {
-                PlacePatcher { label }.fold(expr.clone())
-            }
-            fn patch_args(label: &str, args: &[vir::Expr]) -> Vec<vir::Expr> {
-                args.iter()
-                    .map(|arg| {
-                        assert!(arg.is_place());
-                        patch_expr(label, arg)
-                    })
-                    .collect()
-            }
-            stmts
-                .iter()
-                .map(|stmt| match stmt {
-                    vir::Stmt::Comment(_)
-                    | vir::Stmt::ApplyMagicWand(_)
-                    | vir::Stmt::TransferPerm(_)
-                    | vir::Stmt::Assign(_) => stmt.clone(),
-                    vir::Stmt::Inhale(vir::Inhale { expr }) => vir::Stmt::Inhale(vir::Inhale {
-                        expr: patch_expr(label, expr),
-                    }),
-                    vir::Stmt::Exhale(vir::Exhale { expr, position }) => {
-                        vir::Stmt::Exhale(vir::Exhale {
-                            expr: patch_expr(label, expr),
-                            position: *position,
-                        })
-                    }
-                    vir::Stmt::Fold(vir::Fold {
-                        ref predicate_name,
-                        ref arguments,
-                        permission,
-                        enum_variant,
-                        position,
-                    }) => vir::Stmt::Fold(vir::Fold {
-                        predicate_name: predicate_name.clone(),
-                        arguments: patch_args(label, arguments),
-                        permission: *permission,
-                        enum_variant: enum_variant.clone(),
-                        position: *position,
-                    }),
-                    vir::Stmt::Unfold(vir::Unfold {
-                        ref predicate_name,
-                        ref arguments,
-                        permission,
-                        enum_variant,
-                    }) => vir::Stmt::Unfold(vir::Unfold {
-                        predicate_name: predicate_name.clone(),
-                        arguments: patch_args(label, arguments),
-                        permission: *permission,
-                        enum_variant: enum_variant.clone(),
-                    }),
-                    x => unreachable!("{}", x),
-                })
-                .collect()
-        } else {
-            stmts.to_vec()
-        }
-    }
 }
 
 #[derive(Debug)]
-struct ActionVec(pub Vec<Action>);
+pub(super) struct ActionVec(pub Vec<Action>);
 
 impl Deref for ActionVec {
     type Target = Vec<Action>;
@@ -587,17 +455,18 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
         new_cfg: &vir::CfgMethod,
         label: Option<&str>,
     ) -> Result<Vec<vir::Stmt>, Self::Error> {
-        debug!("[enter] replace_stmt: ##### {} #####", stmt);
+        debug!("[enter] replace_stmt: {}", stmt);
 
         if let vir::Stmt::ExpireBorrows(vir::ExpireBorrows { ref dag }) = stmt {
             let mut stmts = vec![vir::Stmt::comment(format!("{}", stmt))];
-            stmts.extend(self.process_expire_borrows(
+            let expire_borrow_statements = self.process_expire_borrows(
                 dag,
                 pctxt,
                 curr_block_index,
                 new_cfg,
                 label,
-            )?);
+            )?;
+            stmts.extend(expire_borrow_statements);
             return Ok(stmts);
         }
 
@@ -657,11 +526,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
         }
 
         // 1. Insert "unfolding in" inside old expressions. This handles *old* requirements.
-        debug!("[step.1] replace_stmt: {}", stmt);
+        trace!("[step.1] replace_stmt: {}", stmt);
         stmt = self.rewrite_stmt_with_unfoldings_in_old(stmt, pctxt)?;
 
         // 2. Obtain required *curr* permissions. *old* requirements will be handled at steps 0 and/or 4.
-        debug!("[step.2] replace_stmt: {}", stmt);
+        trace!("[step.2] replace_stmt: {}", stmt);
         {
             let all_perms = stmt.get_required_permissions(pctxt.predicates(), pctxt.old_exprs());
             let pred_permissions: Vec<_> =
@@ -684,7 +553,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
 
             let mut perms = acc_permissions;
             perms.extend(pred_permissions.into_iter());
-            debug!(
+            trace!(
                 "required permissions: {{\n{}\n}}",
                 perms
                     .iter()
@@ -707,7 +576,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
         }
 
         // 3. Replace special statements
-        debug!("[step.3] replace_stmt: {}", stmt);
+        trace!("[step.3] replace_stmt: {}", stmt);
         stmt = match stmt {
             vir::Stmt::PackageMagicWand(vir::PackageMagicWand {
                 magic_wand:
@@ -767,11 +636,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
         };
 
         // 4. Add "unfolding" expressions in statement. This handles *old* requirements.
-        debug!("[step.4] replace_stmt: Add unfoldings in stmt {}", stmt);
+        trace!("[step.4] replace_stmt: {}", stmt);
         stmt = self.rewrite_stmt_with_unfoldings(stmt, pctxt)?;
 
         // 5. Apply effect of statement on state
-        debug!("[step.5] replace_stmt: {}", stmt);
+        trace!("[step.5] replace_stmt: {}", stmt);
         stmt = match stmt {
             vir::Stmt::If(vir::If {
                 guard,
@@ -874,7 +743,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
         }
 
         // 7. Handle shared borrows.
-        debug!("[step.6] replace_stmt: {}", stmt);
+        trace!("[step.6] replace_stmt: {}", stmt);
         if let vir::Stmt::Assign(vir::Assign {
             ref target,
             ref source,
@@ -911,15 +780,15 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
                     .collect::<String>()
             );
             for (place, perm_amount, _) in acc_perms {
-                debug!("acc place: {} {}", place, perm_amount);
-                debug!("rhs_place={} {:?}", source, pctxt.state().acc().get(source));
-                debug!("lhs_place={} {:?}", target, pctxt.state().acc().get(target));
+                trace!("acc place: {} {}", place, perm_amount);
+                trace!("rhs_place={} {:?}", source, pctxt.state().acc().get(source));
+                trace!("lhs_place={} {:?}", target, pctxt.state().acc().get(target));
                 if *source == place
                     && Some(&vir::PermAmount::Write) == pctxt.state().acc().get(target)
                 {
                     // We are copying a shared reference, so we do not need to change
                     // the root of rhs.
-                    debug!("Copy of a shared reference. Ignore.");
+                    trace!("Copy of a shared reference. Ignore.");
                     continue;
                 }
                 if perm_amount == vir::PermAmount::Write {
@@ -939,7 +808,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
                     stmts.push(stmt);
                 }
                 let new_place = place.replace_place(source, target);
-                debug!("    new place: {}", new_place);
+                trace!("    new place: {}", new_place);
                 let lhs_read_access = vir::Expr::FieldAccessPredicate(vir::FieldAccessPredicate {
                     base: box new_place,
                     permission: vir::PermAmount::Read,
@@ -967,7 +836,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
                 .map(|(place, perm_amount)| (place.clone(), *perm_amount))
                 .collect();
             for (place, perm_amount) in pred_perms {
-                debug!("pred place: {} {}", place, perm_amount);
+                trace!("pred place: {} {}", place, perm_amount);
                 let predicate_type = place.get_type().clone();
                 if perm_amount == vir::PermAmount::Write {
                     let access =
@@ -988,7 +857,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
                     stmts.push(stmt);
                 }
                 let new_place = place.replace_place(source, target);
-                debug!("    new place: {}", new_place);
+                trace!("    new place: {}", new_place);
                 let lhs_read_access =
                     vir::Expr::PredicateAccessPredicate(vir::PredicateAccessPredicate {
                         predicate_type,
@@ -1038,7 +907,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
         succ: &vir::Successor,
         pctxt: &mut PathCtxt<'p>,
     ) -> Result<(Vec<vir::Stmt>, vir::Successor), Self::Error> {
-        debug!("replace_successor: {}", succ);
+        debug!("[enter] replace_successor: {}", succ);
         let exprs: Vec<&vir::Expr> =
             if let vir::Successor::GotoSwitch(ref guarded_targets, _) = succ {
                 guarded_targets.iter().map(|g| &g.0).collect()
@@ -1055,7 +924,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
 
         let mut some_perms_required = false;
         for (label, perms) in grouped_perms.into_iter() {
-            debug!("Obtain at label {:?} permissions {:?}", label, perms);
+            trace!("Obtain at label {:?} permissions {:?}", label, perms);
             // Hack: skip old permissions
             if label.is_some() {
                 continue;
@@ -1103,6 +972,15 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
             }
         };
 
+        debug!(
+            "[exit] replace_successor = {}, [\n{}\n]",
+            new_succ,
+            stmts
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .join("\n  "),
+        );
         Ok((stmts, new_succ))
     }
 
@@ -1112,44 +990,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
         &mut self,
         bcs: Vec<&PathCtxt<'p>>,
     ) -> Result<(Vec<ActionVec>, PathCtxt<'p>), Self::Error> {
-        trace!("[enter] prepend_join(..{})", &bcs.len());
-        assert!(!bcs.is_empty());
-        if bcs.len() == 1 {
-            Ok((vec![ActionVec(vec![])], bcs[0].clone()))
-        } else {
-            // Define two subgroups
-            let mid = bcs.len() / 2;
-            let left_pctxts = &bcs[..mid];
-            let right_pctxts = &bcs[mid..];
-
-            // Join the subgroups
-            let (left_actions_vec, mut left_pctxt) = self.prepend_join(left_pctxts.to_vec())?;
-            let (right_actions_vec, right_pctxt) = self.prepend_join(right_pctxts.to_vec())?;
-
-            // Join the recursive calls
-            let (merge_actions_left, merge_actions_right) = left_pctxt.join(right_pctxt)?;
-            let merged_pctxt = left_pctxt;
-
-            let mut branch_actions_vec: Vec<ActionVec> = vec![];
-            for mut left_actions in left_actions_vec {
-                left_actions.0.extend(merge_actions_left.iter().cloned());
-                branch_actions_vec.push(left_actions);
-            }
-            for mut right_actions in right_actions_vec {
-                right_actions.0.extend(merge_actions_right.iter().cloned());
-                branch_actions_vec.push(right_actions);
-            }
-
-            trace!(
-                "[exit] prepend_join(..{}): {}",
-                &bcs.len(),
-                branch_actions_vec
-                    .iter()
-                    .map(|v| format!("[{}]", v.iter().to_sorted_multiline_string()))
-                    .to_string()
-            );
-            Ok((branch_actions_vec, merged_pctxt))
-        }
+        prepend_join(bcs)
     }
 
     /// Convert actions to statements and log them.
@@ -1165,6 +1006,49 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
             pctxt.log_mut().log_prejoin_action(block_index, action);
         }
         Ok(stmts)
+    }
+}
+
+pub(super) fn prepend_join<'p>(
+    bcs: Vec<&PathCtxt<'p>>,
+) -> Result<(Vec<ActionVec>, PathCtxt<'p>), FoldUnfoldError> {
+    trace!("[enter] prepend_join(..{})", &bcs.len());
+    assert!(!bcs.is_empty());
+    if bcs.len() == 1 {
+        Ok((vec![ActionVec(vec![])], bcs[0].clone()))
+    } else {
+        // Define two subgroups
+        let mid = bcs.len() / 2;
+        let left_pctxts = &bcs[..mid];
+        let right_pctxts = &bcs[mid..];
+
+        // Join the subgroups
+        let (left_actions_vec, mut left_pctxt) = prepend_join(left_pctxts.to_vec())?;
+        let (right_actions_vec, right_pctxt) = prepend_join(right_pctxts.to_vec())?;
+
+        // Join the recursive calls
+        let (merge_actions_left, merge_actions_right) = left_pctxt.join(right_pctxt)?;
+        let merged_pctxt = left_pctxt;
+
+        let mut branch_actions_vec: Vec<ActionVec> = vec![];
+        for mut left_actions in left_actions_vec {
+            left_actions.0.extend(merge_actions_left.iter().cloned());
+            branch_actions_vec.push(left_actions);
+        }
+        for mut right_actions in right_actions_vec {
+            right_actions.0.extend(merge_actions_right.iter().cloned());
+            branch_actions_vec.push(right_actions);
+        }
+
+        trace!(
+            "[exit] prepend_join(..{}): {}",
+            &bcs.len(),
+            branch_actions_vec
+                .iter()
+                .map(|v| format!("[{}]", v.iter().to_sorted_multiline_string()))
+                .to_string()
+        );
+        Ok((branch_actions_vec, merged_pctxt))
     }
 }
 
@@ -1201,7 +1085,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             position,
         }: vir::FieldExpr,
     ) -> Result<vir::Expr, Self::Error> {
-        debug!("[enter] fold_field {}, {}", base, field);
+        trace!("[enter] fold_field {}, {}", base, field);
 
         let res = if self.wait_old_expr {
             vir::Expr::Field(vir::FieldExpr {
@@ -1222,7 +1106,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             new_base.reconstruct_place(components)
         };
 
-        debug!("[exit] fold_unfolding = {}", res);
+        trace!("[exit] fold_unfolding = {}", res);
         Ok(res)
     }
 
@@ -1237,7 +1121,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             position,
         }: vir::Unfolding,
     ) -> Result<vir::Expr, Self::Error> {
-        debug!(
+        trace!(
             "[enter] fold_unfolding {}, {}, {}, {}",
             predicate_name, arguments[0], base, permission
         );
@@ -1282,7 +1166,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             })
         };
 
-        debug!("[exit] fold_unfolding = {}", res);
+        trace!("[exit] fold_unfolding = {}", res);
         Ok(res)
     }
 
@@ -1295,7 +1179,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             position,
         }: vir::MagicWand,
     ) -> Result<vir::Expr, Self::Error> {
-        debug!("[enter] fold_magic_wand {}, {}", left, right);
+        trace!("[enter] fold_magic_wand {}, {}", left, right);
 
         // Compute lhs state
         let mut lhs_pctxt = self.curr_pctxt.clone();
@@ -1311,7 +1195,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             let pos = place.pos();
             place.old("lhs").set_pos(pos)
         });
-        debug!("State of lhs of magic wand: {}", lhs_state);
+        trace!("State of lhs of magic wand: {}", lhs_state);
 
         // Store states
         std::mem::swap(&mut self.curr_pctxt, &mut lhs_pctxt);
@@ -1337,7 +1221,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             let pos = place.pos();
             place.old("lhs").set_pos(pos)
         });
-        debug!("New state of lhs of magic wand: {}", new_lhs_state);
+        trace!("New state of lhs of magic wand: {}", new_lhs_state);
 
         // Compute rhs state
         let mut rhs_pctxt = self.curr_pctxt.clone();
@@ -1350,7 +1234,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
                 .filter(|p| p.is_pred())
                 .flat_map(|p| vec![Perm::acc(p.get_place().clone(), p.get_perm_amount()), p]),
         )?;
-        debug!("State of rhs of magic wand: {}", rhs_state);
+        trace!("State of rhs of magic wand: {}", rhs_state);
 
         // Store states
         std::mem::swap(&mut self.curr_pctxt, &mut rhs_pctxt);
@@ -1371,7 +1255,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             position,
         });
 
-        debug!("[enter] fold_magic_wand = {}", res);
+        trace!("[enter] fold_magic_wand = {}", res);
         Ok(res)
     }
 
@@ -1383,7 +1267,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             position,
         }: vir::LabelledOld,
     ) -> Result<vir::Expr, Self::Error> {
-        debug!("[enter] fold_labelled_old {}: {}", label, base);
+        trace!("[enter] fold_labelled_old {}: {}", label, base);
 
         let mut tmp_curr_pctxt = if label == "lhs" && self.lhs_pctxt.is_some() {
             self.lhs_pctxt.as_ref().unwrap().clone()
@@ -1424,7 +1308,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             position,
         });
 
-        debug!("[exit] fold_labelled_old = {}", res);
+        trace!("[exit] fold_labelled_old = {}", res);
         Ok(res)
     }
 
@@ -1436,7 +1320,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             field,
         }: vir::DowncastExpr,
     ) -> Result<vir::Expr, Self::Error> {
-        debug!(
+        trace!(
             "[enter] fallible_fold_downcast {} -> {} in {}",
             enum_place, field, base
         );
@@ -1473,12 +1357,12 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             })
         };
 
-        debug!("[exit] fallible_fold_downcast = {}", res);
+        trace!("[exit] fallible_fold_downcast = {}", res);
         Ok(res)
     }
 
     fn fallible_fold(&mut self, expr: vir::Expr) -> Result<vir::Expr, Self::Error> {
-        debug!("[enter] fold {}", expr);
+        trace!("[enter] fold {}", expr);
 
         let res = if self.wait_old_expr || !expr.is_pure() {
             vir::default_fallible_fold_expr(self, expr)?
@@ -1494,7 +1378,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
                 .filter(|p| p.is_curr())
                 .collect();
 
-            debug!(
+            trace!(
                 "get_required_permissions for {}: {{\n  {}\n}}",
                 inner_expr,
                 perms
@@ -1518,7 +1402,7 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             result
         };
 
-        debug!("[exit] fold = {}", res);
+        trace!("[exit] fold = {}", res);
         Ok(res)
     }
 

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -459,13 +459,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
 
         if let vir::Stmt::ExpireBorrows(vir::ExpireBorrows { ref dag }) = stmt {
             let mut stmts = vec![vir::Stmt::comment(format!("{}", stmt))];
-            let expire_borrow_statements = self.process_expire_borrows(
-                dag,
-                pctxt,
-                curr_block_index,
-                new_cfg,
-                label,
-            )?;
+            let expire_borrow_statements =
+                self.process_expire_borrows(dag, pctxt, curr_block_index, new_cfg, label)?;
             stmts.extend(expire_borrow_statements);
             return Ok(stmts);
         }
@@ -1123,7 +1118,10 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
     ) -> Result<vir::Expr, Self::Error> {
         trace!(
             "[enter] fold_unfolding {}, {}, {}, {}",
-            predicate_name, arguments[0], base, permission
+            predicate_name,
+            arguments[0],
+            base,
+            permission
         );
 
         let res = if self.wait_old_expr {
@@ -1322,7 +1320,9 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
     ) -> Result<vir::Expr, Self::Error> {
         trace!(
             "[enter] fallible_fold_downcast {} -> {} in {}",
-            enum_place, field, base
+            enum_place,
+            field,
+            base
         );
 
         let res = if self.wait_old_expr {

--- a/prusti-viper/src/encoder/foldunfold/path_ctxt.rs
+++ b/prusti-viper/src/encoder/foldunfold/path_ctxt.rs
@@ -255,7 +255,8 @@ impl<'a> PathCtxt<'a> {
                         ObtainResult::Failure(missing_perm) => {
                             trace!(
                                 "Failed to obtain: {} because of {}",
-                                pred_perm, missing_perm
+                                pred_perm,
+                                missing_perm
                             );
                             let remove_places = |ctxt: &mut PathCtxt, actions: &mut Vec<_>| {
                                 ctxt.state.remove_moved_matching(|moved_place| {
@@ -267,7 +268,8 @@ impl<'a> PathCtxt<'a> {
                                         let perm = Perm::acc(acc_place, perm_amount);
                                         trace!(
                                             "dropping perm={} missing_perm={}",
-                                            perm, missing_perm
+                                            perm,
+                                            missing_perm
                                         );
                                         actions.push(Action::Drop(perm, missing_perm.clone()));
                                     }
@@ -278,7 +280,8 @@ impl<'a> PathCtxt<'a> {
                                         let perm = Perm::pred(place, perm_amount);
                                         trace!(
                                             "dropping perm={} missing_perm={}",
-                                            perm, missing_perm
+                                            perm,
+                                            missing_perm
                                         );
                                         actions.push(Action::Drop(perm, missing_perm.clone()));
                                     }

--- a/prusti-viper/src/encoder/foldunfold/path_ctxt.rs
+++ b/prusti-viper/src/encoder/foldunfold/path_ctxt.rs
@@ -85,7 +85,7 @@ impl<'a> PathCtxt<'a> {
         perm_amount: PermAmount,
         variant: vir::MaybeEnumVariantIndex,
     ) -> Result<Action, FoldUnfoldError> {
-        debug!("We want to unfold {} with {}", pred_place, perm_amount);
+        trace!("We want to unfold {} with {}", pred_place, perm_amount);
         //assert!(self.state.contains_acc(pred_place), "missing acc({}) in {}", pred_place, self.state);
         assert!(
             self.state.contains_pred(pred_place),
@@ -126,7 +126,7 @@ impl<'a> PathCtxt<'a> {
                     }),
             )?;
 
-        debug!("We unfolded {}", pred_place);
+        trace!("We unfolded {}", pred_place);
 
         trace!(
             "Acc state after unfold: {{\n{}\n}}",
@@ -154,7 +154,7 @@ impl<'a> PathCtxt<'a> {
         let mut left_actions: Vec<Action> = vec![];
         let mut right_actions: Vec<Action> = vec![];
 
-        debug!("Join branches");
+        trace!("Join branches");
         trace!("Left branch: {}", self.state);
         trace!("Right branch: {}", other.state);
         self.state.check_consistency();
@@ -186,7 +186,7 @@ impl<'a> PathCtxt<'a> {
             );
             self.state.set_moved(moved_paths.clone());
             other.state.set_moved(moved_paths.clone());
-            debug!("moved_paths: {}", moved_paths.iter().to_string());
+            trace!("moved_paths: {}", moved_paths.iter().to_string());
 
             trace!("left acc: {{\n{}\n}}", self.state.display_acc());
             trace!("right acc: {{\n{}\n}}", other.state.display_acc());
@@ -206,11 +206,11 @@ impl<'a> PathCtxt<'a> {
             // Compute which access permissions may be preserved
             let (unfold_potential_acc, fold_potential_pred) =
                 compute_fold_target(&self.state.acc_places(), &other.state.acc_places());
-            debug!(
+            trace!(
                 "unfold_potential_acc: {}",
                 unfold_potential_acc.iter().to_sorted_multiline_string()
             );
-            debug!(
+            trace!(
                 "fold_potential_pred: {}",
                 fold_potential_pred.iter().to_sorted_multiline_string()
             );
@@ -218,20 +218,20 @@ impl<'a> PathCtxt<'a> {
             // Remove access permissions that can not be obtained due to a moved path
             let unfold_actual_acc =
                 filter_not_proper_extensions_of(&unfold_potential_acc, &moved_paths);
-            debug!(
+            trace!(
                 "unfold_actual_acc: {}",
                 unfold_actual_acc.iter().to_sorted_multiline_string()
             );
             let fold_actual_pred =
                 filter_not_proper_extensions_of(&fold_potential_pred, &moved_paths);
-            debug!(
+            trace!(
                 "fold_actual_pred: {}",
                 fold_actual_pred.iter().to_sorted_multiline_string()
             );
 
             // Obtain predicates by folding.
             for pred_place in fold_actual_pred {
-                debug!("try to obtain predicate: {}", pred_place);
+                trace!("try to obtain predicate: {}", pred_place);
                 let get_perm_amount = |ctxt: &PathCtxt| {
                     ctxt.state
                         .acc()
@@ -253,7 +253,7 @@ impl<'a> PathCtxt<'a> {
                             left_actions.extend(new_actions);
                         }
                         ObtainResult::Failure(missing_perm) => {
-                            debug!(
+                            trace!(
                                 "Failed to obtain: {} because of {}",
                                 pred_perm, missing_perm
                             );
@@ -265,7 +265,7 @@ impl<'a> PathCtxt<'a> {
                                     if acc_place.has_proper_prefix(&pred_place) {
                                         let perm_amount = ctxt.state.remove_acc_place(&acc_place);
                                         let perm = Perm::acc(acc_place, perm_amount);
-                                        debug!(
+                                        trace!(
                                             "dropping perm={} missing_perm={}",
                                             perm, missing_perm
                                         );
@@ -276,7 +276,7 @@ impl<'a> PathCtxt<'a> {
                                     if place.has_prefix(&pred_place) {
                                         let perm_amount = ctxt.state.remove_pred_place(&place);
                                         let perm = Perm::pred(place, perm_amount);
-                                        debug!(
+                                        trace!(
                                             "dropping perm={} missing_perm={}",
                                             perm, missing_perm
                                         );
@@ -301,7 +301,7 @@ impl<'a> PathCtxt<'a> {
                                   right_actions: &mut Vec<_>|
                  -> Result<bool, FoldUnfoldError> {
                     if !ctxt_left.state.acc().contains_key(acc_place) {
-                        debug!(
+                        trace!(
                             "The left branch needs to obtain an access permission: {}",
                             acc_place
                         );
@@ -331,7 +331,7 @@ impl<'a> PathCtxt<'a> {
             // Drop predicate permissions that can not be obtained due to a move
             for pred_place in &filter_proper_extensions_of(&self.state.pred_places(), &moved_paths)
             {
-                debug!(
+                trace!(
                     "Drop pred {} in left branch (it is moved out in the other branch)",
                     pred_place
                 );
@@ -342,7 +342,7 @@ impl<'a> PathCtxt<'a> {
             }
             for pred_place in &filter_proper_extensions_of(&other.state.pred_places(), &moved_paths)
             {
-                debug!(
+                trace!(
                     "Drop pred {} in right branch (it is moved out in the other branch)",
                     pred_place
                 );
@@ -355,11 +355,11 @@ impl<'a> PathCtxt<'a> {
             // Compute preserved predicate permissions
             let preserved_preds: HashSet<_> =
                 intersection(&self.state.pred_places(), &other.state.pred_places());
-            debug!("preserved_preds: {}", preserved_preds.iter().to_string());
+            trace!("preserved_preds: {}", preserved_preds.iter().to_string());
 
             // Drop predicate permissions that are not in the other branch
             for pred_place in self.state.pred_places().difference(&preserved_preds) {
-                debug!(
+                trace!(
                     "Drop pred {} in left branch (it is not in the other branch)",
                     pred_place
                 );
@@ -369,7 +369,7 @@ impl<'a> PathCtxt<'a> {
                 left_actions.push(Action::Drop(perm.clone(), perm));
             }
             for pred_place in other.state.pred_places().difference(&preserved_preds) {
-                debug!(
+                trace!(
                     "Drop pred {} in right branch (it is not in the other branch)",
                     pred_place
                 );
@@ -381,7 +381,7 @@ impl<'a> PathCtxt<'a> {
 
             // Drop access permissions that can not be obtained due to a move
             for acc_place in &filter_proper_extensions_of(&self.state.acc_places(), &moved_paths) {
-                debug!(
+                trace!(
                     "Drop acc {} in left branch (it is moved out in the other branch)",
                     acc_place
                 );
@@ -391,7 +391,7 @@ impl<'a> PathCtxt<'a> {
                 left_actions.push(Action::Drop(perm.clone(), perm));
             }
             for acc_place in &filter_proper_extensions_of(&other.state.acc_places(), &moved_paths) {
-                debug!(
+                trace!(
                     "Drop acc {} in right branch (it is moved out in the other branch)",
                     acc_place
                 );
@@ -407,7 +407,7 @@ impl<'a> PathCtxt<'a> {
                 .acc_places()
                 .difference(&other.state.acc_places())
             {
-                debug!(
+                trace!(
                     "Drop acc {} in left branch (not present in the other branch)",
                     acc_place
                 );
@@ -423,7 +423,7 @@ impl<'a> PathCtxt<'a> {
                 .acc_places()
                 .difference(&self.state.acc_places())
             {
-                debug!(
+                trace!(
                     "Drop acc {} in right branch (not present in the other branch)",
                     acc_place
                 );
@@ -504,7 +504,7 @@ impl<'a> PathCtxt<'a> {
 
     /// Obtain the required permissions, changing the state inplace and returning the statements.
     fn obtain_all(&mut self, reqs: Vec<Perm>) -> Result<Vec<Action>, FoldUnfoldError> {
-        debug!("[enter] obtain_all: {{{}}}", reqs.iter().to_string());
+        trace!("[enter] obtain_all: {{{}}}", reqs.iter().to_string());
         reqs.iter()
             .map(|perm| self.obtain(perm, false).and_then(|x| x.get_actions()))
             .collect::<Result<Vec<Vec<Action>>, _>>()
@@ -533,7 +533,7 @@ impl<'a> PathCtxt<'a> {
             return Ok(ObtainResult::Success(actions));
         }
 
-        debug!("Try to satisfy requirement {}", req);
+        trace!("Try to satisfy requirement {}", req);
 
         // 3. Obtain with an unfold
         // Find a predicate on a proper prefix of req
@@ -545,7 +545,7 @@ impl<'a> PathCtxt<'a> {
             .cloned();
         if let Some(existing_pred_to_unfold) = existing_prefix_pred_opt {
             let perm_amount = self.state.pred()[&existing_pred_to_unfold];
-            debug!(
+            trace!(
                 "We want to unfold {} with permission {} (we need at least {})",
                 existing_pred_to_unfold,
                 perm_amount,
@@ -560,7 +560,7 @@ impl<'a> PathCtxt<'a> {
             let variant = find_variant(&existing_pred_to_unfold, req.get_place());
             let action = self.unfold(&existing_pred_to_unfold, perm_amount, variant)?;
             actions.push(action);
-            debug!("We unfolded {}", existing_pred_to_unfold);
+            trace!("We unfolded {}", existing_pred_to_unfold);
 
             // Check if we are done
             let new_actions = self.obtain(req, false)?.get_actions()?;
@@ -572,7 +572,7 @@ impl<'a> PathCtxt<'a> {
         // 4. Obtain with a fold
         if req.is_pred() {
             // We want to fold `req`
-            debug!("We want to fold {}", req);
+            trace!("We want to fold {}", req);
             let predicate_name = req.typed_ref_name().unwrap();
             let predicate = self.predicates.get(&predicate_name).unwrap();
 
@@ -612,7 +612,7 @@ impl<'a> PathCtxt<'a> {
                             .chain(self.state.pred().iter())
                             .filter(|(place, _)| place.has_prefix(p.get_place()))
                             .map(|(place, perm_amount)| {
-                                debug!("Place {} can offer {}", place, perm_amount);
+                                trace!("Place {} can offer {}", place, perm_amount);
                                 *perm_amount
                             })
                             .min()
@@ -620,7 +620,7 @@ impl<'a> PathCtxt<'a> {
                     })
                     .min()
                     .unwrap_or(PermAmount::Write);
-                debug!(
+                trace!(
                     "We want to fold {} with permission {} (we need at least {})",
                     req,
                     perm_amount,
@@ -670,7 +670,7 @@ impl<'a> PathCtxt<'a> {
                     .insert_pred(req.get_place().clone(), perm_amount)?;
 
                 // Done. Continue checking the remaining requirements
-                debug!("We folded {}", req);
+                trace!("We folded {}", req);
                 trace!("[exit] obtain");
                 Ok(ObtainResult::Success(actions))
             } else {
@@ -693,7 +693,7 @@ Predicates: {{
             }
         } else if in_join && req.get_perm_amount() == PermAmount::Read {
             // Permissions held by shared references can be dropped
-            // without being explicitly moved becauce &T implements Copy.
+            // without being explicitly moved because &T implements Copy.
             Ok(ObtainResult::Failure(req.clone()))
         } else {
             // We have no predicate to obtain the access permission `req`
@@ -718,7 +718,7 @@ Predicates: {{
 
     /// Returns some of the dropped permissions
     pub fn apply_stmt(&mut self, stmt: &vir::Stmt) -> Result<(), FoldUnfoldError> {
-        debug!("apply_stmt: {}", stmt);
+        trace!("apply_stmt: {}", stmt);
 
         trace!("Acc state before: {{\n{}\n}}", self.state.display_acc());
         trace!("Pred state before: {{\n{}\n}}", self.state.display_pred());

--- a/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
+++ b/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
@@ -261,7 +261,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 stmt
             );
             let new_stmts = self.replace_stmt(
-                // EXTERNAL
                 stmt_index,
                 stmt,
                 false,
@@ -294,7 +293,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 position: method_pos,
             });
             let new_stmts = self.replace_stmt(
-                // EXTERNAL
                 curr_block.statements.len(),
                 &stmt,
                 false,

--- a/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
+++ b/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
@@ -1,11 +1,10 @@
 use std::{mem, ops::Deref};
-
 use log::*;
-
 use prusti_common::{report, utils::to_string::ToString};
 use vir_crate::polymorphic::{self as vir, CfgReplacer};
-
 use super::{action::Action, borrows, path_ctxt::PathCtxt, FoldUnfold, FoldUnfoldError};
+use crate::encoder::foldunfold::{Perm, prepend_join};
+use vir_crate::polymorphic::ExprFolder;
 
 impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
     /// Generates Viper statements that expire all the borrows from the given `dag`. The
@@ -19,7 +18,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
         new_cfg: &vir::CfgMethod,
         label: Option<&str>,
     ) -> Result<Vec<vir::Stmt>, FoldUnfoldError> {
-        trace!("[enter] process_expire_borrows dag=[{:?}]", dag);
+        debug!("[enter] process_expire_borrows dag=[{:?}]", dag);
 
         let mut cfg = build_initial_cfg(dag);
 
@@ -37,10 +36,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 curr_block_index,
                 &final_pctxt,
             )?;
+            cfg.basic_blocks[curr_block_index].statements.extend(curr_block_pre_statements);
+
+            self.dump_debug_info(dag, &cfg, surrounding_block_index, curr_block_index);
 
             let curr_block = &mut cfg.basic_blocks[curr_block_index];
-            curr_block.statements.extend(curr_block_pre_statements);
-
             self.process_node(
                 surrounding_pctxt,
                 surrounding_block_index,
@@ -51,18 +51,25 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 &mut pctxt,
             )?;
 
+            self.dump_debug_info(dag, &cfg, surrounding_block_index, curr_block_index);
+
             final_pctxt[curr_block_index] = Some(pctxt);
         }
 
         // Merge all pctxts with reborrowed_nodes.is_empty() into one.
         *surrounding_pctxt = self.construct_final_pctxt(dag, &mut cfg, &final_pctxt)?;
 
-        Ok(self.generate_final_statements(&cfg, label))
+        let final_statements = self.generate_final_statements(&cfg, label);
+        debug!(
+            "[exit] process_expire_borrows = [\n{}\n]",
+            final_statements.iter().map(|s| s.to_string()).collect::<Vec<_>>().join("\n  ")
+        );
+        Ok(final_statements)
     }
 
     #[allow(clippy::too_many_arguments)]
     fn construct_initial_pctxt(
-        &mut self,
+        &self,
         dag: &vir::borrows::DAG,
         cfg: &mut borrows::CFG,
         surrounding_pctxt: &mut PathCtxt<'p>,
@@ -96,7 +103,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
     }
 
     fn construct_initial_pctxt_no_predecessors(
-        &mut self,
+        &self,
         dag: &vir::borrows::DAG,
         cfg: &mut borrows::CFG,
         surrounding_pctxt: &mut PathCtxt<'p>,
@@ -113,14 +120,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
             self.get_cfg_block_of_last_borrow(surrounding_block_index, &curr_node.borrow);
         if !start_block.weak_eq(&end_block) {
             let path = new_cfg.find_path(start_block, end_block).unwrap();
-            debug!(
+            trace!(
                 "process_expire_borrows borrow={:?} path={:?}",
                 curr_node.borrow, path
             );
             let dropped_permissions = surrounding_pctxt
                 .log()
                 .collect_dropped_permissions(&path, dag);
-            debug!(
+            trace!(
                 "process_expire_borrows borrow={:?} dropped_permissions={:?}",
                 curr_node.borrow, dropped_permissions
             );
@@ -137,7 +144,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
 
     #[allow(clippy::too_many_arguments)]
     fn construct_initial_pctxt_with_predecessors(
-        &mut self,
+        &self,
         dag: &vir::borrows::DAG,
         cfg: &mut borrows::CFG,
         surrounding_pctxt: &mut PathCtxt<'p>,
@@ -158,14 +165,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 self.get_cfg_block_of_last_borrow(surrounding_block_index, &curr_node.borrow);
             if start_block != end_block {
                 let path = new_cfg.find_path(start_block, end_block).unwrap();
-                debug!(
+                trace!(
                     "process_expire_borrows borrow={:?} path={:?}",
                     curr_node.borrow, path
                 );
                 let dropped_permissions = surrounding_pctxt
                     .log()
                     .collect_dropped_permissions(&path, dag);
-                debug!(
+                trace!(
                     "process_expire_borrows borrow={:?} dropped_permissions={}",
                     curr_node.borrow,
                     dropped_permissions.iter().to_string()
@@ -183,7 +190,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
             incoming_pctxt.push(pctxt);
         }
         let incoming_pctxt_refs = incoming_pctxt.iter().collect();
-        let (actions, mut pctxt) = self.prepend_join(incoming_pctxt_refs)?;
+        let (actions, mut pctxt) = prepend_join(incoming_pctxt_refs)?;
         for (&src_index, action) in curr_block.predecessors.iter().zip(&actions) {
             assert!(src_index < curr_block_index);
             if !action.is_empty() {
@@ -230,11 +237,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
         }
 
         for (stmt_index, stmt) in curr_node.stmts.iter().enumerate() {
-            debug!(
+            trace!(
                 "process_expire_borrows block={} ({:?}) stmt={}",
                 curr_block_index, curr_node.borrow, stmt
             );
-            let new_stmts = self.replace_stmt(
+            let new_stmts = self.replace_stmt( // EXTERNAL
                 stmt_index,
                 stmt,
                 false,
@@ -253,7 +260,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
         let mut maybe_original_place = None;
         for (mut read_access, original_place) in duplicated_perms {
             if let Some(ref place) = curr_node.place {
-                debug!(
+                trace!(
                     "place={} original_place={} read_access={}",
                     place, original_place, read_access
                 );
@@ -264,7 +271,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 expr: read_access,
                 position: self.method_pos,
             });
-            let new_stmts = self.replace_stmt(
+            let new_stmts = self.replace_stmt( // EXTERNAL
                 curr_block.statements.len(),
                 &stmt,
                 false,
@@ -289,11 +296,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
         // would need to restore write permissions to `x.f` without doing the same for `x.f.g`.
         // This would require making sure that we are unfolded up to `x.f.g` and emit
         // restoration for each place segment separately.
-        debug!(
+        trace!(
             "curr_node.alive_conflicting_borrows={:?}",
             curr_node.alive_conflicting_borrows
         );
-        debug!(
+        trace!(
             "curr_node.conflicting_borrows={:?}",
             curr_node.conflicting_borrows
         );
@@ -307,11 +314,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 .statements
                 .extend(self.restore_write_permissions(curr_node.borrow, pctxt)?);
         }
-        debug!(
+        trace!(
             "curr_node.alive_conflicting_borrows={:?}",
             curr_node.alive_conflicting_borrows
         );
-        debug!(
+        trace!(
             "curr_node.conflicting_borrows={:?}",
             curr_node.conflicting_borrows
         );
@@ -320,7 +327,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
     }
 
     fn construct_final_pctxt(
-        &mut self,
+        &self,
         dag: &vir::borrows::DAG,
         cfg: &mut borrows::CFG,
         final_pctxt: &[Option<PathCtxt<'p>>],
@@ -336,7 +343,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
             .iter()
             .map(|i| final_pctxt[*i].as_ref().unwrap())
             .collect();
-        let (actions, mut final_pctxt) = self.prepend_join(final_pctxts)?;
+        let (actions, mut final_pctxt) = prepend_join(final_pctxts)?;
         for (&i, action) in final_blocks.iter().zip(actions.iter()) {
             if !action.is_empty() {
                 let mut stmts_to_add = Vec::new();
@@ -361,7 +368,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
     }
 
     fn generate_final_statements(
-        &mut self,
+        &self,
         cfg: &borrows::CFG,
         label: Option<&str>,
     ) -> Vec<vir::Stmt> {
@@ -411,6 +418,138 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
             ),
             |writer| cfg.to_graphviz(writer, curr_block_index),
         );
+    }
+
+    /// Restore `Write` permissions that were converted to `Read` due to borrowing.
+    fn restore_write_permissions(
+        &self,
+        borrow: vir::borrows::Borrow,
+        pctxt: &mut PathCtxt,
+    ) -> Result<Vec<vir::Stmt>, FoldUnfoldError> {
+        trace!("[enter] restore_write_permissions({:?})", borrow);
+        let mut stmts = Vec::new();
+        for access in pctxt.log().get_converted_to_read_places(borrow) {
+            trace!("restore_write_permissions access={}", access);
+            let perm = match access {
+                vir::Expr::PredicateAccessPredicate(vir::PredicateAccessPredicate {
+                                                        box ref argument,
+                                                        permission,
+                                                        ..
+                                                    }) => {
+                    assert!(permission == vir::PermAmount::Remaining);
+                    Perm::pred(argument.clone(), vir::PermAmount::Read)
+                }
+                vir::Expr::FieldAccessPredicate(vir::FieldAccessPredicate {
+                                                    box ref base,
+                                                    permission,
+                                                    ..
+                                                }) => {
+                    assert!(permission == vir::PermAmount::Remaining);
+                    Perm::acc(base.clone(), vir::PermAmount::Read)
+                }
+                x => unreachable!("{:?}", x),
+            };
+            stmts.extend(
+                pctxt
+                    .obtain_permissions(vec![perm])?
+                    .iter()
+                    .map(|a| a.to_stmt()),
+            );
+            let inhale_stmt = vir::Stmt::Inhale(vir::Inhale { expr: access });
+            pctxt.apply_stmt(&inhale_stmt)?;
+            stmts.push(inhale_stmt);
+        }
+
+        // Log borrow expiration
+        pctxt.log_mut().log_borrow_expiration(borrow);
+
+        trace!(
+            "[exit] restore_write_permissions({:?}) = {}",
+            borrow,
+            vir::stmts_to_str(&stmts)
+        );
+        Ok(stmts)
+    }
+
+    /// Wrap `_1.val_ref.f.g.` into `old[label](_1.val_ref).f.g`. This is needed
+    /// to make `_1.val_ref` reachable inside a package statement of a magic wand.
+    fn patch_places(&self, stmts: &[vir::Stmt], maybe_label: Option<&str>) -> Vec<vir::Stmt> {
+        if let Some(label) = maybe_label {
+            struct PlacePatcher<'a> {
+                label: &'a str,
+            }
+            impl<'a> vir::ExprFolder for PlacePatcher<'a> {
+                fn fold(&mut self, e: vir::Expr) -> vir::Expr {
+                    match e {
+                        vir::Expr::Field(vir::FieldExpr {
+                                             base: box vir::Expr::Local(_),
+                                             ..
+                                         }) => e.old(self.label),
+                        _ => vir::default_fold_expr(self, e),
+                    }
+                }
+                fn fold_labelled_old(&mut self, labelled_old: vir::LabelledOld) -> vir::Expr {
+                    // Do not replace places that are already old.
+                    vir::Expr::LabelledOld(labelled_old)
+                }
+            }
+            fn patch_expr(label: &str, expr: &vir::Expr) -> vir::Expr {
+                PlacePatcher { label }.fold(expr.clone())
+            }
+            fn patch_args(label: &str, args: &[vir::Expr]) -> Vec<vir::Expr> {
+                args.iter()
+                    .map(|arg| {
+                        assert!(arg.is_place());
+                        patch_expr(label, arg)
+                    })
+                    .collect()
+            }
+            stmts
+                .iter()
+                .map(|stmt| match stmt {
+                    vir::Stmt::Comment(_)
+                    | vir::Stmt::ApplyMagicWand(_)
+                    | vir::Stmt::TransferPerm(_)
+                    | vir::Stmt::Assign(_) => stmt.clone(),
+                    vir::Stmt::Inhale(vir::Inhale { expr }) => vir::Stmt::Inhale(vir::Inhale {
+                        expr: patch_expr(label, expr),
+                    }),
+                    vir::Stmt::Exhale(vir::Exhale { expr, position }) => {
+                        vir::Stmt::Exhale(vir::Exhale {
+                            expr: patch_expr(label, expr),
+                            position: *position,
+                        })
+                    }
+                    vir::Stmt::Fold(vir::Fold {
+                                        ref predicate_name,
+                                        ref arguments,
+                                        permission,
+                                        enum_variant,
+                                        position,
+                                    }) => vir::Stmt::Fold(vir::Fold {
+                        predicate_name: predicate_name.clone(),
+                        arguments: patch_args(label, arguments),
+                        permission: *permission,
+                        enum_variant: enum_variant.clone(),
+                        position: *position,
+                    }),
+                    vir::Stmt::Unfold(vir::Unfold {
+                                          ref predicate_name,
+                                          ref arguments,
+                                          permission,
+                                          enum_variant,
+                                      }) => vir::Stmt::Unfold(vir::Unfold {
+                        predicate_name: predicate_name.clone(),
+                        arguments: patch_args(label, arguments),
+                        permission: *permission,
+                        enum_variant: enum_variant.clone(),
+                    }),
+                    x => unreachable!("{}", x),
+                })
+                .collect()
+        } else {
+            stmts.to_vec()
+        }
     }
 }
 

--- a/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
+++ b/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
@@ -5,6 +5,7 @@ use vir_crate::polymorphic::{self as vir, CfgReplacer};
 use super::{action::Action, borrows, path_ctxt::PathCtxt, FoldUnfold, FoldUnfoldError};
 use crate::encoder::foldunfold::{Perm, prepend_join};
 use vir_crate::polymorphic::ExprFolder;
+use crate::encoder::Encoder;
 
 impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
     /// Generates Viper statements that expire all the borrows from the given `dag`. The
@@ -25,7 +26,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
         let mut final_pctxt: Vec<Option<PathCtxt>> = vec![None; cfg.basic_blocks.len()];
 
         for curr_block_index in 0..cfg.basic_blocks.len() {
-            self.dump_debug_info(dag, &cfg, surrounding_block_index, curr_block_index);
+            if self.dump_debug_info {
+                dump_borrows_cfg(self.encoder, dag, &cfg, surrounding_block_index, curr_block_index);
+            }
 
             let (mut pctxt, curr_block_pre_statements) = self.construct_initial_pctxt(
                 dag,
@@ -38,8 +41,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
             )?;
             cfg.basic_blocks[curr_block_index].statements.extend(curr_block_pre_statements);
 
-            self.dump_debug_info(dag, &cfg, surrounding_block_index, curr_block_index);
-
             let curr_block = &mut cfg.basic_blocks[curr_block_index];
             self.process_node(
                 surrounding_pctxt,
@@ -49,17 +50,16 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 curr_block_index,
                 label,
                 &mut pctxt,
+                self.method_pos,
             )?;
-
-            self.dump_debug_info(dag, &cfg, surrounding_block_index, curr_block_index);
 
             final_pctxt[curr_block_index] = Some(pctxt);
         }
 
         // Merge all pctxts with reborrowed_nodes.is_empty() into one.
-        *surrounding_pctxt = self.construct_final_pctxt(dag, &mut cfg, &final_pctxt)?;
+        *surrounding_pctxt = construct_final_pctxt(dag, &mut cfg, &final_pctxt)?;
 
-        let final_statements = self.generate_final_statements(&cfg, label);
+        let final_statements = generate_final_statements(&cfg, label);
         debug!(
             "[exit] process_expire_borrows = [\n{}\n]",
             final_statements.iter().map(|s| s.to_string()).collect::<Vec<_>>().join("\n  ")
@@ -229,6 +229,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
         curr_block_index: usize,
         label: Option<&str>,
         pctxt: &mut PathCtxt<'p>,
+        method_pos: vir::Position,
     ) -> Result<(), FoldUnfoldError> {
         let curr_node = &curr_block.node;
         trace!("process_node: {:?}", curr_node);
@@ -242,13 +243,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
                 curr_block_index, curr_node.borrow, stmt
             );
             let new_stmts = self.replace_stmt( // EXTERNAL
-                stmt_index,
-                stmt,
-                false,
-                pctxt,
-                surrounding_block_index,
-                new_cfg,
-                label,
+                   stmt_index,
+                   stmt,
+                   false,
+                   pctxt,
+                   surrounding_block_index,
+                   new_cfg,
+                   label,
             )?;
             curr_block.statements.extend(new_stmts);
         }
@@ -269,16 +270,16 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
             maybe_original_place = Some(original_place);
             let stmt = vir::Stmt::Exhale(vir::Exhale {
                 expr: read_access,
-                position: self.method_pos,
+                position: method_pos,
             });
             let new_stmts = self.replace_stmt( // EXTERNAL
-                curr_block.statements.len(),
-                &stmt,
-                false,
-                pctxt,
-                surrounding_block_index,
-                new_cfg,
-                label,
+                   curr_block.statements.len(),
+                   &stmt,
+                   false,
+                   pctxt,
+                   surrounding_block_index,
+                   new_cfg,
+                   label,
             )?;
             curr_block.statements.extend(new_stmts);
         }
@@ -308,11 +309,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
             for &borrow in &curr_node.conflicting_borrows {
                 curr_block
                     .statements
-                    .extend(self.restore_write_permissions(borrow, pctxt)?);
+                    .extend(restore_write_permissions(borrow, pctxt)?);
             }
             curr_block
                 .statements
-                .extend(self.restore_write_permissions(curr_node.borrow, pctxt)?);
+                .extend(restore_write_permissions(curr_node.borrow, pctxt)?);
         }
         trace!(
             "curr_node.alive_conflicting_borrows={:?}",
@@ -325,232 +326,226 @@ impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {
 
         Ok(())
     }
+}
 
-    fn construct_final_pctxt(
-        &self,
-        dag: &vir::borrows::DAG,
-        cfg: &mut borrows::CFG,
-        final_pctxt: &[Option<PathCtxt<'p>>],
-    ) -> Result<PathCtxt<'p>, FoldUnfoldError> {
-        let final_blocks: Vec<_> = cfg
-            .basic_blocks
-            .iter()
-            .enumerate()
-            .filter(|(_, block)| block.successors.is_empty())
-            .map(|(i, _)| i)
-            .collect();
-        let final_pctxts: Vec<_> = final_blocks
-            .iter()
-            .map(|i| final_pctxt[*i].as_ref().unwrap())
-            .collect();
-        let (actions, mut final_pctxt) = prepend_join(final_pctxts)?;
-        for (&i, action) in final_blocks.iter().zip(actions.iter()) {
-            if !action.is_empty() {
-                let mut stmts_to_add = Vec::new();
-                for a in action.deref() {
-                    stmts_to_add.push(a.to_stmt());
-                    if let Action::Drop(perm, missing_perm) = a {
-                        if dag.in_borrowed_places(missing_perm.get_place())
-                            && perm.get_perm_amount() != vir::PermAmount::Read
-                        {
-                            let comment =
-                                format!("restored (in branch merge): {} ({})", perm, missing_perm);
-                            stmts_to_add.push(vir::Stmt::comment(comment));
-                            final_pctxt.mut_state().restore_dropped_perm(perm.clone())?;
-                        }
+fn construct_final_pctxt<'p>(
+    dag: &vir::borrows::DAG,
+    cfg: &mut borrows::CFG,
+    final_pctxt: &[Option<PathCtxt<'p>>],
+) -> Result<PathCtxt<'p>, FoldUnfoldError> {
+    let final_blocks: Vec<_> = cfg
+        .basic_blocks
+        .iter()
+        .enumerate()
+        .filter(|(_, block)| block.successors.is_empty())
+        .map(|(i, _)| i)
+        .collect();
+    let final_pctxts: Vec<_> = final_blocks
+        .iter()
+        .map(|i| final_pctxt[*i].as_ref().unwrap())
+        .collect();
+    let (actions, mut final_pctxt) = prepend_join(final_pctxts)?;
+    for (&i, action) in final_blocks.iter().zip(actions.iter()) {
+        if !action.is_empty() {
+            let mut stmts_to_add = Vec::new();
+            for a in action.deref() {
+                stmts_to_add.push(a.to_stmt());
+                if let Action::Drop(perm, missing_perm) = a {
+                    if dag.in_borrowed_places(missing_perm.get_place())
+                        && perm.get_perm_amount() != vir::PermAmount::Read
+                    {
+                        let comment =
+                            format!("restored (in branch merge): {} ({})", perm, missing_perm);
+                        stmts_to_add.push(vir::Stmt::comment(comment));
+                        final_pctxt.mut_state().restore_dropped_perm(perm.clone())?;
                     }
                 }
-                //let stmts_to_add = action.iter().map(|a| a.to_stmt());
-                cfg.basic_blocks[i].statements.extend(stmts_to_add);
+            }
+            //let stmts_to_add = action.iter().map(|a| a.to_stmt());
+            cfg.basic_blocks[i].statements.extend(stmts_to_add);
+        }
+    }
+    Ok(final_pctxt)
+}
+
+fn dump_borrows_cfg(
+    encoder: &Encoder,
+    dag: &vir::borrows::DAG,
+    cfg: &borrows::CFG,
+    surrounding_block_index: vir::CfgBlockIndex,
+    curr_block_index: usize,
+) {
+    let source_path = encoder.env().source_path();
+    let source_filename = source_path.file_name().unwrap().to_str().unwrap();
+    report::log::report_with_writer(
+        "graphviz_reborrowing_dag_during_foldunfold",
+        format!(
+            "{}.{:?}.{}.dot",
+            source_filename,
+            dag,
+            surrounding_block_index.index()
+        ),
+        |writer| cfg.to_graphviz(writer, curr_block_index),
+    );
+}
+
+fn generate_final_statements(
+    cfg: &borrows::CFG,
+    label: Option<&str>,
+) -> Vec<vir::Stmt> {
+    let mut stmts = Vec::new();
+    for (i, block) in cfg.basic_blocks.iter().enumerate() {
+        stmts.push(vir::Stmt::If(vir::If {
+            guard: block.guard.clone(),
+            then_stmts: patch_places(&block.statements, label),
+            else_stmts: vec![],
+        }));
+        for ((from, to), statements) in &cfg.edges {
+            if *from == i {
+                let condition = vir::Expr::and(
+                    block.guard.clone(),
+                    cfg.basic_blocks[*to].current_guard.clone(),
+                );
+                stmts.push(vir::Stmt::If(vir::If {
+                    guard: condition,
+                    then_stmts: patch_places(statements, label),
+                    else_stmts: vec![],
+                }));
             }
         }
-        Ok(final_pctxt)
     }
+    stmts
+}
 
-    fn generate_final_statements(
-        &self,
-        cfg: &borrows::CFG,
-        label: Option<&str>,
-    ) -> Vec<vir::Stmt> {
-        let mut stmts = Vec::new();
-        for (i, block) in cfg.basic_blocks.iter().enumerate() {
-            stmts.push(vir::Stmt::If(vir::If {
-                guard: block.guard.clone(),
-                then_stmts: self.patch_places(&block.statements, label),
-                else_stmts: vec![],
-            }));
-            for ((from, to), statements) in &cfg.edges {
-                if *from == i {
-                    let condition = vir::Expr::and(
-                        block.guard.clone(),
-                        cfg.basic_blocks[*to].current_guard.clone(),
-                    );
-                    stmts.push(vir::Stmt::If(vir::If {
-                        guard: condition,
-                        then_stmts: self.patch_places(statements, label),
-                        else_stmts: vec![],
-                    }));
+/// Wrap `_1.val_ref.f.g.` into `old[label](_1.val_ref).f.g`. This is needed
+/// to make `_1.val_ref` reachable inside a package statement of a magic wand.
+fn patch_places(stmts: &[vir::Stmt], maybe_label: Option<&str>) -> Vec<vir::Stmt> {
+    if let Some(label) = maybe_label {
+        struct PlacePatcher<'a> {
+            label: &'a str,
+        }
+        impl<'a> vir::ExprFolder for PlacePatcher<'a> {
+            fn fold(&mut self, e: vir::Expr) -> vir::Expr {
+                match e {
+                    vir::Expr::Field(vir::FieldExpr {
+                                         base: box vir::Expr::Local(_),
+                                         ..
+                                     }) => e.old(self.label),
+                    _ => vir::default_fold_expr(self, e),
                 }
             }
+            fn fold_labelled_old(&mut self, labelled_old: vir::LabelledOld) -> vir::Expr {
+                // Do not replace places that are already old.
+                vir::Expr::LabelledOld(labelled_old)
+            }
+        }
+        fn patch_expr(label: &str, expr: &vir::Expr) -> vir::Expr {
+            PlacePatcher { label }.fold(expr.clone())
+        }
+        fn patch_args(label: &str, args: &[vir::Expr]) -> Vec<vir::Expr> {
+            args.iter()
+                .map(|arg| {
+                    assert!(arg.is_place());
+                    patch_expr(label, arg)
+                })
+                .collect()
         }
         stmts
-    }
-
-    fn dump_debug_info(
-        &self,
-        dag: &vir::borrows::DAG,
-        cfg: &borrows::CFG,
-        surrounding_block_index: vir::CfgBlockIndex,
-        curr_block_index: usize,
-    ) {
-        if !self.dump_debug_info {
-            return;
-        }
-        let source_path = self.encoder.env().source_path();
-        let source_filename = source_path.file_name().unwrap().to_str().unwrap();
-        report::log::report_with_writer(
-            "graphviz_reborrowing_dag_during_foldunfold",
-            format!(
-                "{}.{:?}.{}.dot",
-                source_filename,
-                dag,
-                surrounding_block_index.index()
-            ),
-            |writer| cfg.to_graphviz(writer, curr_block_index),
-        );
-    }
-
-    /// Restore `Write` permissions that were converted to `Read` due to borrowing.
-    fn restore_write_permissions(
-        &self,
-        borrow: vir::borrows::Borrow,
-        pctxt: &mut PathCtxt,
-    ) -> Result<Vec<vir::Stmt>, FoldUnfoldError> {
-        trace!("[enter] restore_write_permissions({:?})", borrow);
-        let mut stmts = Vec::new();
-        for access in pctxt.log().get_converted_to_read_places(borrow) {
-            trace!("restore_write_permissions access={}", access);
-            let perm = match access {
-                vir::Expr::PredicateAccessPredicate(vir::PredicateAccessPredicate {
-                                                        box ref argument,
-                                                        permission,
-                                                        ..
-                                                    }) => {
-                    assert!(permission == vir::PermAmount::Remaining);
-                    Perm::pred(argument.clone(), vir::PermAmount::Read)
+            .iter()
+            .map(|stmt| match stmt {
+                vir::Stmt::Comment(_)
+                | vir::Stmt::ApplyMagicWand(_)
+                | vir::Stmt::TransferPerm(_)
+                | vir::Stmt::Assign(_) => stmt.clone(),
+                vir::Stmt::Inhale(vir::Inhale { expr }) => vir::Stmt::Inhale(vir::Inhale {
+                    expr: patch_expr(label, expr),
+                }),
+                vir::Stmt::Exhale(vir::Exhale { expr, position }) => {
+                    vir::Stmt::Exhale(vir::Exhale {
+                        expr: patch_expr(label, expr),
+                        position: *position,
+                    })
                 }
-                vir::Expr::FieldAccessPredicate(vir::FieldAccessPredicate {
-                                                    box ref base,
+                vir::Stmt::Fold(vir::Fold {
+                                    ref predicate_name,
+                                    ref arguments,
+                                    permission,
+                                    enum_variant,
+                                    position,
+                                }) => vir::Stmt::Fold(vir::Fold {
+                    predicate_name: predicate_name.clone(),
+                    arguments: patch_args(label, arguments),
+                    permission: *permission,
+                    enum_variant: enum_variant.clone(),
+                    position: *position,
+                }),
+                vir::Stmt::Unfold(vir::Unfold {
+                                      ref predicate_name,
+                                      ref arguments,
+                                      permission,
+                                      enum_variant,
+                                  }) => vir::Stmt::Unfold(vir::Unfold {
+                    predicate_name: predicate_name.clone(),
+                    arguments: patch_args(label, arguments),
+                    permission: *permission,
+                    enum_variant: enum_variant.clone(),
+                }),
+                x => unreachable!("{}", x),
+            })
+            .collect()
+    } else {
+        stmts.to_vec()
+    }
+}
+
+/// Restore `Write` permissions that were converted to `Read` due to borrowing.
+fn restore_write_permissions(
+    borrow: vir::borrows::Borrow,
+    pctxt: &mut PathCtxt,
+) -> Result<Vec<vir::Stmt>, FoldUnfoldError> {
+    trace!("[enter] restore_write_permissions({:?})", borrow);
+    let mut stmts = Vec::new();
+    for access in pctxt.log().get_converted_to_read_places(borrow) {
+        trace!("restore_write_permissions access={}", access);
+        let perm = match access {
+            vir::Expr::PredicateAccessPredicate(vir::PredicateAccessPredicate {
+                                                    box ref argument,
                                                     permission,
                                                     ..
                                                 }) => {
-                    assert!(permission == vir::PermAmount::Remaining);
-                    Perm::acc(base.clone(), vir::PermAmount::Read)
-                }
-                x => unreachable!("{:?}", x),
-            };
-            stmts.extend(
-                pctxt
-                    .obtain_permissions(vec![perm])?
-                    .iter()
-                    .map(|a| a.to_stmt()),
-            );
-            let inhale_stmt = vir::Stmt::Inhale(vir::Inhale { expr: access });
-            pctxt.apply_stmt(&inhale_stmt)?;
-            stmts.push(inhale_stmt);
-        }
-
-        // Log borrow expiration
-        pctxt.log_mut().log_borrow_expiration(borrow);
-
-        trace!(
-            "[exit] restore_write_permissions({:?}) = {}",
-            borrow,
-            vir::stmts_to_str(&stmts)
-        );
-        Ok(stmts)
-    }
-
-    /// Wrap `_1.val_ref.f.g.` into `old[label](_1.val_ref).f.g`. This is needed
-    /// to make `_1.val_ref` reachable inside a package statement of a magic wand.
-    fn patch_places(&self, stmts: &[vir::Stmt], maybe_label: Option<&str>) -> Vec<vir::Stmt> {
-        if let Some(label) = maybe_label {
-            struct PlacePatcher<'a> {
-                label: &'a str,
+                assert!(permission == vir::PermAmount::Remaining);
+                Perm::pred(argument.clone(), vir::PermAmount::Read)
             }
-            impl<'a> vir::ExprFolder for PlacePatcher<'a> {
-                fn fold(&mut self, e: vir::Expr) -> vir::Expr {
-                    match e {
-                        vir::Expr::Field(vir::FieldExpr {
-                                             base: box vir::Expr::Local(_),
-                                             ..
-                                         }) => e.old(self.label),
-                        _ => vir::default_fold_expr(self, e),
-                    }
-                }
-                fn fold_labelled_old(&mut self, labelled_old: vir::LabelledOld) -> vir::Expr {
-                    // Do not replace places that are already old.
-                    vir::Expr::LabelledOld(labelled_old)
-                }
+            vir::Expr::FieldAccessPredicate(vir::FieldAccessPredicate {
+                                                box ref base,
+                                                permission,
+                                                ..
+                                            }) => {
+                assert!(permission == vir::PermAmount::Remaining);
+                Perm::acc(base.clone(), vir::PermAmount::Read)
             }
-            fn patch_expr(label: &str, expr: &vir::Expr) -> vir::Expr {
-                PlacePatcher { label }.fold(expr.clone())
-            }
-            fn patch_args(label: &str, args: &[vir::Expr]) -> Vec<vir::Expr> {
-                args.iter()
-                    .map(|arg| {
-                        assert!(arg.is_place());
-                        patch_expr(label, arg)
-                    })
-                    .collect()
-            }
-            stmts
+            x => unreachable!("{:?}", x),
+        };
+        stmts.extend(
+            pctxt
+                .obtain_permissions(vec![perm])?
                 .iter()
-                .map(|stmt| match stmt {
-                    vir::Stmt::Comment(_)
-                    | vir::Stmt::ApplyMagicWand(_)
-                    | vir::Stmt::TransferPerm(_)
-                    | vir::Stmt::Assign(_) => stmt.clone(),
-                    vir::Stmt::Inhale(vir::Inhale { expr }) => vir::Stmt::Inhale(vir::Inhale {
-                        expr: patch_expr(label, expr),
-                    }),
-                    vir::Stmt::Exhale(vir::Exhale { expr, position }) => {
-                        vir::Stmt::Exhale(vir::Exhale {
-                            expr: patch_expr(label, expr),
-                            position: *position,
-                        })
-                    }
-                    vir::Stmt::Fold(vir::Fold {
-                                        ref predicate_name,
-                                        ref arguments,
-                                        permission,
-                                        enum_variant,
-                                        position,
-                                    }) => vir::Stmt::Fold(vir::Fold {
-                        predicate_name: predicate_name.clone(),
-                        arguments: patch_args(label, arguments),
-                        permission: *permission,
-                        enum_variant: enum_variant.clone(),
-                        position: *position,
-                    }),
-                    vir::Stmt::Unfold(vir::Unfold {
-                                          ref predicate_name,
-                                          ref arguments,
-                                          permission,
-                                          enum_variant,
-                                      }) => vir::Stmt::Unfold(vir::Unfold {
-                        predicate_name: predicate_name.clone(),
-                        arguments: patch_args(label, arguments),
-                        permission: *permission,
-                        enum_variant: enum_variant.clone(),
-                    }),
-                    x => unreachable!("{}", x),
-                })
-                .collect()
-        } else {
-            stmts.to_vec()
-        }
+                .map(|a| a.to_stmt()),
+        );
+        let inhale_stmt = vir::Stmt::Inhale(vir::Inhale { expr: access });
+        pctxt.apply_stmt(&inhale_stmt)?;
+        stmts.push(inhale_stmt);
     }
+
+    // Log borrow expiration
+    pctxt.log_mut().log_borrow_expiration(borrow);
+
+    trace!(
+        "[exit] restore_write_permissions({:?}) = {}",
+        borrow,
+        vir::stmts_to_str(&stmts)
+    );
+    Ok(stmts)
 }
 
 fn build_initial_cfg(dag: &vir::borrows::DAG) -> borrows::CFG {

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -53,7 +53,7 @@ impl ApplyOnState for vir::Stmt {
         state: &mut State,
         predicates: &HashMap<String, vir::Predicate>,
     ) -> Result<(), FoldUnfoldError> {
-        debug!("apply_on_state '{}'", self);
+        trace!("apply_on_state '{}'", self);
         trace!("State acc before {{\n{}\n}}", state.display_acc());
         trace!("State pred before {{\n{}\n}}", state.display_pred());
         trace!("State moved before {{\n{}\n}}", state.display_moved());
@@ -337,7 +337,7 @@ impl ApplyOnState for vir::Stmt {
 
                 // Move also the acc permission if the rhs is old.
                 if state.contains_acc(left) && !state.contains_acc(right) && right.is_old() {
-                    debug!("Moving acc({}) to acc({}) state.", left, right);
+                    trace!("Moving acc({}) to acc({}) state.", left, right);
                     state.insert_acc(right.clone(), *state.acc().get(left).unwrap())?;
                     if !left.is_local() && !left.is_curr() {
                         state.remove_acc_place(left);
@@ -352,7 +352,7 @@ impl ApplyOnState for vir::Stmt {
                 /*
                 // Hack: Move also the acc permission
                 if state.contains_acc(lhs_place) && !state.contains_acc(rhs_place) {
-                    debug!("Moving acc({}) to acc({}) state.", lhs_place, rhs_place);
+                    trace!("Moving acc({}) to acc({}) state.", lhs_place, rhs_place);
                     state.insert_acc(
                         rhs_place.clone(),
                         state.acc().get(lhs_place).unwrap().clone()
@@ -412,12 +412,12 @@ impl ApplyOnState for vir::Stmt {
                 if let Some(found_variant) = find_unfolded_variant(state, enum_place) {
                     // The enum has already been downcasted.
                     debug_assert!(field.name.ends_with(found_variant.get_variant_name()));
-                    debug!(
+                    trace!(
                         "Place {} has already been downcasted to {}",
                         enum_place, field
                     );
                 } else {
-                    debug!("Downcast {} to {}", enum_place, field);
+                    trace!("Downcast {} to {}", enum_place, field);
                     let predicate_name = enum_place.typed_ref_name().unwrap();
                     let predicate = predicates.get(&predicate_name).unwrap();
                     if let vir::Predicate::Enum(enum_predicate) = predicate {
@@ -437,7 +437,7 @@ impl ApplyOnState for vir::Stmt {
                             trace!("Downcast adds variant's footprint {:?}", variant_footprint);
                             state.insert_all_perms(variant_footprint.into_iter())?;
                         } else {
-                            debug!("Place {} has not been unfolded yet", discriminant_place);
+                            trace!("Place {} has not been unfolded yet", discriminant_place);
                         }
                     } else {
                         unreachable!()

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -414,7 +414,8 @@ impl ApplyOnState for vir::Stmt {
                     debug_assert!(field.name.ends_with(found_variant.get_variant_name()));
                     trace!(
                         "Place {} has already been downcasted to {}",
-                        enum_place, field
+                        enum_place,
+                        field
                     );
                 } else {
                     trace!("Downcast {} to {}", enum_place, field);

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1059,7 +1059,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         // Encode statements to inform fold-unfold of the downcasts
         let mut downcast_stmts = vec![];
         for (place, variant_idx) in self.mir_encoder.get_downcasts_at_location(location).into_iter() {
-            let span = self.mir_encoder.get_span_of_location(location);
             let (encoded_place, pre_stmts, place_ty, _) = self
                     // TODO: may need to look at place to decide the arrayaccesskind here
                     .encode_projection(place.local, &place.projection, ArrayAccessKind::Shared, location)?;
@@ -3456,11 +3455,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 ).with_span(span)?;
                 let vir_access =
                     vir::Expr::pred_permission(place_expr.clone().old(label), perm_amount).unwrap();
-                self
+                let inv = self
                     .encoder
                     .encode_invariant_func_app(place_ty, place_expr.old(label))
-                    .with_span(span)
-                    .map(|inv| vir::Expr::and(vir_access, inv))
+                    .with_span(span)?;
+                Ok(vir::Expr::and(vir_access, inv))
             };
             let mut lhs: Vec<_> = borrow_info
                 .blocking_paths

--- a/prusti-viper/src/utils/mod.rs
+++ b/prusti-viper/src/utils/mod.rs
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use rustc_middle::ty;
+use rustc_middle::mir;
 
 pub mod to_string;
 pub mod type_visitor;
@@ -42,4 +43,8 @@ pub fn ty_to_string(typ: &ty::TyKind) -> String {
 
 pub fn is_reference(base_ty: ty::Ty) -> bool {
     matches!(base_ty.kind(), ty::TyKind::RawPtr(..) | ty::TyKind::Ref(..))
+}
+
+pub fn is_shared_reference(base_ty: ty::Ty) -> bool {
+    matches!(base_ty.kind(), ty::TyKind::Ref(_, _, mir::Mutability::Not))
 }


### PR DESCRIPTION
The code that processes expiring borrows seems unnecessarily complicated. In this PR I'm rewriting its methods that don't use `self` into functions, I'm replacing various `&mut self` with `&self` and I'm moving many `debug!` messages to `trace!`. 