### PR TITLE
Display an error message if an unsupported index type is used.

### DIFF
--- a/prusti-tests/tests/verify_overflow/fail/index-vec.rs
+++ b/prusti-tests/tests/verify_overflow/fail/index-vec.rs
@@ -3,7 +3,7 @@ use prusti_contracts::*;
 
 #[pure]
 fn get_third(v: &Vec<u32>) -> u32 {
-    v[2] //~ ERROR Using usize as index/range type for &std::vec::Vec<u32> is not supported yet
+    v[2] //~ ERROR Using usize as index/range type for &std::vec::Vec<u32> is not currently supported in pure functions
 }
 
 fn main(){}

--- a/prusti-tests/tests/verify_overflow/fail/index-vec.rs
+++ b/prusti-tests/tests/verify_overflow/fail/index-vec.rs
@@ -1,0 +1,9 @@
+extern crate prusti_contracts;
+use prusti_contracts::*;
+
+#[pure]
+fn get_third(v: &Vec<u32>) -> u32 {
+    v[2] //~ ERROR Using usize as index/range type for &std::vec::Vec<u32> is not supported yet
+}
+
+fn main(){}

--- a/prusti-viper/src/encoder/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/pure_functions/interpreter.rs
@@ -506,11 +506,18 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 let base_ty = self.mir_encoder.get_operand_ty(&args[0]);
 
                                 let idx_ty = self.mir_encoder.get_operand_ty(&args[1]);
+                                let idx_ty_did = match idx_ty.ty_adt_def() {
+                                    Some(def) => def.did,
+                                    None => return Err(SpannedEncodingError::unsupported(
+                                        format!("Using {} as index/range type for {} is not supported yet", idx_ty, base_ty),
+                                        span,
+                                    ))
+                                };
                                 let idx_ident = self
                                     .encoder
                                     .env()
                                     .tcx()
-                                    .def_path_str(idx_ty.ty_adt_def().unwrap().did);
+                                    .def_path_str(idx_ty_did);
                                 let encoded_idx = &encoded_args[1];
 
                                 let (start, end) = match &*idx_ident {

--- a/prusti-viper/src/encoder/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/pure_functions/interpreter.rs
@@ -513,11 +513,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                         span,
                                     ))
                                 };
-                                let idx_ident = self
-                                    .encoder
-                                    .env()
-                                    .tcx()
-                                    .def_path_str(idx_ty_did);
+                                let idx_ident = self.encoder.env().tcx().def_path_str(idx_ty_did);
                                 let encoded_idx = &encoded_args[1];
 
                                 let (start, end) = match &*idx_ident {

--- a/prusti-viper/src/encoder/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/pure_functions/interpreter.rs
@@ -509,7 +509,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 let idx_ty_did = match idx_ty.ty_adt_def() {
                                     Some(def) => def.did,
                                     None => return Err(SpannedEncodingError::unsupported(
-                                        format!("Using {} as index/range type for {} is not supported yet", idx_ty, base_ty),
+                                        format!("Using {} as index/range type for {} is not currently supported in pure functions", idx_ty, base_ty),
                                         span,
                                     ))
                                 };


### PR DESCRIPTION
Previously, the following pure function would cause Prusti to crash:

```rust
#[pure]
fn get_third(v: &Vec<u32>) -> u32 {
    v[2]
}
```

with the error:

```
thread 'rustc' panicked at 'called `Option::unwrap()` on a `None` value', prusti-viper/src/encoder/pure_functions/interpreter.rs:513:71
```

Now, it reports an error:
```
[Prusti: unsupported feature] Using usize as index/range type for &std::vec::Vec<u32> is not supported yet
```