### PR TITLE
JNI local frame fixes for `viper/src/verifier.rs`

### DIFF
--- a/viper/src/verifier.rs
+++ b/viper/src/verifier.rs
@@ -87,7 +87,8 @@ impl<'a, VerifierState> Drop for Verifier<'a, VerifierState> {
     fn drop(&mut self) {
         // tell the JVM GC it's okay to clean up `self.verifier_instance`
         // when the last local frame is popped
-        self.env.pop_local_frame(JObject::null()).unwrap();
+        self.jni
+            .unwrap_result(self.env.pop_local_frame(JObject::null()));
     }
 }
 
@@ -95,7 +96,7 @@ impl<'a> Verifier<'a, state::Uninitialized> {
     pub fn parse_command_line(self, args: &[String]) -> Verifier<'a, state::Stopped> {
         // this local frame will be popped by the Drop implementation
         // of `self` at the end of this code block:
-        self.env.push_local_frame(16).unwrap();
+        self.jni.unwrap_result(self.env.push_local_frame(16));
         {
             let args = self.jni.new_seq(
                 &args


### PR DESCRIPTION
I added some additional local frames around the JNI interaction in `viper/src/verifier.rs`.

I guess the most significant one is the popping of the local frame that holds `self.verifier_instance`. This is a `JObject` (which implements the `Copy` trait). Due to the type state pattern used in `Verifier`, it is a little hard to place the local frame boundaries, so I had to resort to `push_local_frame` and `pop_local_frame` statements. This works, but looks prone to error from a code maintenance perspective. I'm not sure how to make this look nicer, without removing the type state pattern altogether, but that seemed a bit out-of-scope for this PR.