### PR TITLE
Issue #709. Fix and extra regression test case for `ProcedureEncoder::encode_assign_array_repeat_initializer()`

### DIFF
--- a/prusti-tests/tests/verify/pass/arrays/repeat-expr-initialization.rs
+++ b/prusti-tests/tests/verify/pass/arrays/repeat-expr-initialization.rs
@@ -4,6 +4,23 @@
 //   initializers like [1, 2, 3]
 // - bool as element type
 
+extern crate prusti_contracts;
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+pub struct A(usize);
+
+#[derive(Clone, Copy)]
+pub struct B([A; 16]);
+
+impl B {
+    #[pure]
+    /// Initialization of an array holding ADTs.
+    pub fn new() -> Self {
+        Self([A(0); 16])
+    }
+}
+
 fn main() {
     let a = [false; 3];
 

--- a/prusti-tests/tests/verify/pass/arrays/repeat-expr-initialization.rs
+++ b/prusti-tests/tests/verify/pass/arrays/repeat-expr-initialization.rs
@@ -4,23 +4,6 @@
 //   initializers like [1, 2, 3]
 // - bool as element type
 
-extern crate prusti_contracts;
-use prusti_contracts::*;
-
-#[derive(Clone, Copy)]
-pub struct A(usize);
-
-#[derive(Clone, Copy)]
-pub struct B([A; 16]);
-
-impl B {
-    #[pure]
-    /// Initialization of an array holding ADTs.
-    pub fn new() -> Self {
-        Self([A(0); 16])
-    }
-}
-
 fn main() {
     let a = [false; 3];
 

--- a/prusti-tests/tests/verify/pass/issues/issue-709.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-709.rs
@@ -1,0 +1,18 @@
+extern crate prusti_contracts;
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+pub struct A(usize);
+
+#[derive(Clone, Copy)]
+pub struct B([A; 16]);
+
+impl B {
+    #[pure]
+    /// Initialization of an array holding ADTs.
+    pub fn new() -> Self {
+        Self([A(0); 16])
+    }
+}
+
+pub fn main() {}

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5678,6 +5678,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let lookup_ret_ty = self.encoder.encode_snapshot_type(array_types.elem_ty_rs, &tymap)
             .with_span(span)?;
 
+        let inhaled_operand = if lookup_ret_ty.is_domain() || lookup_ret_ty.is_snapshot() {
+            vir::Expr::snap_app(encoded_operand)
+        } else {
+            encoded_operand
+        };
+
         let mut stmts = self.encode_havoc_and_allocation(&encoded_lhs);
         for i in 0..len {
             let idx = vir::Expr::from(i);
@@ -5689,7 +5695,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             );
 
             stmts.push(vir::Stmt::Inhale( vir::Inhale {
-                expr: vir_expr!{ [lookup_pure_call] == [encoded_operand] }
+                expr: vir_expr!{ [lookup_pure_call] == [inhaled_operand] }
             }));
         }
 


### PR DESCRIPTION
I've created a fix and regression test case for `ProcedureEncoder::encode_assign_array_repeat_initializer()`, where it failed to initialize arrays holding ADTs. I'm currently not sure about a couple of things, such as:

* Should I check whether the right-hand size implements the `Copy` trait before applying the snapshot encoding? Or would it never end up here in the first place due to that a "pure" array lookup is already happening? (i.e. it would fail before it gets to the lookup if the return type is not `Copy`).
* In this case, it seems to work without generating additional pre-statements. However, I can already give one corner case where this breaks. In this counter-example Viper complains about the missing `UnitDomain` (I guess it's missing because the pre-statements where not properly generated with my fix?)
```rust
#[derive(Clone, Copy)]
pub struct C([(); 16]);

impl C {
    #[pure]
    /// Initialization of an array holding units `()`.
    pub fn new() -> Self {
        Self([(); 16])
    }
}
```