### PR TITLE
Enable rustfmt on prusti-tests and fixed formatting in tests

### DIFF
--- a/prusti-tests/.rustfmt.toml
+++ b/prusti-tests/.rustfmt.toml
@@ -1,0 +1,5 @@
+# Allow longer line widths, so that error messages don't get cut off, because this could break a test case.
+# Note: rustfmt is very picky about trailing comments and might move a comment to the next line anyway :'-(
+max_width = 1000
+wrap_comments = false
+comment_width = 1000

--- a/prusti-tests/.rustfmt.toml
+++ b/prusti-tests/.rustfmt.toml
@@ -1,5 +1,0 @@
-# Allow longer line widths, so that error messages don't get cut off, because this could break a test case.
-# Note: rustfmt is very picky about trailing comments and might move a comment to the next line anyway :'-(
-max_width = 1000
-wrap_comments = false
-comment_width = 1000

--- a/prusti-tests/tests/cargotest.rs
+++ b/prusti-tests/tests/cargotest.rs
@@ -5,8 +5,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use cargo_test_support::{cargo_test, project, symlink_supported};
-use std::path::{Path, PathBuf};
-use std::fs;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 fn cargo_prusti_path() -> PathBuf {
     let target_directory = if cfg!(debug_assertions) {
@@ -19,13 +21,27 @@ fn cargo_prusti_path() -> PathBuf {
     } else {
         "cargo-prusti"
     };
-    let local_prusti_rustc_path: PathBuf = ["target", target_directory, executable_name].iter().collect();
+    let local_prusti_rustc_path: PathBuf = ["target", target_directory, executable_name]
+        .iter()
+        .collect();
     if local_prusti_rustc_path.exists() {
-        return fs::canonicalize(&local_prusti_rustc_path).unwrap_or_else(|_| panic!("Failed to canonicalize the path {:?}", local_prusti_rustc_path));
+        return fs::canonicalize(&local_prusti_rustc_path).unwrap_or_else(|_| {
+            panic!(
+                "Failed to canonicalize the path {:?}",
+                local_prusti_rustc_path
+            )
+        });
     }
-    let workspace_prusti_rustc_path: PathBuf = ["..", "target", target_directory, executable_name].iter().collect();
+    let workspace_prusti_rustc_path: PathBuf = ["..", "target", target_directory, executable_name]
+        .iter()
+        .collect();
     if workspace_prusti_rustc_path.exists() {
-        return fs::canonicalize(&workspace_prusti_rustc_path).unwrap_or_else(|_| panic!("Failed to canonicalize the path {:?}", workspace_prusti_rustc_path));
+        return fs::canonicalize(&workspace_prusti_rustc_path).unwrap_or_else(|_| {
+            panic!(
+                "Failed to canonicalize the path {:?}",
+                workspace_prusti_rustc_path
+            )
+        });
     }
     panic!(
         "Could not find the {:?} cargo-prusti binary to be used in tests. \
@@ -39,8 +55,7 @@ fn simple_assert_true() {
     let p = project()
         .file("src/main.rs", "fn main() { assert!(true); }")
         .build();
-    p.process(cargo_prusti_path())
-        .run();
+    p.process(cargo_prusti_path()).run();
 }
 
 #[cargo_test]
@@ -82,15 +97,23 @@ error: could not compile `foo` due to previous error
 fn test_local_project<T: Into<PathBuf>>(project_name: T) {
     let mut project_builder = project().no_manifest();
     let relative_project_path = Path::new("tests/cargo_verify").join(project_name.into());
-    let project_path = fs::canonicalize(&relative_project_path).unwrap_or_else(|_| panic!("Failed to canonicalize the path {}", relative_project_path.display()));
+    let project_path = fs::canonicalize(&relative_project_path).unwrap_or_else(|_| {
+        panic!(
+            "Failed to canonicalize the path {}",
+            relative_project_path.display()
+        )
+    });
 
     // Populate the test project with symlinks to the local project
     let project_path_content = fs::read_dir(&project_path)
         .unwrap_or_else(|_| panic!("Failed to read directory {}", project_path.display()));
     for entry in project_path_content {
-        let entry = entry.unwrap_or_else(|_| panic!("Failed to read content of {}", project_path.display()));
+        let entry = entry
+            .unwrap_or_else(|_| panic!("Failed to read content of {}", project_path.display()));
         let path = entry.path();
-        let file_name = path.as_path().file_name()
+        let file_name = path
+            .as_path()
+            .file_name()
             .unwrap_or_else(|| panic!("Failed to obtain the name of {}", path.display()));
         if file_name == "target" {
             continue;
@@ -108,7 +131,12 @@ fn test_local_project<T: Into<PathBuf>>(project_name: T) {
         .and_then(|p| p.parent())
         .and_then(|p| p.parent())
         .and_then(|p| p.parent())
-        .unwrap_or_else(|| panic!("Failed to obtain parent folders of {}", project_path.display()));
+        .unwrap_or_else(|| {
+            panic!(
+                "Failed to obtain parent folders of {}",
+                project_path.display()
+            )
+        });
     let prusti_contract_deps = [
         "prusti-utils",
         "prusti-specs",
@@ -119,13 +147,17 @@ fn test_local_project<T: Into<PathBuf>>(project_name: T) {
     for crate_name in &prusti_contract_deps {
         project_builder = project_builder.symlink_dir(
             prusti_dev_path.join(crate_name).as_path(),
-            Path::new(crate_name)
+            Path::new(crate_name),
         );
     }
 
     // Fetch dependencies using the same target folder of cargo-prusti
     let project = project_builder.build();
-    project.process("cargo").arg("build").env("CARGO_TARGET_DIR", "target/verify").run();
+    project
+        .process("cargo")
+        .arg("build")
+        .env("CARGO_TARGET_DIR", "target/verify")
+        .run();
 
     // Set the expected exit status, stdout and stderr
     let mut test_builder = project.process(cargo_prusti_path());

--- a/prusti-tests/tests/compiletest.rs
+++ b/prusti-tests/tests/compiletest.rs
@@ -27,11 +27,15 @@ fn find_prusti_rustc_path() -> PathBuf {
     } else {
         "prusti-rustc"
     };
-    let local_prusti_rustc_path: PathBuf = ["target", target_directory, executable_name].iter().collect();
+    let local_prusti_rustc_path: PathBuf = ["target", target_directory, executable_name]
+        .iter()
+        .collect();
     if local_prusti_rustc_path.exists() {
         return local_prusti_rustc_path;
     }
-    let workspace_prusti_rustc_path: PathBuf = ["..", "target", target_directory, executable_name].iter().collect();
+    let workspace_prusti_rustc_path: PathBuf = ["..", "target", target_directory, executable_name]
+        .iter()
+        .collect();
     if workspace_prusti_rustc_path.exists() {
         return workspace_prusti_rustc_path;
     }
@@ -82,10 +86,7 @@ fn run_prusti_tests(group_name: &str, filter: &Option<String>, rustc_flags: Opti
     }
 
     // Add compilation flags
-    config.target_rustcflags = Some(format!(
-        "--edition=2018 {}",
-        rustc_flags.unwrap_or("")
-    ));
+    config.target_rustcflags = Some(format!("--edition=2018 {}", rustc_flags.unwrap_or("")));
 
     let path: PathBuf = ["tests", group_name, "ui"].iter().collect();
     if path.exists() {
@@ -134,9 +135,7 @@ fn run_verification_base(group_name: &str, filter: &Option<String>) {
 }
 
 fn run_verification_no_overflow(group_name: &str, filter: &Option<String>) {
-    let _temporary_env_vars = (
-        TemporaryEnvVar::set("PRUSTI_CHECK_OVERFLOWS", "false"),
-    );
+    let _temporary_env_vars = (TemporaryEnvVar::set("PRUSTI_CHECK_OVERFLOWS", "false"),);
 
     run_verification_base(group_name, filter);
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-10.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-10.rs
@@ -4,16 +4,17 @@ use prusti_contracts::*;
 
 #[derive(Clone, Copy)]
 pub struct A {
-    inner: usize
+    inner: usize,
 }
 pub struct B {
-    inner: [A]
+    inner: [A],
 }
 
 impl B {
     /// Mutably reference an ADT within a slice
     #[requires(index < self.inner.len())]
-    pub fn get_mut(&mut self, index: usize) -> &mut A { //~ ERROR generating fold-unfold Viper statements failed
+    pub fn get_mut(&mut self, index: usize) -> &mut A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         &mut self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-11.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-11.rs
@@ -4,25 +4,27 @@ use prusti_contracts::*;
 
 #[derive(Clone, Copy)]
 pub struct A {
-    _inner: usize
+    _inner: usize,
 }
 
 #[repr(transparent)]
 pub struct B {
-    inner: [A]
+    inner: [A],
 }
 
 impl B {
     /// Obtain a shared reference to an ADT within a slice
     #[requires(index < self.inner.len())]
-    pub fn get(&self, index: usize) -> &A { //~ ERROR generating fold-unfold Viper statements failed
+    pub fn get(&self, index: usize) -> &A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         &self.inner[index]
     }
 
     /// Obtain a shared reference to an ADT within a slice
     #[pure]
     #[requires(index < self.inner.len())]
-    pub const fn get_pure(&self, index: usize) -> &A { //~ ERROR generating fold-unfold Viper statements failed
+    pub const fn get_pure(&self, index: usize) -> &A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         &self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-12.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-12.rs
@@ -16,7 +16,8 @@ impl B {
     }
 }
 
-pub fn test(b: &mut B) { //~ ERROR generating fold-unfold Viper statements failed
+pub fn test(b: &mut B) {
+    //~^ ERROR generating fold-unfold Viper statements failed
     b.get_mut(1)[0] = A(1);
 }
 

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-13.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-13.rs
@@ -4,25 +4,27 @@ use prusti_contracts::*;
 
 #[derive(Clone, Copy)]
 pub struct A {
-    _inner: usize
+    _inner: usize,
 }
 
 #[repr(transparent)]
 pub struct B {
-    inner: [A]
+    inner: [A],
 }
 
 impl B {
     /// Obtain a shared reference to a slice of ADTs within a slice
     #[requires(index <= self.inner.len())]
-    pub fn get(&self, index: usize) -> &[A] { //~ ERROR generating fold-unfold Viper statements failed
+    pub fn get(&self, index: usize) -> &[A] {
+        //~^ ERROR generating fold-unfold Viper statements failed
         &self.inner[0..index]
     }
 
     /// Obtain a shared reference to a slice of ADTs within a slice
     #[pure]
     #[requires(index <= self.inner.len())]
-    pub fn get_pure(&self, index: usize) -> &[A] { //~ ERROR generating fold-unfold Viper statements failed
+    pub fn get_pure(&self, index: usize) -> &[A] {
+        //~^ ERROR generating fold-unfold Viper statements failed
         &self.inner[0..index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-2.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-2.rs
@@ -11,14 +11,16 @@ pub struct B([A; 16]);
 impl B {
     /// Lookup an ADT from an array
     #[requires(index < self.0.len())]
-    pub const fn get(&self, index: usize) -> A { //~ ERROR generating fold-unfold Viper statements failed
+    pub const fn get(&self, index: usize) -> A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         self.0[index]
     }
 
     /// Lookup an ADT from an array
     #[pure]
     #[requires(index < self.0.len())]
-    pub const fn get_pure(&self, index: usize) -> A { //~ ERROR generating fold-unfold Viper statements failed
+    pub const fn get_pure(&self, index: usize) -> A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-4.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-4.rs
@@ -11,7 +11,8 @@ pub struct B(pub [A; 16]);
 impl B {
     /// Mutably reference an ADT within an array
     #[requires(index < self.0.len())]
-    pub fn get_mut(&mut self, index: usize) -> &mut A { //~ ERROR generating fold-unfold Viper statements failed
+    pub fn get_mut(&mut self, index: usize) -> &mut A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         &mut self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-5.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-5.rs
@@ -11,14 +11,16 @@ pub struct B(pub [A; 16]);
 impl B {
     /// Obtain a shared reference an ADT within an array
     #[requires(index < self.0.len())]
-    pub const fn get(&self, index: usize) -> &A { //~ ERROR generating fold-unfold Viper statements failed
+    pub const fn get(&self, index: usize) -> &A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         &self.0[index]
     }
 
     /// Obtain a shared reference an ADT within an array
     #[pure]
     #[requires(index < self.0.len())]
-    pub const fn get_pure(&self, index: usize) -> &A { //~ ERROR generating fold-unfold Viper statements failed
+    pub const fn get_pure(&self, index: usize) -> &A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         &self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-8.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-8.rs
@@ -17,14 +17,16 @@ impl B {
 
     /// Lookup an ADT from a slice
     #[requires(index < self.len())]
-    pub const fn get(&self, index: usize) -> A { //~ ERROR generating fold-unfold Viper statements failed
+    pub const fn get(&self, index: usize) -> A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         self.inner[index]
     }
 
     /// Lookup an ADT from a slice
     #[pure]
     #[requires(index < self.len())]
-    pub const fn get_pure(&self, index: usize) -> A { //~ ERROR generating fold-unfold Viper statements failed
+    pub const fn get_pure(&self, index: usize) -> A {
+        //~^ ERROR generating fold-unfold Viper statements failed
         self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-9.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-9.rs
@@ -17,10 +17,10 @@ impl B {
 
     /// Assign an ADT to a slice element directly
     #[requires(index < self.len())]
-    pub fn set(&mut self, index: usize, a: A) { //~ ERROR generating fold-unfold Viper statements failed
+    pub fn set(&mut self, index: usize, a: A) {
+        //~^ ERROR generating fold-unfold Viper statements failed
         self.inner[index] = a;
     }
-
 }
 
 fn main() {}

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-718-1.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-718-1.rs
@@ -4,17 +4,18 @@ use prusti_contracts::*;
 
 #[derive(Clone, Copy)]
 pub struct A {
-    _inner: usize
+    _inner: usize,
 }
 pub struct B {
-    inner: [A]
+    inner: [A],
 }
 
 impl B {
     /// Obtain the length of a slice.
     #[pure]
     // FIXME: https://github.com/viperproject/prusti-dev/issues/718
-    pub const fn len(&self) -> usize { //~ ERROR unhandled verification error
+    pub const fn len(&self) -> usize {
+        //~^ ERROR unhandled verification error
         self.inner.len()
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-718-2.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-718-2.rs
@@ -6,12 +6,12 @@ pub const SIZE_A: usize = core::mem::size_of::<A>();
 
 #[derive(Clone, Copy)]
 pub struct A {
-    _inner: usize
+    _inner: usize,
 }
 
 #[repr(transparent)]
 pub struct B {
-    inner: [A]
+    inner: [A],
 }
 
 impl B {

--- a/x.py
+++ b/x.py
@@ -32,7 +32,7 @@ RUSTFMT_CRATES = [
     'prusti-launch',
     'prusti-server',
     #'prusti-specs',
-    #'prusti-tests',
+    'prusti-tests',
     'prusti-utils',
     #'prusti-viper',
     'viper',

--- a/x.py
+++ b/x.py
@@ -32,7 +32,7 @@ RUSTFMT_CRATES = [
     'prusti-launch',
     'prusti-server',
     #'prusti-specs',
-    # 'prusti-tests',
+    'prusti-tests',
     'prusti-utils',
     #'prusti-viper',
     'viper',
@@ -479,10 +479,7 @@ def fmt_all():
         fmt_in(crate)
     for path in RUSTFMT_PATHS:
         for file in glob.glob(path, recursive=True):
-            if file.startswith('prusti-tests/'):
-                run_command(['rustfmt', '--config-path', './prusti-tests/', file])
-            else:
-                run_command(['rustfmt', file])
+            run_command(['rustfmt', file])
 
 def fmt_check_in(cwd):
     """Run cargo fmt check in the given subproject."""
@@ -494,10 +491,7 @@ def fmt_check_all():
         fmt_check_in(crate)
     for path in RUSTFMT_PATHS:
         for file in glob.glob(path, recursive=True):
-            if file.startswith('prusti-tests/'):
-                run_command(['rustfmt', '--config-path', './prusti-tests/', '--check', file])
-            else:
-                run_command(['rustfmt', '--check', file])
+            run_command(['rustfmt', '--check', file])
 
 def main(argv):
     global verbose

--- a/x.py
+++ b/x.py
@@ -32,7 +32,7 @@ RUSTFMT_CRATES = [
     'prusti-launch',
     'prusti-server',
     #'prusti-specs',
-    'prusti-tests',
+    # 'prusti-tests',
     'prusti-utils',
     #'prusti-viper',
     'viper',
@@ -42,6 +42,7 @@ RUSTFMT_CRATES = [
 ]
 
 RUSTFMT_PATHS = [
+    'prusti-tests/tests/verify_partial/**/*.rs',
     'prusti-viper/src/encoder/foldunfold/mod.rs',
     'prusti-viper/src/encoder/mir/mod.rs',
     'prusti-viper/src/encoder/high/mod.rs',
@@ -477,7 +478,11 @@ def fmt_all():
     for crate in RUSTFMT_CRATES:
         fmt_in(crate)
     for path in RUSTFMT_PATHS:
-        run_command(['rustfmt', path])
+        for file in glob.glob(path, recursive=True):
+            if file.startswith('prusti-tests/'):
+                run_command(['rustfmt', '--config-path', './prusti-tests/', file])
+            else:
+                run_command(['rustfmt', file])
 
 def fmt_check_in(cwd):
     """Run cargo fmt check in the given subproject."""
@@ -488,7 +493,11 @@ def fmt_check_all():
     for crate in RUSTFMT_CRATES:
         fmt_check_in(crate)
     for path in RUSTFMT_PATHS:
-        run_command(['rustfmt', '--check', path])
+        for file in glob.glob(path, recursive=True):
+            if file.startswith('prusti-tests/'):
+                run_command(['rustfmt', '--config-path', './prusti-tests/', '--check', file])
+            else:
+                run_command(['rustfmt', '--check', file])
 
 def main(argv):
     global verbose


### PR DESCRIPTION
In #720 it was discovered that rustfmt is not enabled on the `prusti-tests` folder. This PR fixes that and also fixes the formatting for the tests contained within (only 2 test files were affected). Running `x.py fmt-all` will successfully ensure newlines at the end of all formatted test files.