### PR TITLE
Fix #714 and remove usages of AddrOf

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-714.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-714.rs
@@ -1,0 +1,27 @@
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+pub enum E {
+    A,
+    B,
+    C
+}
+
+impl E {
+    #[pure]
+    pub fn len(&self) -> usize {
+        0
+    }
+}
+
+#[pure]
+pub fn a() -> E {
+    E::A
+}
+
+#[pure]
+pub fn test() -> usize {
+    a().len()
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -713,17 +713,18 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         self.snapshot_encoder.borrow_mut().encode_type(self, ty, tymap)
     }
 
-    /// Encodes a snapshot constructor directly. Can only be used on ADTs with
-    /// a single variant.
-    pub fn encode_snapshot_constructor(
+    /// Constructs a snapshot. The `variant` is needed only if `ty` is an enum.
+    /// The result is not necessarily a domain; it could be a primitive type.
+    pub fn encode_snapshot(
         &self,
         ty: ty::Ty<'tcx>,
+        variant: Option<usize>,
         args: Vec<vir::Expr>,
         tymap: &SubstMap<'tcx>,
     )
         -> EncodingResult<vir::Expr>
     {
-        self.snapshot_encoder.borrow_mut().encode_constructor(self, ty, args, tymap)
+        self.snapshot_encoder.borrow_mut().encode_constructor(self, ty, variant, args, tymap)
     }
 
     pub fn encode_snapshot_array_idx(
@@ -774,7 +775,6 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     pub fn is_quantifiable(&self, ty: ty::Ty<'tcx>, tymap: &SubstMap<'tcx>,) -> EncodingResult<bool> {
         self.snapshot_encoder.borrow_mut().is_quantifiable(self, ty, tymap)
     }
-
 
     pub fn encode_const_expr(
         &self,

--- a/prusti-viper/src/encoder/errors/error_manager.rs
+++ b/prusti-viper/src/encoder/errors/error_manager.rs
@@ -10,8 +10,9 @@ use rustc_span::source_map::SourceMap;
 use rustc_span::MultiSpan;
 use viper::VerificationError;
 use prusti_interface::PrustiError;
-use log::debug;
+use log::{debug, trace};
 use prusti_interface::data::ProcedureDefId;
+use backtrace::trace;
 
 /// The cause of a panic!()
 #[derive(Clone, Debug)]
@@ -119,7 +120,7 @@ impl<'tcx> ErrorManager<'tcx>
 
     pub fn register<T: Into<MultiSpan>>(&mut self, span: T, error_ctxt: ErrorCtxt, def_id: ProcedureDefId) -> Position {
         let pos = self.register_span(span);
-        debug!("Register error at: {:?}", pos.id());
+        trace!("Register error {:?} of {:?} at position id {:?}", error_ctxt, def_id, pos.id());
         self.error_contexts.insert(pos.id(), (error_ctxt, def_id));
         pos
     }
@@ -128,7 +129,7 @@ impl<'tcx> ErrorManager<'tcx>
         let span = span.into();
         let pos_id = self.next_pos_id;
         self.next_pos_id += 1;
-        debug!("Register position {:?} at span {:?}", pos_id, span);
+        trace!("Register span {:?} at position id {:?}", span, pos_id);
         let pos = if let Some(primary_span) = span.primary_span() {
             let lines_info_res = self
                 .codemap

--- a/prusti-viper/src/encoder/foldunfold/footprint.rs
+++ b/prusti-viper/src/encoder/foldunfold/footprint.rs
@@ -32,12 +32,16 @@ impl ExprFootprintGetter for vir::Expr {
             vir::Expr::Local(_)
             | vir::Expr::Field(_)
             | vir::Expr::Variant(_)
-            | vir::Expr::AddrOf(_)
             | vir::Expr::LabelledOld(_)
             | vir::Expr::Const(_)
             | vir::Expr::FuncApp(_)
             | vir::Expr::DomainFuncApp(_)
             | vir::Expr::InhaleExhale(_) => HashSet::new(),
+
+            vir::Expr::AddrOf(..) => {
+                //HashSet::new()
+                unreachable!()
+            }
 
             vir::Expr::Unfolding(vir::Unfolding {
                 arguments,

--- a/prusti-viper/src/encoder/mir/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure_functions/interpreter.rs
@@ -814,8 +814,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                         }
                                     }
                                 }
-                                let snapshot = self.encoder.encode_snapshot_constructor(
+                                let snapshot = self.encoder.encode_snapshot(
                                     ty,
+                                    None,
                                     field_exprs,
                                     &self.tymap,
                                 ).with_span(span)?;
@@ -869,15 +870,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                         }
                                     }
                                 }
-                                // TODO: construct snapshot for enumerations
-                                if num_variants == 1 {
-                                    let snapshot = self.encoder.encode_snapshot_constructor(
-                                        ty,
-                                        field_exprs,
-                                        &self.tymap,
-                                    ).with_span(span)?;
-                                    state.substitute_value(&encoded_lhs, snapshot);
-                                }
+                                let snapshot = self.encoder.encode_snapshot(
+                                    ty,
+                                    Some(variant_index),
+                                    field_exprs,
+                                    &self.tymap,
+                                ).with_span(span)?;
+                                state.substitute_value(&encoded_lhs, snapshot);
                             }
 
                             &mir::AggregateKind::Array(elem_ty) => {
@@ -903,8 +902,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     position: vir::Position::default(),
                                 });
 
