### PR TITLE
Update dependencies (nightly-2021-11-15)

### DIFF
--- a/prusti-tests/tests/parse/ui/predicates-visibility.stdout
+++ b/prusti-tests/tests/parse/ui/predicates-visibility.stdout
@@ -43,14 +43,14 @@ mod foo {
                                                                     &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                             &match ()
                                                                                                                  {
-                                                                                                                 ()
+                                                                                                                 _args
                                                                                                                  =>
                                                                                                                  [],
                                                                                                              }),)
                                                                          {
-                                                                         (arg0,)
+                                                                         _args
                                                                          =>
-                                                                         [::core::fmt::ArgumentV1::new(arg0,
+                                                                         [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                        ::core::fmt::Display::fmt)],
                                                                      }))
     }

--- a/prusti-tests/tests/parse/ui/predicates.stdout
+++ b/prusti-tests/tests/parse/ui/predicates.stdout
@@ -45,14 +45,13 @@ fn pred1(a: bool) -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }
@@ -95,14 +94,13 @@ fn pred2(a: bool) -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }
@@ -149,14 +147,13 @@ fn forall_implication() -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }
@@ -190,14 +187,13 @@ fn exists_implication() -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }

--- a/prusti-tests/tests/verify/ui/predicate.stdout
+++ b/prusti-tests/tests/verify/ui/predicate.stdout
@@ -52,14 +52,13 @@ fn true_p1() -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }
@@ -89,14 +88,13 @@ fn true_p2() -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }
@@ -126,14 +124,13 @@ fn forall_identity() -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }
@@ -167,14 +164,13 @@ fn exists_identity() -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }
@@ -248,14 +244,13 @@ fn false_p() -> bool {
                                                                 &match (&::core::fmt::Arguments::new_v1(&["predicate"],
                                                                                                         &match ()
                                                                                                              {
-                                                                                                             ()
+                                                                                                             _args
                                                                                                              =>
                                                                                                              [],
                                                                                                          }),)
                                                                      {
-                                                                     (arg0,)
-                                                                     =>
-                                                                     [::core::fmt::ArgumentV1::new(arg0,
+                                                                     _args =>
+                                                                     [::core::fmt::ArgumentV1::new(_args.0,
                                                                                                    ::core::fmt::Display::fmt)],
                                                                  }))
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-11-02"
+channel = "nightly-2021-11-15"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-std", "rustfmt" ]
 profile = "minimal"


### PR DESCRIPTION
* [x] Update rustc version to `nightly-2021-11-15`.
* [ ] Manualy update outdated dependencies (see the list below).
* [ ] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ cargo outdated --root-deps-only --workspace

info: syncing channel updates for 'nightly-2021-11-15-x86_64-unknown-linux-gnu'
info: latest update on 2021-11-15, rust version 1.58.0-nightly (ad4423997 2021-11-14)
info: downloading component 'cargo'
info: downloading component 'llvm-tools-preview'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustc-dev'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'llvm-tools-preview'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustc-dev'
info: installing component 'rustfmt'
thread 'main' panicked at 'package cache lock is not currently held, Cargo forgot to call `acquire_package_cache_lock` before we got to this stack frame', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-0.57.0/src/cargo/util/config/mod.rs:1542:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
cargo outdated failed to execute
```
</details>

@Aurel300 could you take care of this?