### PR TITLE
Fix issue #693

### DIFF
--- a/prusti-common/src/vir/optimizations/mod.rs
+++ b/prusti-common/src/vir/optimizations/mod.rs
@@ -50,7 +50,7 @@ fn log_methods(
 pub fn optimize_program(p: Program, source_file_name: &str) -> Program {
     let mut program = p;
     let optimizations = config::optimizations();
-    info!("Enabled optimisations: {:?}", optimizations);
+    debug!("Enabled optimisations: {:?}", optimizations);
 
     // can't borrow self because we need to move fields
     if optimizations.inline_constant_functions {

--- a/prusti-interface/src/environment/mir_analyses/initialization.rs
+++ b/prusti-interface/src/environment/mir_analyses/initialization.rs
@@ -37,7 +37,7 @@ pub fn compute_definitely_initialized<'a, 'tcx: 'a>(
     body: &'a mir::Body<'tcx>,
     tcx: TyCtxt<'tcx>,
 ) -> DefinitelyInitializedAnalysisResult<'tcx> {
-    let stopwatch = Stopwatch::start("prusti-client", "initialization analysis");
+    let stopwatch = Stopwatch::start_debug("prusti-client", "initialization analysis");
     let analyzer = Analyzer::new(tcx);
     let pointwise_state = analyzer.run_fwd_analysis::<DefinitelyInitializedState>(body)
         .map_err(|e| panic!("Error while analyzing function at {:?}: {}", body.span, e.to_pretty_str(body)))

--- a/prusti-tests/tests/verify/ui/forall_triggers.stderr
+++ b/prusti-tests/tests/verify/ui/forall_triggers.stderr
@@ -1,4 +1,4 @@
-error: [Prusti: invalid specification] A trigger must mention all bounded variables.
+error: [Prusti: invalid specification] a trigger must mention all bounded variables.
   --> $DIR/forall_triggers.rs:12:79
    |
 12 | #[requires(forall(|n: usize, res: usize| count(n) == res ==> true, triggers=[(count(n),)]))]

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-693-1.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-693-1.rs
@@ -1,0 +1,18 @@
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+pub struct A;
+
+impl A {
+    #[pure]
+    pub fn get(&self) -> A {
+        A
+    }
+}
+
+#[pure]
+pub fn test(a: A) -> A {
+    a.get().get()
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-693-2.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-693-2.rs
@@ -1,0 +1,23 @@
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+pub struct A;
+
+impl A {
+    #[pure]
+    pub fn get(&self) -> A {
+        A
+    }
+
+    #[pure]
+    pub fn len(&self) -> usize {
+        0
+    }
+}
+
+#[pure]
+pub fn test(a: A) -> usize {
+    a.get().len()
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-693-3.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-693-3.rs
@@ -1,0 +1,23 @@
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+pub struct A;
+
+impl A {
+    #[pure]
+    pub fn len(&self) -> usize {
+        0
+    }
+}
+
+#[pure]
+pub fn a() -> A {
+    A
+}
+
+#[pure]
+pub fn test() -> usize {
+    a().len()
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-693-4.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-693-4.rs
@@ -1,0 +1,23 @@
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+pub struct A(usize);
+
+impl A {
+    #[pure]
+    pub fn len(&self) -> usize {
+        0
+    }
+}
+
+#[pure]
+pub fn a() -> A {
+    A(0)
+}
+
+#[pure]
+pub fn test() -> usize {
+    a().len()
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -713,6 +713,8 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         self.snapshot_encoder.borrow_mut().encode_type(self, ty, tymap)
     }
 
+    /// Encodes a snapshot constructor directly. Can only be used on ADTs with
+    /// a single variant.
     pub fn encode_snapshot_constructor(
         &self,
         ty: ty::Ty<'tcx>,

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -277,6 +277,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         self.procedures.borrow_mut().drain().map(|(_, value)| value).collect()
     }
 
+    /// Return, if there is any, the unique instantiation of the given closure.
     pub fn get_single_closure_instantiation(
         &self,
         closure_def_id: DefId,
@@ -893,11 +894,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             let proc_name = self.env.get_absolute_item_name(proc_def_id);
             let proc_def_path = self.env.get_item_def_path(proc_def_id);
             let wrapper_def_id = self.get_wrapper_def_id(proc_def_id);
-            let proc_span = self.env.get_item_span(wrapper_def_id);
-            info!(
-                "Encoding: {} from {:?} ({})",
-                proc_name, proc_span, proc_def_path
-            );
+            info!("Encoding: {} ({})", proc_name, proc_def_path);
             assert!(substs.is_empty());
             if self.is_pure(proc_def_id) {
                 // Check that the pure Rust function satisfies the basic

--- a/prusti-viper/src/encoder/errors/encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/encoding_error.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use rustc_span::MultiSpan;
-use log::debug;
+use log::trace;
 use crate::encoder::errors::SpannedEncodingError;
 use crate::encoder::errors::EncodingErrorKind;
 use backtrace::Backtrace;
@@ -22,19 +22,19 @@ pub type EncodingResult<T> = Result<T, EncodingError>;
 impl EncodingError {
     /// Usage of an unsupported Rust feature (e.g. dereferencing raw pointers)
     pub fn unsupported<M: ToString>(message: M) -> Self {
-        debug!("Constructing unsupported error at:\n{:?}", Backtrace::new());
+        trace!("Constructing unsupported error at:\n{:?}", Backtrace::new());
         EncodingError::Positionless(EncodingErrorKind::unsupported(message))
     }
 
     /// An incorrect usage of Prusti (e.g. call an impure function in a contract)
     pub fn incorrect<M: ToString>(message: M) -> Self {
-        debug!("Constructing incorrect error at:\n{:?}", Backtrace::new());
+        trace!("Constructing incorrect error at:\n{:?}", Backtrace::new());
         EncodingError::Positionless(EncodingErrorKind::incorrect(message))
     }
 
     /// An internal error of Prusti (e.g. failure of the fold-unfold)
     pub fn internal<M: ToString>(message: M) -> Self {
-        debug!("Constructing internal error at:\n{:?}", Backtrace::new());
+        trace!("Constructing internal error at:\n{:?}", Backtrace::new());
         EncodingError::Positionless(EncodingErrorKind::internal(message))
     }
 

--- a/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use rustc_span::MultiSpan;
-use log::debug;
+use log::trace;
 use prusti_interface::PrustiError;
 use crate::encoder::errors::EncodingError;
 use crate::encoder::errors::EncodingErrorKind;
@@ -46,7 +46,7 @@ impl SpannedEncodingError {
 
     /// Usage of an unsupported Rust feature (e.g. dereferencing raw pointers)
     pub fn unsupported<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
-        debug!("Constructing unsupported error at:\n{:?}", Backtrace::new());
+        trace!("Constructing unsupported error at:\n{:?}", Backtrace::new());
         SpannedEncodingError::new(
             EncodingErrorKind::unsupported(message),
             span
@@ -55,7 +55,7 @@ impl SpannedEncodingError {
 
     /// An incorrect usage of Prusti (e.g. call an impure function in a contract)
     pub fn incorrect<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
-        debug!("Constructing incorrect error at:\n{:?}", Backtrace::new());
+        trace!("Constructing incorrect error at:\n{:?}", Backtrace::new());
         SpannedEncodingError::new(
             EncodingErrorKind::incorrect(message),
             span
@@ -64,7 +64,7 @@ impl SpannedEncodingError {
 
     /// An internal error of Prusti (e.g. failure of the fold-unfold)
     pub fn internal<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
-        debug!("Constructing internal error at:\n{:?}", Backtrace::new());
+        trace!("Constructing internal error at:\n{:?}", Backtrace::new());
         SpannedEncodingError::new(
             EncodingErrorKind::internal(message),
             span

--- a/prusti-viper/src/encoder/mir/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure_functions/encoder.rs
@@ -16,7 +16,7 @@ use crate::encoder::{
     mir::types::MirTypeEncoderInterface,
     mir_encoder::{MirEncoder, PlaceEncoder, PlaceEncoding, PRECONDITION_LABEL, WAND_LHS_LABEL},
     mir_interpreter::{
-        run_backward_interpretation, BackwardMirInterpreter, MultiExprBackwardInterpreterState,
+        run_backward_interpretation, BackwardMirInterpreter, ExprBackwardInterpreterState,
     },
     snapshot, Encoder,
 };
@@ -74,7 +74,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
 
         let state = run_backward_interpretation(self.mir, &self.interpreter)?
             .unwrap_or_else(|| panic!("Procedure {:?} contains a loop", self.proc_def_id));
-        let body_expr = state.into_expressions().remove(0);
+        let body_expr = state.into_expr().unwrap();
         debug!(
             "Pure function {} has been encoded with expr: {}",
             function_name, body_expr
@@ -105,10 +105,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 )
                 .with_span(span)?;
             let new_place: vir::Expr = self.encode_local(arg)?.into();
-            state.substitute_place(&target_place, new_place);
+            state.substitute_value(&target_place, new_place);
         }
 
-        let mut body_expr = state.into_expressions().remove(0);
+        let mut body_expr = state.into_expr().unwrap();
         debug!(
             "Pure function {} has been encoded with expr: {}",
             function_name, body_expr

--- a/prusti-viper/src/encoder/mir/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure_functions/interpreter.rs
@@ -11,7 +11,7 @@ use crate::encoder::{
     mir::types::MirTypeEncoderInterface,
     mir_encoder::{MirEncoder, PlaceEncoder, PlaceEncoding, PRECONDITION_LABEL, WAND_LHS_LABEL},
     mir_interpreter::{
-        run_backward_interpretation, BackwardMirInterpreter, MultiExprBackwardInterpreterState,
+        run_backward_interpretation, BackwardMirInterpreter, ExprBackwardInterpreterState,
     },
     snapshot, Encoder,
 };
@@ -27,18 +27,21 @@ use vir_crate::polymorphic::{self as vir, ExprIterator};
 
 pub(crate) struct PureFunctionBackwardInterpreter<'p, 'v: 'p, 'tcx: 'v> {
     encoder: &'p Encoder<'v, 'tcx>,
+    /// MIR of the pure function being encoded.
     mir: &'p mir::Body<'tcx>,
+    /// MirEncoder of the pure function being encoded.
     mir_encoder: MirEncoder<'p, 'v, 'tcx>,
-    /// True if the encoder is currently encoding an assertion and not a pure function body. This
-    /// flag is used to distinguish when assert terminators should be translated into `false` and
-    /// when to a undefined function calls. This distinction allows overflow checks to be checked
-    /// on the caller side and assumed on the definition side.
-    is_encoding_assertion: bool,
-    parent_def_id: DefId,
+    /// True if a panic should be encoded to a `false` boolean value.
+    /// This flag is used to distinguish whether an assert terminators generated e.g. for an
+    /// integer overflow should be translated into `false` and when to an "unreachable" function
+    /// call with a `false` precondition.
+    encode_panic_to_false: bool,
+    /// DefId of the caller. Used for error reporting.
+    caller_def_id: DefId,
     tymap: SubstMap<'tcx>,
 }
 
-/// XXX: This encoding works backward, but there is the risk of generating expressions whose length
+/// This encoding works backward, so there is the risk of generating expressions whose length
 /// is exponential in the number of branches. If this becomes a problem, consider doing a forward
 /// encoding (keeping path conditions expressions).
 impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
@@ -46,16 +49,16 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
         encoder: &'p Encoder<'v, 'tcx>,
         mir: &'p mir::Body<'tcx>,
         def_id: DefId,
-        is_encoding_assertion: bool,
-        parent_def_id: DefId,
+        encode_panic_to_false: bool,
+        caller_def_id: DefId,
         tymap: SubstMap<'tcx>,
     ) -> Self {
         PureFunctionBackwardInterpreter {
             encoder,
             mir,
             mir_encoder: MirEncoder::new(encoder, mir, def_id),
-            is_encoding_assertion,
-            parent_def_id,
+            encode_panic_to_false,
+            caller_def_id,
             tymap,
         }
     }
@@ -68,15 +71,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
     /// fold-unfold pass.
     fn apply_downcasts(
         &self,
-        state: &mut MultiExprBackwardInterpreterState,
+        state: &mut ExprBackwardInterpreterState,
         location: mir::Location,
     ) -> SpannedEncodingResult<()> {
-        // This assertion is just to check the time complexity.
-        // MultiExprBackwardInterpreterState is more generic than needed.
-        debug_assert_eq!(state.exprs().len(), 1);
-
         let span = self.mir_encoder.get_span_of_location(location);
-        for expr in state.exprs_mut() {
+        if let Some(expr) = state.expr_mut() {
             let downcasts = self.mir_encoder.get_downcasts_at_location(location);
             // Reverse `downcasts` because the encoding works backward
             for (place, variant_idx) in downcasts.into_iter().rev() {
@@ -122,14 +121,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
         &self,
         operand: &mir::Operand<'tcx>,
     ) -> EncodingResult<Option<vir::Expr>> {
-        // TODO: de-duplicate with mir_encoder.encode_operand_place
-        // TODO: maybe return `None` from mir_encoder.encode_operand_place for arrays in general?
+        // TODO: De-duplicate with mir_encoder.encode_operand_place.
+        //   Maybe returning `None` from mir_encoder.encode_operand_place for arrays in general?
         Ok(match operand {
-            &mir::Operand::Move(ref place) | &mir::Operand::Copy(ref place) => {
+            mir::Operand::Move(ref place) | &mir::Operand::Copy(ref place) => {
                 Some(self.encode_place(place)?.0)
             }
 
-            &mir::Operand::Constant(_) => None,
+            mir::Operand::Constant(_) => None,
         })
     }
 
@@ -194,7 +193,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
 impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
     for PureFunctionBackwardInterpreter<'p, 'v, 'tcx>
 {
-    type State = MultiExprBackwardInterpreterState;
+    type State = ExprBackwardInterpreterState;
     type Error = SpannedEncodingError;
 
     fn apply_terminator(
@@ -240,9 +239,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 let pos = self.encoder.error_manager().register(
                     term.source_info.span,
                     ErrorCtxt::Unexpected,
-                    self.parent_def_id,
+                    self.caller_def_id,
                 );
-                MultiExprBackwardInterpreterState::new_single(
+                ExprBackwardInterpreterState::new_defined(
                     undef_expr(pos).with_span(term.source_info.span)?,
                 )
             }
@@ -252,9 +251,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 let pos = self.encoder.error_manager().register(
                     term.source_info.span,
                     ErrorCtxt::Unexpected,
-                    self.parent_def_id,
+                    self.caller_def_id,
                 );
-                MultiExprBackwardInterpreterState::new_single(
+                ExprBackwardInterpreterState::new_defined(
                     unreachable_expr(pos).with_span(term.source_info.span)?,
                 )
             }
@@ -291,7 +290,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     .encode_type(self.mir.return_ty())
                     .with_span(span)?;
                 let return_var = vir_local! { _0: {return_type} };
-                MultiExprBackwardInterpreterState::new_single(
+                ExprBackwardInterpreterState::new_defined(
                     self.encoder
                         .encode_value_expr(vir::Expr::local(return_var), self.mir.return_ty())
                         .with_span(span)?,
@@ -349,7 +348,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 trace!("cfg_targets: {:?}", cfg_targets);
 
                 let refined_default_target = if default_is_unreachable && !cfg_targets.is_empty() {
-                    // Here we can assume that the `cfg_targets` are exhausive, and that
+                    // Here we can assume that the `cfg_targets` are exhaustive, and that
                     // `default_target` is unreachable
                     trace!("The default target is unreachable");
                     cfg_targets.pop().unwrap().1
@@ -359,24 +358,22 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
                 trace!("cfg_targets: {:?}", cfg_targets);
 
-                MultiExprBackwardInterpreterState::new(
-                    (0..states[&refined_default_target].exprs().len())
-                        .map(|expr_index| {
-                            cfg_targets.iter().fold(
-                                states[&refined_default_target].exprs()[expr_index].clone(),
-                                |else_expr, (guard, target)| {
-                                    let then_expr = states[target].exprs()[expr_index].clone();
-                                    if then_expr == else_expr {
-                                        // Optimization
-                                        else_expr
-                                    } else {
-                                        vir::Expr::ite(guard.clone(), then_expr, else_expr)
-                                    }
-                                },
-                            )
+                let final_expr = states[&refined_default_target].expr().map(|default_expr| {
+                    cfg_targets
+                        .iter()
+                        .map(|(guard, target)|
+                            // If the default target is defined, all targets should be defined.
+                            (guard, states[target].expr().unwrap()))
+                        .fold(default_expr.clone(), |else_expr, (guard, then_expr)| {
+                            if then_expr == &else_expr {
+                                // Optimization
+                                else_expr
+                            } else {
+                                vir::Expr::ite(guard.clone(), then_expr.clone(), else_expr)
+                            }
                         })
-                        .collect(),
-                )
+                });
+                ExprBackwardInterpreterState::new(final_expr)
             }
 
             TerminatorKind::DropAndReplace { .. } => unimplemented!(),
@@ -419,7 +416,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                         let (encoded_lhs, ty, _) = self.encode_place(lhs_place).with_span(span)?;
                         let lhs_value = self
                             .encoder
-                            .encode_value_expr(encoded_lhs, ty)
+                            .encode_value_expr(encoded_lhs.clone(), ty)
                             .with_span(span)?;
                         let encoded_args: Vec<vir::Expr> = args
                             .iter()
@@ -439,7 +436,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     PRECONDITION_LABEL,
                                 );
                                 let mut state = states[target_block].clone();
-                                state.substitute_value(&lhs_value, encoded_rhs);
+                                state.substitute_value(&encoded_lhs, encoded_rhs);
                                 state
                             }
 
@@ -450,7 +447,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     .mir_encoder
                                     .encode_old_expr(encoded_args[0].clone(), WAND_LHS_LABEL);
                                 let mut state = states[target_block].clone();
-                                state.substitute_value(&lhs_value, encoded_rhs);
+                                state.substitute_value(&encoded_lhs, encoded_rhs);
                                 state
                             }
 
@@ -567,7 +564,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     self.encoder
                                         .encode_pure_function_use(
                                             def_id,
-                                            self.parent_def_id,
+                                            self.caller_def_id,
                                             &tymap,
                                         )
                                         .with_span(term.source_info.span)?
@@ -596,7 +593,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 let pos = self.encoder.error_manager().register(
                                     term.source_info.span,
                                     ErrorCtxt::PureFunctionCall,
-                                    self.parent_def_id,
+                                    self.caller_def_id,
                                 );
                                 let encoded_rhs = vir::Expr::func_app(
                                     function_name,
@@ -632,9 +629,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                         let pos = self.encoder.error_manager().register(
                             term.source_info.span,
                             error_ctxt,
-                            self.parent_def_id,
+                            self.caller_def_id,
                         );
-                        MultiExprBackwardInterpreterState::new_single(
+                        ExprBackwardInterpreterState::new_defined(
                             unreachable_expr(pos).with_span(term.source_info.span)?,
                         )
                     };
@@ -675,29 +672,21 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 let pos = self.encoder.error_manager().register(
                     term.source_info.span,
                     error_ctxt,
-                    self.parent_def_id,
+                    self.caller_def_id,
                 );
 
-                MultiExprBackwardInterpreterState::new(
-                    states[target]
-                        .exprs()
-                        .iter()
-                        .map(|expr| {
-                            let failure_result = if self.is_encoding_assertion {
-                                // We are encoding an assertion, so all failures should be
-                                // equivalent to false.
-                                Ok(false.into())
-                            } else {
-                                // We are encoding a pure function, so all failures should
-                                // be unreachable.
-                                unreachable_expr(pos).with_span(term.source_info.span)
-                            };
-                            failure_result.map(|result| {
-                                vir::Expr::ite(viper_guard.clone(), expr.clone(), result)
-                            })
-                        })
-                        .collect::<Result<_, _>>()?,
-                )
+                let failure_encoding = if self.encode_panic_to_false {
+                    // We are encoding an assertion, so all failures should be equivalent to false.
+                    debug_assert!(matches!(self.mir.return_ty().kind(), ty::TyKind::Bool));
+                    false.into()
+                } else {
+                    // We are encoding a pure function, so all failures should be unreachable.
+                    unreachable_expr(pos).with_span(term.source_info.span)?
+                };
+
+                ExprBackwardInterpreterState::new(states[target].expr().map(|target_expr| {
+                    vir::Expr::ite(viper_guard.clone(), target_expr.clone(), failure_encoding)
+                }))
             }
 
             TerminatorKind::Yield { .. }
@@ -738,8 +727,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
             mir::StatementKind::Assign(box (ref lhs, ref rhs)) => {
                 let (encoded_lhs, ty, _) = self.encode_place(lhs).unwrap();
+                trace!("Encoding assignment to LHS {:?}", encoded_lhs);
 
-                if !state.use_place(&encoded_lhs) {
+                if !state.uses_place(&encoded_lhs) {
                     // If the lhs is not mentioned in our state, do nothing
                     trace!("The state does not mention {:?}", encoded_lhs);
                     return Ok(());
@@ -770,7 +760,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                         match opt_encoded_rhs {
                             Some(encoded_rhs) => {
                                 // Substitute a place
-                                state.substitute_place(&encoded_lhs, encoded_rhs);
+                                state.substitute_value(&encoded_lhs, encoded_rhs);
                             }
                             None => {
                                 // Substitute a place of a value with an expression
@@ -809,7 +799,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                         Some(encoded_rhs) => {
                                             // Substitute a place
                                             field_exprs.push(encoded_rhs.clone());
-                                            state.substitute_place(&field_place, encoded_rhs);
+                                            state.substitute_value(&field_place, encoded_rhs);
                                         }
                                         None => {
                                             // Substitute a place of a value with an expression
@@ -829,7 +819,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     field_exprs,
                                     &self.tymap,
                                 ).with_span(span)?;
-                                state.substitute_place(&encoded_lhs, snapshot);
+                                state.substitute_value(&encoded_lhs, snapshot);
                             }
 
                             &mir::AggregateKind::Adt(adt_def, variant_index, subst, _, _) => {
@@ -845,6 +835,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     encoded_lhs_variant =
                                         encoded_lhs_variant.variant(&variant_def.ident.as_str());
                                 }
+                                let mut field_exprs = vec![];
                                 for (field_index, field) in variant_def.fields.iter().enumerate() {
                                     let operand = &operands[field_index];
                                     let field_name = &field.ident.as_str();
@@ -862,13 +853,15 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     match encoded_operand {
                                         Some(encoded_rhs) => {
                                             // Substitute a place
-                                            state.substitute_place(&field_place, encoded_rhs);
+                                            field_exprs.push(encoded_rhs.clone());
+                                            state.substitute_value(&field_place, encoded_rhs);
                                         }
                                         None => {
                                             // Substitute a place of a value with an expression
                                             let rhs_expr =
                                                 self.mir_encoder.encode_operand_expr(operand)
                                                     .with_span(span)?;
+                                            field_exprs.push(rhs_expr.clone());
                                             state.substitute_value(
                                                 &self.encoder.encode_value_expr(field_place, field_ty).with_span(span)?,
                                                 rhs_expr,
@@ -876,6 +869,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                         }
                                     }
                                 }
+                                let snapshot = self.encoder.encode_snapshot_constructor(
+                                    ty,
+                                    field_exprs,
+                                    &self.tymap,
+                                ).with_span(span)?;
+                                state.substitute_value(&encoded_lhs, snapshot);
                             }
 
                             &mir::AggregateKind::Array(elem_ty) => {
@@ -907,7 +906,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     &self.tymap,
                                 ).with_span(span)?;
 
-                                state.substitute_place(&encoded_lhs, snapshot);
+                                state.substitute_value(&encoded_lhs, snapshot);
                             }
 
                             ref x => unimplemented!("{:?}", x),
@@ -997,7 +996,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     &mir::Rvalue::NullaryOp(_op, _op_ty) => unimplemented!(),
 
                     &mir::Rvalue::Discriminant(ref src) => {
-                        let (encoded_src, src_ty, _) = self.encode_place(src).unwrap();
+                        let (encoded_src, src_ty, _) = self.encode_place(src).with_span(span)?;
                         match src_ty.kind() {
                             ty::TyKind::Adt(adt_def, _) if !adt_def.is_box() => {
                                 let num_variants = adt_def.variants.len();
@@ -1006,7 +1005,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     let pos = self
                                         .encoder
                                         .error_manager()
-                                        .register(stmt.source_info.span, ErrorCtxt::Unexpected, self.parent_def_id);
+                                        .register(stmt.source_info.span, ErrorCtxt::Unexpected, self.caller_def_id);
                                     let function_name = self.encoder.encode_builtin_function_use(
                                         BuiltinFunctionKind::Unreachable(vir::Type::Int),
                                     );
@@ -1036,8 +1035,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     &mir::Rvalue::Ref(_, mir::BorrowKind::Unique, ref place)
                     | &mir::Rvalue::Ref(_, mir::BorrowKind::Mut { .. }, ref place)
                     | &mir::Rvalue::Ref(_, mir::BorrowKind::Shared, ref place) => {
-                        // will panic if attempting to encode unsupported type
-                        let encoded_place = self.encode_place(place).unwrap().0;
+                        let (encoded_place, _, _) = self.encode_place(place).with_span(span)?;
                         let encoded_ref = match encoded_place {
                             vir::Expr::Field( vir::FieldExpr {
                                 box ref base,
@@ -1051,7 +1049,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                         };
 
                         // Substitute the place
-                        state.substitute_place(&encoded_lhs, encoded_ref);
+                        state.substitute_value(&encoded_lhs, encoded_ref);
                     }
 
                     &mir::Rvalue::Cast(mir::CastKind::Misc, ref operand, dst_ty) => {

--- a/prusti-viper/src/encoder/mir/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure_functions/interpreter.rs
@@ -826,7 +826,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 let num_variants = adt_def.variants.len();
                                 let variant_def = &adt_def.variants[variant_index];
                                 let mut encoded_lhs_variant = encoded_lhs.clone();
-                                if num_variants != 1 {
+                                if num_variants > 1 {
                                     let discr_field = self.encoder.encode_discriminant_field();
                                     state.substitute_value(
                                         &encoded_lhs.clone().field(discr_field),
@@ -869,12 +869,15 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                         }
                                     }
                                 }
-                                let snapshot = self.encoder.encode_snapshot_constructor(
-                                    ty,
-                                    field_exprs,
-                                    &self.tymap,
-                                ).with_span(span)?;
-                                state.substitute_value(&encoded_lhs, snapshot);
+                                // TODO: construct snapshot for enumerations
+                                if num_variants == 1 {
+                                    let snapshot = self.encoder.encode_snapshot_constructor(
+                                        ty,
+                                        field_exprs,
+                                        &self.tymap,
+                                    ).with_span(span)?;
+                                    state.substitute_value(&encoded_lhs, snapshot);
+                                }
                             }
 
                             &mir::AggregateKind::Array(elem_ty) => {

--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -438,15 +438,15 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
     ) -> EncodingResult<vir::Expr> {
         trace!("Encode operand expr {:?}", operand);
         Ok(match operand {
-            &mir::Operand::Constant(box mir::Constant {
+            mir::Operand::Constant(box mir::Constant {
                 literal: mir::ConstantKind::Ty(ty::Const { ty, val }),
                 ..
             }) => self.encoder.encode_const_expr(ty, val)?,
-            &mir::Operand::Constant(box mir::Constant {
+            mir::Operand::Constant(box mir::Constant {
                 literal: mir::ConstantKind::Val(val, ty),
                 ..
-            }) => self.encoder.encode_const_expr(ty, &ty::ConstKind::Value(val))?,
-            &mir::Operand::Copy(ref place) | &mir::Operand::Move(ref place) => {
+            }) => self.encoder.encode_const_expr(ty, &ty::ConstKind::Value(*val))?,
+            mir::Operand::Copy(ref place) | &mir::Operand::Move(ref place) => {
                 // let val_place = self.eval_place(&place)?;
                 // inlined to do try_into_expr
                 let (encoded_place, place_ty, _) = self.encode_place(place)?;

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -433,6 +433,10 @@ impl SnapshotEncoder {
     ) -> EncodingResult<Expr> {
         let snapshot = self.encode_snapshot(encoder, ty, tymap)?;
         match snapshot {
+            Snapshot::Unit => {
+                assert!(args.is_empty());
+                Ok(self.domains[UNIT_DOMAIN_NAME].functions[0].apply(args))
+            },
             Snapshot::Complex { ref variants, .. } => {
                 assert_eq!(variants.len(), 1);
                 Ok(variants[0].0.apply(args))

--- a/prusti-viper/src/encoder/spec_encoder.rs
+++ b/prusti-viper/src/encoder/spec_encoder.rs
@@ -12,7 +12,7 @@ use crate::encoder::mir_encoder::{MirEncoder, PlaceEncoder, PlaceEncoding};
 use crate::encoder::mir_encoder::PRECONDITION_LABEL;
 use crate::encoder::mir_interpreter::{
     run_backward_interpretation_point_to_point, BackwardMirInterpreter,
-    MultiExprBackwardInterpreterState,
+    ExprBackwardInterpreterState,
 };
 use crate::encoder::mir::pure_functions::{PureFunctionBackwardInterpreter, PureFunctionEncoderInterface};
 use crate::encoder::Encoder;
@@ -192,8 +192,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
         }
         for var in &bounded_vars {
             if !found_bounded_vars.contains(var) {
+                debug!("bounded_vars: {:?}", bounded_vars);
+                debug!("encoded_expressions: {:?}", encoded_expressions);
+                debug!("found_bounded_vars: {:?}", found_bounded_vars);
+                debug!("var: {:?}", var);
                 // FIXME: We should mention the missing variable in the error message.
-                let msg = "A trigger must mention all bounded variables.";
+                let msg = "a trigger must mention all bounded variables.";
                 let span = rustc_span::MultiSpan::from_spans(
                     trigger.terms().iter().map(|term| self.encoder.env().tcx().def_span(term.expr)).collect()
                 );
@@ -592,7 +596,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
 
         // Translate an intermediate state to the state at the beginning of the method
         let substs = self.encoder.type_substitution_polymorphic_type_map(self.tymap).with_span(mir.span)?;
-        let state = MultiExprBackwardInterpreterState::new_single_with_substs(
+        let state = ExprBackwardInterpreterState::new_defined_with_substs(
             expr,
             substs,
         );
@@ -609,9 +613,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecEncoder<'p, 'v, 'tcx> {
             expr_location.block,
             expr_location.statement_index,
             state,
-            MultiExprBackwardInterpreterState::new(vec![]),
+            ExprBackwardInterpreterState::new_undefined(),
         )?.unwrap_or_else(|| panic!("cannot encode {:?} because its CFG contains a loop", def_id));
-        let pre_state_expr = initial_state.into_expressions().remove(0);
+        let pre_state_expr = initial_state.into_expr().unwrap();
 
         trace!("Expr at the beginning: {}", pre_state_expr);
         Ok(pre_state_expr)
@@ -734,7 +738,7 @@ struct StraightLineBackwardInterpreter<'p, 'v: 'p, 'tcx: 'v> {
     interpreter: PureFunctionBackwardInterpreter<'p, 'v, 'tcx>,
 }
 
-/// XXX: This encoding works backward, but there is the risk of generating expressions whose length
+/// This encoding works backward, so there is the risk of generating expressions whose length
 /// is exponential in the number of branches. If this becomes a problem, consider doing a forward
 /// encoding (keeping path conditions expressions).
 impl<'p, 'v: 'p, 'tcx: 'v> StraightLineBackwardInterpreter<'p, 'v, 'tcx> {
@@ -756,7 +760,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> StraightLineBackwardInterpreter<'p, 'v, 'tcx> {
 impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
     for StraightLineBackwardInterpreter<'p, 'v, 'tcx>
 {
-    type State = MultiExprBackwardInterpreterState;
+    type State = ExprBackwardInterpreterState;
     type Error = SpannedEncodingError;
 
     fn apply_terminator(
@@ -766,15 +770,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         states: HashMap<mir::BasicBlock, &Self::State>,
     ) -> Result<Self::State, Self::Error> {
         trace!("apply_terminator {:?}, states: {:?}", term, states);
-        if !states.is_empty() && states.values().all(|state| !state.exprs().is_empty()) {
-            // All states are initialized
-            self.interpreter.apply_terminator(bb, term, states)
-        } else {
-            // One of the states is not yet initialized
-            trace!("Skip terminator {:?}", term);
-            Ok(MultiExprBackwardInterpreterState::new(vec![]))
-        }
+        self.interpreter.apply_terminator(bb, term, states)
     }
+
     fn apply_statement(
         &self,
         bb: mir::BasicBlock,
@@ -783,14 +781,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         state: &mut Self::State,
     ) -> Result<(), Self::Error> {
         trace!("apply_statement {:?}, state: {:?}", stmt, state);
-        if !state.exprs().is_empty() {
-            // The state is initialized
-            self.interpreter
-                .apply_statement(bb, stmt_index, stmt, state)?;
-        } else {
-            // The state is not yet initialized
-            trace!("Skip statement {:?}", stmt);
-        }
-        Ok(())
+        self.interpreter.apply_statement(bb, stmt_index, stmt, state)
     }
 }

--- a/prusti-viper/src/verifier.rs
+++ b/prusti-viper/src/verifier.rs
@@ -170,7 +170,8 @@ impl<'v, 'tcx> Verifier<'v, 'tcx> {
             let proc_name = self.env.get_absolute_item_name(proc_id);
             let proc_def_path = self.env.get_item_def_path(proc_id);
             let proc_span = self.env.get_item_span(proc_id);
-            info!(" - {} from {:?} ({})", proc_name, proc_span, proc_def_path);
+            info!(" - {} ({})", proc_name, proc_def_path);
+            info!("   Source: {:?}", proc_span);
         }
 
         // // Check support status, and queue encoding


### PR DESCRIPTION
* Replaces the `Vec<vir::Expr>` in `MultiExprBackwardInterpreterState` with `Option<vir::Expr>`. The encoding is expected to stay exactly the same.
* Fixes #693
* ~~Simplify pure function encoder~~ In a different PR