### PR TITLE
Fix TransferPerm between old(..) expressions

### DIFF
--- a/prusti-tests/tests/verify/fail/issues/issue-737-1.rs
+++ b/prusti-tests/tests/verify/fail/issues/issue-737-1.rs
@@ -19,7 +19,7 @@ impl Stack {
     #[requires(0 < self.len())]
     fn top_node(&mut self) -> &mut Node {
         match self.head {
-            None => { unreachable!() },
+            None => { unreachable!() }, //~ ERROR unreachable!(..) statement might be reachable
             Some(ref mut node) => node,
         }
     }

--- a/prusti-tests/tests/verify/pass/issues/issue-737-1.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-737-1.rs
@@ -1,0 +1,29 @@
+use prusti_contracts::*;
+
+struct Node {
+    elem: i32,
+    next: Option<Box<Node>>,
+}
+
+pub struct Stack {
+    head: Option<Box<Node>>,
+}
+
+impl Stack {
+    #[pure]
+    #[trusted]
+    fn len(&self) -> i32 {
+        unimplemented!()
+    }
+
+    #[requires(0 < self.len())]
+    fn top_node(&mut self) -> &mut Node {
+        match self.head {
+            None => { unreachable!() },
+            Some(ref mut node) => node,
+        }
+    }
+}
+
+#[trusted]
+fn main() {}

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -470,8 +470,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> vir::CfgReplacer<PathCtxt<'p>, ActionVec> for FoldUnf
 
         if let vir::Stmt::ExpireBorrows(vir::ExpireBorrows { ref dag }) = stmt {
             let mut stmts = vec![vir::Stmt::comment(format!("{}", stmt))];
+            trace!("State acc {{\n{}\n}}", pctxt.state().display_acc());
+            trace!("State pred {{\n{}\n}}", pctxt.state().display_pred());
+            trace!("State moved {{\n{}\n}}", pctxt.state().display_moved());
             let expire_borrow_statements =
                 self.process_expire_borrows(dag, pctxt, curr_block_index, new_cfg, label)?;
+            trace!("State acc {{\n{}\n}}", pctxt.state().display_acc());
+            trace!("State pred {{\n{}\n}}", pctxt.state().display_pred());
+            trace!("State moved {{\n{}\n}}", pctxt.state().display_moved());
             stmts.extend(expire_borrow_statements);
             return Ok(stmts);
         }

--- a/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
+++ b/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
@@ -400,10 +400,11 @@ fn dump_borrows_cfg(
     report::log::report_with_writer(
         "graphviz_reborrowing_dag_during_foldunfold",
         format!(
-            "{}.{:?}.{}.dot",
+            "{}.{:?}.{}.{}.dot",
             source_filename,
             dag,
-            surrounding_block_index.index()
+            surrounding_block_index.index(),
+            curr_block_index,
         ),
         |writer| cfg.to_graphviz(writer, curr_block_index),
     );

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -286,9 +286,18 @@ impl ApplyOnState for vir::Stmt {
                 // Like `has_prefix`, but ignoring the labels if they are equal.
                 fn old_has_prefix(this: &vir::Expr, other: &vir::Expr) -> bool {
                     if let (
-                        vir::Expr::LabelledOld(vir::LabelledOld{ label: this_label, base: this_base, .. }),
-                        vir::Expr::LabelledOld(vir::LabelledOld{ label: other_label, base: other_base, .. })
-                    ) = (this, other) {
+                        vir::Expr::LabelledOld(vir::LabelledOld {
+                            label: this_label,
+                            base: this_base,
+                            ..
+                        }),
+                        vir::Expr::LabelledOld(vir::LabelledOld {
+                            label: other_label,
+                            base: other_base,
+                            ..
+                        }),
+                    ) = (this, other)
+                    {
                         this_label == other_label && this_base.has_prefix(other_base)
                     } else {
                         this.has_prefix(other)
@@ -298,9 +307,18 @@ impl ApplyOnState for vir::Stmt {
                 // Like `has_proper_prefix`, but ignoring the labels if they are equal.
                 fn old_has_proper_prefix(this: &vir::Expr, other: &vir::Expr) -> bool {
                     if let (
-                        vir::Expr::LabelledOld(vir::LabelledOld{ label: this_label, base: this_base, .. }),
-                        vir::Expr::LabelledOld(vir::LabelledOld{ label: other_label, base: other_base, .. })
-                    ) = (this, other) {
+                        vir::Expr::LabelledOld(vir::LabelledOld {
+                            label: this_label,
+                            base: this_base,
+                            ..
+                        }),
+                        vir::Expr::LabelledOld(vir::LabelledOld {
+                            label: other_label,
+                            base: other_base,
+                            ..
+                        }),
+                    ) = (this, other)
+                    {
                         this_label == other_label && this_base.has_proper_prefix(other_base)
                     } else {
                         this.has_proper_prefix(other)
@@ -308,18 +326,30 @@ impl ApplyOnState for vir::Stmt {
                 }
 
                 // Like `replace_place`, but ignoring the labels if they are equal.
-                fn old_replace_place(this: &vir::Expr, target: &vir::Expr, replacement: &vir::Expr) -> vir::Expr {
+                fn old_replace_place(
+                    this: &vir::Expr,
+                    target: &vir::Expr,
+                    replacement: &vir::Expr,
+                ) -> vir::Expr {
                     if let (
-                        vir::Expr::LabelledOld(vir::LabelledOld{ label: this_label, base: this_base, .. }),
-                        vir::Expr::LabelledOld(vir::LabelledOld{ label: target_label, base: target_base, .. })
-                    ) = (this, target) {
+                        vir::Expr::LabelledOld(vir::LabelledOld {
+                            label: this_label,
+                            base: this_base,
+                            ..
+                        }),
+                        vir::Expr::LabelledOld(vir::LabelledOld {
+                            label: target_label,
+                            base: target_base,
+                            ..
+                        }),
+                    ) = (this, target)
+                    {
                         if this_label == target_label {
                             if let vir::Expr::LabelledOld(repl_labelled) = replacement {
                                 return vir::Expr::LabelledOld(vir::LabelledOld {
-                                    base: box this_base.clone().replace_place(
-                                        target_base,
-                                        repl_labelled.base.as_ref()
-                                    ),
+                                    base: box this_base
+                                        .clone()
+                                        .replace_place(target_base, repl_labelled.base.as_ref()),
                                     label: repl_labelled.label.clone(),
                                     position: repl_labelled.position.clone(),
                                 });
@@ -351,9 +381,7 @@ impl ApplyOnState for vir::Stmt {
                         .acc()
                         .iter()
                         .filter(|(p, _)| old_has_proper_prefix(p, left))
-                        .map(|(p, perm_amount)| {
-                            (old_replace_place(p, left, right), *perm_amount)
-                        })
+                        .map(|(p, perm_amount)| (old_replace_place(p, left, right), *perm_amount))
                         .filter(|(p, _)| !p.is_local())
                         .collect()
                 };
@@ -369,9 +397,7 @@ impl ApplyOnState for vir::Stmt {
                         .pred()
                         .iter()
                         .filter(|(p, _)| old_has_prefix(p, left))
-                        .map(|(p, perm_amount)| {
-                            (old_replace_place(p, left, right), *perm_amount)
-                        })
+                        .map(|(p, perm_amount)| (old_replace_place(p, left, right), *perm_amount))
                         .collect()
                 };
 

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -351,7 +351,7 @@ impl ApplyOnState for vir::Stmt {
                                         .clone()
                                         .replace_place(target_base, repl_labelled.base.as_ref()),
                                     label: repl_labelled.label.clone(),
-                                    position: repl_labelled.position.clone(),
+                                    position: repl_labelled.position,
                                 });
                             } else {
                                 return this_base.clone().replace_place(target_base, replacement);

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -283,14 +283,62 @@ impl ApplyOnState for vir::Stmt {
 
                 // Restore permissions from the `lhs` to the `rhs`
 
+                // Like `has_prefix`, but ignoring the labels if they are equal.
+                fn old_has_prefix(this: &vir::Expr, other: &vir::Expr) -> bool {
+                    if let (
+                        vir::Expr::LabelledOld(vir::LabelledOld{ label: this_label, base: this_base, .. }),
+                        vir::Expr::LabelledOld(vir::LabelledOld{ label: other_label, base: other_base, .. })
+                    ) = (this, other) {
+                        this_label == other_label && this_base.has_prefix(other_base)
+                    } else {
+                        this.has_prefix(other)
+                    }
+                }
+
+                // Like `has_proper_prefix`, but ignoring the labels if they are equal.
+                fn old_has_proper_prefix(this: &vir::Expr, other: &vir::Expr) -> bool {
+                    if let (
+                        vir::Expr::LabelledOld(vir::LabelledOld{ label: this_label, base: this_base, .. }),
+                        vir::Expr::LabelledOld(vir::LabelledOld{ label: other_label, base: other_base, .. })
+                    ) = (this, other) {
+                        this_label == other_label && this_base.has_proper_prefix(other_base)
+                    } else {
+                        this.has_proper_prefix(other)
+                    }
+                }
+
+                // Like `replace_place`, but ignoring the labels if they are equal.
+                fn old_replace_place(this: &vir::Expr, target: &vir::Expr, replacement: &vir::Expr) -> vir::Expr {
+                    if let (
+                        vir::Expr::LabelledOld(vir::LabelledOld{ label: this_label, base: this_base, .. }),
+                        vir::Expr::LabelledOld(vir::LabelledOld{ label: target_label, base: target_base, .. })
+                    ) = (this, target) {
+                        if this_label == target_label {
+                            if let vir::Expr::LabelledOld(repl_labelled) = replacement {
+                                return vir::Expr::LabelledOld(vir::LabelledOld {
+                                    base: box this_base.clone().replace_place(
+                                        target_base,
+                                        repl_labelled.base.as_ref()
+                                    ),
+                                    label: repl_labelled.label.clone(),
+                                    position: repl_labelled.position.clone(),
+                                });
+                            } else {
+                                return this_base.clone().replace_place(target_base, replacement);
+                            }
+                        }
+                    }
+                    this.clone().replace_place(target, replacement)
+                }
+
                 // In Prusti, lose permission from the lhs and rhs
-                state.remove_pred_matching(|p| p.has_prefix(left));
-                state.remove_acc_matching(|p| p.has_proper_prefix(left) && !p.is_local());
-                state.remove_pred_matching(|p| p.has_prefix(right));
-                state.remove_acc_matching(|p| p.has_proper_prefix(right) && !p.is_local());
+                state.remove_pred_matching(|p| old_has_prefix(p, left));
+                state.remove_acc_matching(|p| old_has_proper_prefix(p, left) && !p.is_local());
+                state.remove_pred_matching(|p| old_has_prefix(p, right));
+                state.remove_acc_matching(|p| old_has_proper_prefix(p, right) && !p.is_local());
 
                 // The rhs is no longer moved
-                state.remove_moved_matching(|p| p.has_prefix(right));
+                state.remove_moved_matching(|p| old_has_prefix(p, right));
 
                 let rhs_is_array = right.get_type().name().starts_with("Array$");
 
@@ -302,9 +350,9 @@ impl ApplyOnState for vir::Stmt {
                     original_state
                         .acc()
                         .iter()
-                        .filter(|(p, _)| p.has_proper_prefix(left))
+                        .filter(|(p, _)| old_has_proper_prefix(p, left))
                         .map(|(p, perm_amount)| {
-                            (p.clone().replace_place(left, right), *perm_amount)
+                            (old_replace_place(p, left, right), *perm_amount)
                         })
                         .filter(|(p, _)| !p.is_local())
                         .collect()
@@ -320,9 +368,9 @@ impl ApplyOnState for vir::Stmt {
                     original_state
                         .pred()
                         .iter()
-                        .filter(|(p, _)| p.has_prefix(left))
+                        .filter(|(p, _)| old_has_prefix(p, left))
                         .map(|(p, perm_amount)| {
-                            (p.clone().replace_place(left, right), *perm_amount)
+                            (old_replace_place(p, left, right), *perm_amount)
                         })
                         .collect()
                 };
@@ -370,7 +418,7 @@ impl ApplyOnState for vir::Stmt {
                 */
 
                 // Finally, mark the lhs as moved
-                if !left.has_prefix(right) &&   // Maybe this is always true?
+                if !old_has_prefix(left, right) &&   // Maybe this is always true?
                         !unchecked
                 {
                     state.insert_moved(left.clone());


### PR DESCRIPTION
This PR fixes one of the programs in issue #737. This is a short-term patch. The proper fix would be to make aliasing a first-class concept in the fold-unfold algorithm (e.g tracking sets of surely-aliasing expressions), such that `TransferPerm` statements (and the reborrowing DAG) are no longer needed. However, I need to find time for that.