### PR TITLE
Update dependencies (nightly-2021-11-02)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "arrayvec"
@@ -195,12 +195,12 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 [[package]]
 name = "cargo-test-macro"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/cargo.git#94ca096afbf25f670e76e07dca754fcfe27134be"
+source = "git+https://github.com/rust-lang/cargo.git#b4ab730ca6e0a0644e47a90aca727836ed2a83f5"
 
 [[package]]
 name = "cargo-test-support"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/cargo.git#94ca096afbf25f670e76e07dca754fcfe27134be"
+source = "git+https://github.com/rust-lang/cargo.git#b4ab730ca6e0a0644e47a90aca727836ed2a83f5"
 dependencies = [
  "anyhow",
  "cargo-test-macro",
@@ -222,7 +222,7 @@ dependencies = [
 [[package]]
 name = "cargo-util"
 version = "0.1.1"
-source = "git+https://github.com/rust-lang/cargo.git#94ca096afbf25f670e76e07dca754fcfe27134be"
+source = "git+https://github.com/rust-lang/cargo.git#b4ab730ca6e0a0644e47a90aca727836ed2a83f5"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -2274,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -2,7 +2,7 @@
 name = "analysis"
 version = "0.1.0"
 authors = ["Federico Poli <federpoli@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 log = { version = "0.4", features = ["release_max_level_info"] }

--- a/prusti-common/Cargo.toml
+++ b/prusti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti-common"
 version = "0.1.0"
 authors = ["Julian Dunskus <julian.dunskus@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 doctest = false # we have no doc tests

--- a/prusti-contracts-impl/Cargo.toml
+++ b/prusti-contracts-impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti-contracts-impl"
 version = "0.1.0"
 authors = ["Vytautas Astrauskas <vastrauskas@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/prusti-contracts-internal/Cargo.toml
+++ b/prusti-contracts-internal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti-contracts-internal"
 version = "0.1.0"
 authors = ["Vytautas Astrauskas <vastrauskas@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/prusti-contracts-test/Cargo.toml
+++ b/prusti-contracts-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti-contracts-test"
 version = "0.1.0"
 authors = ["Vytautas Astrauskas <vastrauskas@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 prusti-contracts = { path = "../prusti-contracts" }

--- a/prusti-contracts/Cargo.toml
+++ b/prusti-contracts/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti-contracts"
 version = "0.1.0"
 authors = ["Vytautas Astrauskas <vastrauskas@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 prusti-contracts-impl = { path = "../prusti-contracts-impl" }

--- a/prusti-interface/Cargo.toml
+++ b/prusti-interface/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Federico Poli <federpoli@gmail.com>"]
 description = "Interface between prusti and prusti-viper"
 license = "MPL-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [lib]
 doctest = false # we have no doc tests

--- a/prusti-launch/Cargo.toml
+++ b/prusti-launch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti-launch"
 version = "0.1.0"
 authors = ["Julian Dunskus <julian.dunskus@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/lib.rs"

--- a/prusti-server/Cargo.toml
+++ b/prusti-server/Cargo.toml
@@ -4,7 +4,7 @@ description = "Server-side logic & handling for Prusti"
 name = "prusti-server"
 license = "MPL-2.0"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 test = true # we have unit tests

--- a/prusti-specs/Cargo.toml
+++ b/prusti-specs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti-specs"
 version = "0.1.0"
 authors = ["Vytautas Astrauskas <vastrauskas@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 doctest = false # we have no doc tests

--- a/prusti-specs/src/specifications/common.rs
+++ b/prusti-specs/src/specifications/common.rs
@@ -150,7 +150,7 @@ impl NameGenerator {
 
     pub(crate) fn generate_mod_name(&self, ident: &syn::Ident) -> String {
         let uuid = Uuid::new_v4().to_simple();
-        format!("{}_{}", ident.to_string(), uuid)
+        format!("{}_{}", ident, uuid)
     }
 }
 

--- a/prusti-tests/Cargo.toml
+++ b/prusti-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti-tests"
 version = "0.2.0"
 authors = ["Federico Poli <federpoli@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dev-dependencies]
 compiletest_rs = "0.7.0"

--- a/prusti-tests/tests/cargo_verify/failing_crate/Cargo.toml
+++ b/prusti-tests/tests/cargo_verify/failing_crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "failing_crate"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 prusti-contracts = { path = "prusti-contracts" } # The test suite will prepare a symbolic link for this

--- a/prusti-tests/tests/cargo_verify/prusti_toml/Cargo.toml
+++ b/prusti-tests/tests/cargo_verify/prusti_toml/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prusti_toml"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 prusti-contracts = { path = "prusti-contracts" } # The test suite will prepare a symbolic link for this

--- a/prusti-tests/tests/cargo_verify/prusti_toml/output.stderr
+++ b/prusti-tests/tests/cargo_verify/prusti_toml/output.stderr
@@ -16,7 +16,7 @@ error: [Prusti: verification error] the asserted expression might not hold
  --> src/lib.rs:7:5
   |
 7 |     assert!(false);
-  |     ^^^^^^^^^^^^^^^
+  |     ^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/prusti-tests/tests/cargo_verify/prusti_toml/output.stdout
+++ b/prusti-tests/tests/cargo_verify/prusti_toml/output.stdout
@@ -4,7 +4,7 @@
 #![feature(register_tool)]
 #![register_tool(prusti)]
 #[prelude_import]
-use std::prelude::rust_2018::*;
+use std::prelude::rust_2021::*;
 #[macro_use]
 extern crate std;
 use prusti_contracts::*;

--- a/prusti-tests/tests/cargo_verify/prusti_toml_fail/Cargo.toml
+++ b/prusti-tests/tests/cargo_verify/prusti_toml_fail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prusti_toml"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 prusti-contracts = { path = "prusti-contracts" } # The test suite will prepare a symbolic link for this

--- a/prusti-tests/tests/cargotest.rs
+++ b/prusti-tests/tests/cargotest.rs
@@ -72,7 +72,7 @@ fn simple_assert_false() {
  --> src/main.rs:1:13
   |
 1 | fn main() { assert!(false); }
-  |             ^^^^^^^^^^^^^^^
+  |             ^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/prusti-tests/tests/verify/ui/calls.stderr
+++ b/prusti-tests/tests/verify/ui/calls.stderr
@@ -2,7 +2,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/calls.rs:29:5
    |
 29 |     assert!(z == 5);
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/prusti-tests/tests/verify/ui/counterexamples/bool.stderr
+++ b/prusti-tests/tests/verify/ui/counterexamples/bool.stderr
@@ -56,7 +56,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/bool.rs:17:5
    |
 17 |     assert!(b);
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^
    |
 note: counterexample for "b"
   initial value: false

--- a/prusti-tests/tests/verify/ui/counterexamples/no-return.stderr
+++ b/prusti-tests/tests/verify/ui/counterexamples/no-return.stderr
@@ -2,7 +2,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/no-return.rs:11:5
    |
 11 |     assert!(z != y + 5);
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
    |
 note: counterexample for "x"
   initial value: 42

--- a/prusti-tests/tests/verify/ui/counterexamples/replace.stderr
+++ b/prusti-tests/tests/verify/ui/counterexamples/replace.stderr
@@ -2,7 +2,7 @@ error: [Prusti: verification error] panic!(..) statement might be reachable
   --> $DIR/replace.rs:11:16
    |
 11 |                panic!("no access"); 
-   |                ^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^
    |
 note: counterexample for "x"
   initial value: ref('$' (0x24))

--- a/prusti-tests/tests/verify/ui/counterexamples/structs.stderr
+++ b/prusti-tests/tests/verify/ui/counterexamples/structs.stderr
@@ -68,7 +68,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/structs.rs:35:5
    |
 35 |     assert!(x.value == x.other_value || x.valid);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: counterexample for "x"
   initial value: A {

--- a/prusti-tests/tests/verify/ui/counterexamples/tuples.stderr
+++ b/prusti-tests/tests/verify/ui/counterexamples/tuples.stderr
@@ -52,7 +52,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/tuples.rs:15:5
    |
 15 |     assert!(x.0 == x.1);
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
    |
 note: counterexample for "x"
   initial value: (
@@ -73,7 +73,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/tuples.rs:21:13
    |
 21 |             assert!(x.0 == 0);
-   |             ^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^
    |
 note: counterexample for "x"
   initial value: (

--- a/prusti-tests/tests/verify/ui/false.stderr
+++ b/prusti-tests/tests/verify/ui/false.stderr
@@ -14,7 +14,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/false.rs:12:5
    |
 12 |     assert!(false);
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/prusti-tests/tests/verify/ui/pledges.stderr
+++ b/prusti-tests/tests/verify/ui/pledges.stderr
@@ -2,7 +2,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/pledges.rs:34:5
    |
 34 |     assert!(a.f == 6);
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/prusti-tests/tests/verify/ui/pure.stderr
+++ b/prusti-tests/tests/verify/ui/pure.stderr
@@ -2,7 +2,7 @@ error: [Prusti: verification error] the asserted expression might not hold
   --> $DIR/pure.rs:39:5
    |
 39 |     assert!(z == 5);
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/prusti-utils/Cargo.toml
+++ b/prusti-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prusti-utils"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/prusti-viper/Cargo.toml
+++ b/prusti-viper/Cargo.toml
@@ -5,7 +5,7 @@ name = "prusti-viper"
 readme = "README.md"
 license = "MPL-2.0"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 doctest = false # we have no doc tests

--- a/prusti-viper/src/encoder/foldunfold/action.rs
+++ b/prusti-viper/src/encoder/foldunfold/action.rs
@@ -67,7 +67,7 @@ impl Action {
 impl fmt::Display for Action {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Action::Fold(..) | Action::Unfold(..) => write!(f, "{}", self.to_stmt().to_string()),
+            Action::Fold(..) | Action::Unfold(..) => write!(f, "{}", self.to_stmt()),
             Action::Drop(ref perm, ref missing_perm) => {
                 write!(f, "drop {} ({})", perm, missing_perm)
             }

--- a/prusti/Cargo.toml
+++ b/prusti/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prusti"
 version = "0.2.0"
 authors = ["Vytautas Astrauskas <vastrauskas@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "prusti-driver"

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -10,7 +10,7 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_interface::{interface::Compiler, Config, Queries};
 use rustc_middle::ty::{
     self,
-    query::{query_values::mir_borrowck, Providers},
+    query::{query_values::mir_borrowck, ExternProviders, Providers},
     TyCtxt,
 };
 use rustc_session::Session;
@@ -35,9 +35,8 @@ fn mir_borrowck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> mir_borrowck<'tc
     original_mir_borrowck(tcx, def_id)
 }
 
-fn override_queries(_session: &Session, local: &mut Providers, external: &mut Providers) {
+fn override_queries(_session: &Session, local: &mut Providers, _external: &mut ExternProviders) {
     local.mir_borrowck = mir_borrowck;
-    external.mir_borrowck = mir_borrowck;
 }
 
 impl rustc_driver::Callbacks for PrustiCompilerCalls {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-10-15"
+channel = "nightly-2021-11-02"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-std", "rustfmt" ]
 profile = "minimal"

--- a/test-crates/Cargo.toml
+++ b/test-crates/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-crates"
 version = "0.1.0"
 authors = ["Federico Poli <federpoli@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 prusti-launch = { path = "../prusti-launch" }

--- a/vir-gen/Cargo.toml
+++ b/vir-gen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vir-gen"
 version = "0.1.0"
 authors = ["Vytautas Astrauskas <vastrauskas@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A VIR generator."
 

--- a/vir-gen/src/deriver/visitors.rs
+++ b/vir-gen/src/deriver/visitors.rs
@@ -144,7 +144,7 @@ impl Deriver {
             call
         };
         let method = parse_quote! {
-            pub fn #method_name(&mut self, #parameter_name: #parameter_type) -> #result_type {
+            fn #method_name(&mut self, #parameter_name: #parameter_type) -> #result_type {
                 #body
             }
         };
@@ -167,7 +167,7 @@ impl Deriver {
         };
         let method = parse_quote! {
             #[allow(clippy::boxed_local)]
-            pub fn #method_name(&mut self, #parameter_name: Box<#parameter_type>) -> #result_type {
+            fn #method_name(&mut self, #parameter_name: Box<#parameter_type>) -> #result_type {
                 #body
             }
         };
@@ -200,7 +200,7 @@ impl Deriver {
             }
         };
         let method = parse_quote! {
-            pub fn #method_name(&mut self) -> #result_type {
+            fn #method_name(&mut self) -> #result_type {
                 #result
             }
         };
@@ -234,7 +234,7 @@ impl Deriver {
             }
         };
         let method = parse_quote! {
-            pub fn #method_name(&mut self, #parameter_name: #parameter_type) -> #result_type {
+            fn #method_name(&mut self, #parameter_name: #parameter_type) -> #result_type {
                 #result
             }
         };

--- a/vir/Cargo.toml
+++ b/vir/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vir"
 version = "0.1.0"
 authors = ["Vytautas Astrauskas <vastrauskas@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 index_vec = { version = "0.1.2", features = ["serde"] }

--- a/vir/defs/polymorphic/ast/expr.rs
+++ b/vir/defs/polymorphic/ast/expr.rs
@@ -2380,7 +2380,7 @@ impl fmt::Display for ForAll {
                 .map(|x| x.to_string())
                 .collect::<Vec<String>>()
                 .join(", "),
-            (&self.body).to_string()
+            self.body
         )
     }
 }
@@ -2421,7 +2421,7 @@ impl fmt::Display for Exists {
                 .map(|x| x.to_string())
                 .collect::<Vec<String>>()
                 .join(", "),
-            (&self.body).to_string()
+            self.body
         )
     }
 }
@@ -2452,9 +2452,7 @@ impl fmt::Display for LetExpr {
         write!(
             f,
             "(let {:?} == ({}) in {})",
-            &self.variable,
-            (&self.def).to_string(),
-            (&self.body).to_string()
+            &self.variable, self.def, self.body
         )
     }
 }
@@ -2584,9 +2582,7 @@ impl fmt::Display for DowncastExpr {
         write!(
             f,
             "(downcast {} to {} in {})",
-            (&self.enum_place).to_string(),
-            &self.field,
-            (&self.base).to_string(),
+            self.enum_place, &self.field, self.base,
         )
     }
 }
@@ -2612,7 +2608,7 @@ pub struct SnapApp {
 
 impl fmt::Display for SnapApp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "snap({})", (&*self.base).to_string())
+        write!(f, "snap({})", self.base)
     }
 }
 

--- a/vir/src/legacy/ast/expr.rs
+++ b/vir/src/legacy/ast/expr.rs
@@ -198,7 +198,7 @@ impl fmt::Display for Expr {
                     .map(|x| x.to_string())
                     .collect::<Vec<String>>()
                     .join(", "),
-                body.to_string()
+                body
             ),
             Expr::Exists(ref vars, ref triggers, ref body, ref _pos) => write!(
                 f,
@@ -212,15 +212,11 @@ impl fmt::Display for Expr {
                     .map(|x| x.to_string())
                     .collect::<Vec<String>>()
                     .join(", "),
-                body.to_string()
+                body
             ),
-            Expr::LetExpr(ref var, ref expr, ref body, ref _pos) => write!(
-                f,
-                "(let {:?} == ({}) in {})",
-                var,
-                expr.to_string(),
-                body.to_string()
-            ),
+            Expr::LetExpr(ref var, ref expr, ref body, ref _pos) => {
+                write!(f, "(let {:?} == ({}) in {})", var, expr, body)
+            }
             Expr::FuncApp(ref name, ref args, ref params, ref typ, ref _pos) => write!(
                 f,
                 "{}<{},{}>({})",
@@ -230,7 +226,7 @@ impl fmt::Display for Expr {
                     .map(|p| p.typ.to_string())
                     .collect::<Vec<String>>()
                     .join(", "),
-                typ.to_string(),
+                typ,
                 args.iter()
                     .map(|f| f.to_string())
                     .collect::<Vec<String>>()
@@ -268,14 +264,10 @@ impl fmt::Display for Expr {
                 write!(f, "[({}), ({})]", inhale_expr, exhale_expr)
             }
 
-            Expr::Downcast(ref base, ref enum_place, ref field) => write!(
-                f,
-                "(downcast {} to {} in {})",
-                enum_place.to_string(),
-                field,
-                base.to_string(),
-            ),
-            Expr::SnapApp(ref expr, _) => write!(f, "snap({})", expr.to_string()),
+            Expr::Downcast(ref base, ref enum_place, ref field) => {
+                write!(f, "(downcast {} to {} in {})", enum_place, field, base,)
+            }
+            Expr::SnapApp(ref expr, _) => write!(f, "snap({})", expr),
         }
     }
 }


### PR DESCRIPTION
* [x] Update rustc version to `nightly-2021-11-02`.
* [x] Manualy update outdated dependencies (see the list below).
* [x] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ cargo outdated --root-deps-only --workspace

info: syncing channel updates for 'nightly-2021-11-02-x86_64-unknown-linux-gnu'
info: latest update on 2021-11-02, rust version 1.58.0-nightly (db062de72 2021-11-01)
info: downloading component 'cargo'
info: downloading component 'llvm-tools-preview'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustc-dev'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'llvm-tools-preview'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustc-dev'
info: installing component 'rustfmt'
error: no matching package named `cargo-test-support` found
location searched: https://github.com/rust-lang/cargo.git#94ca096a
required by package `prusti-tests v0.2.0 (/home/runner/work/prusti-dev/prusti-dev/prusti-tests)`
cargo outdated failed to execute
```
</details>

@vakaras could you take care of this?