-                                let snapshot = self.encoder.encode_snapshot_constructor(
+                                let snapshot = self.encoder.encode_snapshot(
                                     ty,
+                                    None,
                                     vec![elems],
                                     &self.tymap,
                                 ).with_span(span)?;
@@ -1039,8 +1039,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     | &mir::Rvalue::Ref(_, mir::BorrowKind::Mut { .. }, ref place)
                     | &mir::Rvalue::Ref(_, mir::BorrowKind::Shared, ref place) => {
                         let (encoded_place, _, _) = self.encode_place(place).with_span(span)?;
-                        let snapshot = self.encoder.encode_snapshot_constructor(
+                        let snapshot = self.encoder.encode_snapshot(
                             ty,
+                            None,
                             vec![encoded_place],
                             &self.tymap
                         ).with_span(span)?;
@@ -1113,7 +1114,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                             position: vir::Position::default(),
                         });
 
-                        let slice_snap = self.encoder.encode_snapshot_constructor(ty, vec![elems_seq], &self.tymap,).with_span(span)?;
+                        let slice_snap = self.encoder.encode_snapshot(ty, None, vec![elems_seq], &self.tymap).with_span(span)?;
 
                         state.substitute_value(&opt_lhs_value_place.unwrap(), slice_snap);
 

--- a/prusti-viper/src/encoder/mir/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure_functions/interpreter.rs
@@ -872,7 +872,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 }
                                 let snapshot = self.encoder.encode_snapshot(
                                     ty,
-                                    Some(variant_index),
+                                    Some(variant_index.as_usize()),
                                     field_exprs,
                                     &self.tymap,
                                 ).with_span(span)?;

--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -306,25 +306,16 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
         Ok(match base_ty.kind() {
             ty::TyKind::RawPtr(ty::TypeAndMut { ty, .. })
             | ty::TyKind::Ref(_, ty, _) => {
-                let access = if encoded_base.is_addr_of() {
-                    // Simplify `*&<expr>` ==> `<expr>`
-                    encoded_base.get_parent().unwrap()
-                } else {
-                    let ref_field = self.encoder()
-                        .encode_dereference_field(ty)?;
-                    encoded_base.field(ref_field)
-                };
+                let ref_field = self.encoder()
+                    .encode_dereference_field(ty)?;
+                let access = encoded_base.field(ref_field);
                 (access, ty, None)
             }
             ty::TyKind::Adt(adt_def, _subst) if adt_def.is_box() => {
-                let access = if encoded_base.is_addr_of() {
-                    encoded_base.get_parent().unwrap()
-                } else {
-                    let field_ty = base_ty.boxed_ty();
-                    let ref_field = self.encoder()
-                        .encode_dereference_field(field_ty)?;
-                    encoded_base.field(ref_field)
-                };
+                let field_ty = base_ty.boxed_ty();
+                let ref_field = self.encoder()
+                    .encode_dereference_field(field_ty)?;
+                let access = encoded_base.field(ref_field);
                 (access, base_ty.boxed_ty(), None)
             }
             ref x => {

--- a/prusti-viper/src/encoder/mir_interpreter.rs
+++ b/prusti-viper/src/encoder/mir_interpreter.rs
@@ -270,7 +270,7 @@ impl ExprBackwardInterpreterState {
         if let Some(curr_expr) = self.expr.as_mut() {
             // Replace two times to avoid cloning `expr`, which could be big.
             let expr = mem::replace(curr_expr, true.into());
-            let new_expr = expr.replace_place(&target, &replacement).simplify_addr_of();
+            let new_expr = expr.replace_place(&target, &replacement);
             let _ = mem::replace(curr_expr, new_expr);
         }
     }

--- a/prusti-viper/src/encoder/snapshot/patcher.rs
+++ b/prusti-viper/src/encoder/snapshot/patcher.rs
@@ -98,11 +98,7 @@ impl<'v, 'tcx: 'v> FallibleExprFolder for SnapshotPatcher<'v, 'tcx> {
                     vir::Type::Int if field.name == "val_int" => Ok(*receiver),
                     vir::Type::Bool if field.name == "val_bool" => Ok(*receiver),
                     vir::Type::Snapshot(_) => {
-                        let res = match field.name.as_str() {
-                            "val_ref" => Ok(*receiver),
-                            _ => self.snapshot_encoder.snap_field(self.encoder, *receiver, field, self.tymap),
-                        }?;
-                        Ok(res)
+                        self.snapshot_encoder.snap_field(self.encoder, *receiver, field, self.tymap)
                     }
                     _ => Ok(vir::Expr::Field( vir::FieldExpr {
                         base: receiver,


### PR DESCRIPTION
* Remove all usages of `Expr::AddrOf` from prusti-viper.
* Add `variant: Option<usize>` argument to `SnapshotEncoder::encode_constructor`.
* Fix #714.
