### PR TITLE
Encode move of copy types as copy

### DIFF
--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -11,8 +11,10 @@ extern crate polonius_engine;
 extern crate rustc_borrowck;
 extern crate rustc_data_structures;
 extern crate rustc_index;
+extern crate rustc_infer;
 extern crate rustc_middle;
 extern crate rustc_span;
+extern crate rustc_trait_selection;
 extern crate serde;
 
 pub mod abstract_interpretation;

--- a/analysis/src/mir_utils.rs
+++ b/analysis/src/mir_utils.rs
@@ -9,10 +9,12 @@
 
 use log::trace;
 use rustc_data_structures::fx::FxHashSet;
+use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::{
     mir,
     ty::{self, TyCtxt},
 };
+use rustc_trait_selection::infer::InferCtxtExt;
 
 /// Convert a `location` to a string representing the statement or terminator at that `location`
 pub fn location_to_stmt_str(location: mir::Location, mir: &mir::Body) -> String {
@@ -207,4 +209,27 @@ pub(crate) fn collapse<'tcx>(
         }
     }
     recurse(mir, tcx, places, guide_place.local.into(), guide_place);
+}
+
+pub fn is_copy<'tcx>(
+    tcx: ty::TyCtxt<'tcx>,
+    ty: ty::Ty<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+) -> bool {
+    if let Some(copy_trait) = tcx.lang_items().copy_trait() {
+        // We need this check because `type_implements_trait`
+        // panics when called on reference types.
+        if let ty::TyKind::Ref(_, _, mutability) = ty.kind() {
+            // Shared references are copy, mutable references are not.
+            matches!(mutability, mir::Mutability::Not)
+        } else {
+            tcx.infer_ctxt().enter(|infcx| {
+                infcx
+                    .type_implements_trait(copy_trait, ty, ty::List::empty(), param_env)
+                    .must_apply_considering_regions()
+            })
+        }
+    } else {
+        false
+    }
 }

--- a/analysis/tests/test_cases/definitely_initialized/array.rs
+++ b/analysis/tests/test_cases/definitely_initialized/array.rs
@@ -1,0 +1,7 @@
+#[analyzer::run]
+fn main() {
+    let x = [1, 2, 3];
+    drop(x);
+    let y = [Box::new(4)];
+    drop(y);
+}

--- a/analysis/tests/test_cases/definitely_initialized/array.stdout
+++ b/analysis/tests/test_cases/definitely_initialized/array.stdout
@@ -1,0 +1,314 @@
+Analyzing file $DIR/array.rs using DefinitelyInitializedAnalysis...
+Result for function main():
+{
+  "bb0": [
+    [
+      [
+        "state:",
+        [],
+        "statement: StorageLive(_1)"
+      ],
+      [
+        "state:",
+        [],
+        "statement: _1 = [const 1_i32, const 2_i32, const 3_i32]"
+      ],
+      [
+        "state:",
+        [
+          "_1"
+        ],
+        "statement: FakeRead(ForLet(None), _1)"
+      ],
+      [
+        "state:",
+        [
+          "_1"
+        ],
+        "statement: StorageLive(_2)"
+      ],
+      [
+        "state:",
+        [
+          "_1"
+        ],
+        "statement: StorageLive(_3)"
+      ],
+      [
+        "state:",
+        [
+          "_1"
+        ],
+        "statement: _3 = _1"
+      ]
+    ],
+    "state before terminator:",
+    [
+      "_1",
+      "_3"
+    ],
+    "terminator: _2 = std::mem::drop::<[i32; 3]>(move _3) -> [return: bb1, unwind: bb8]",
+    {
+      "bb1": [
+        "state:",
+        [
+          "_1",
+          "_2"
+        ]
+      ],
+      "bb8": [
+        "state:",
+        []
+      ]
+    }
+  ],
+  "bb1": [
+    [
+      [
+        "state:",
+        [
+          "_1",
+          "_2"
+        ],
+        "statement: StorageDead(_3)"
+      ],
+      [
+        "state:",
+        [
+          "_1",
+          "_2"
+        ],
+        "statement: StorageDead(_2)"
+      ],
+      [
+        "state:",
+        [
+          "_1"
+        ],
+        "statement: StorageLive(_4)"
+      ],
+      [
+        "state:",
+        [
+          "_1"
+        ],
+        "statement: StorageLive(_5)"
+      ]
+    ],
+    "state before terminator:",
+    [
+      "_1"
+    ],
+    "terminator: _5 = std::boxed::Box::<i32>::new(const 4_i32) -> [return: bb2, unwind: bb8]",
+    {
+      "bb2": [
+        "state:",
+        [
+          "_1",
+          "_5"
+        ]
+      ],
+      "bb8": [
+        "state:",
+        []
+      ]
+    }
+  ],
+  "bb2": [
+    [
+      [
+        "state:",
+        [
+          "_1",
+          "_5"
+        ],
+        "statement: _4 = [move _5]"
+      ]
+    ],
+    "state before terminator:",
+    [
+      "_1",
+      "_4"
+    ],
+    "terminator: drop(_5) -> [return: bb3, unwind: bb8]",
+    {
+      "bb3": [
+        "state:",
+        [
+          "_1",
+          "_4"
+        ]
+      ],
+      "bb8": [
+        "state:",
+        []
+      ]
+    }
+  ],
+  "bb3": [
+    [
+      [
+        "state:",
+        [
+          "_1",
+          "_4"
+        ],
+        "statement: StorageDead(_5)"
+      ],
+      [
+        "state:",
+        [
+          "_1",
+          "_4"
+        ],
+        "statement: FakeRead(ForLet(None), _4)"
+      ],
+      [
+        "state:",
+        [
+          "_1",
+          "_4"
+        ],
+        "statement: StorageLive(_6)"
+      ],
+      [
+        "state:",
+        [
+          "_1",
+          "_4"
+        ],
+        "statement: StorageLive(_7)"
+      ],
+      [
+        "state:",
+        [
+          "_1",
+          "_4"
+        ],
+        "statement: _7 = move _4"
+      ]
+    ],
+    "state before terminator:",
+    [
+      "_1",
+      "_7"
+    ],
+    "terminator: _6 = std::mem::drop::<[std::boxed::Box<i32>; 1]>(move _7) -> [return: bb4, unwind: bb6]",
+    {
+      "bb4": [
+        "state:",
+        [
+          "_1",
+          "_6"
+        ]
+      ],
+      "bb6": [
+        "state:",
+        []
+      ]
+    }
+  ],
+  "bb4": [
+    [
+      [
+        "state:",
+        [
+          "_1",
+          "_6"
+        ],
+        "statement: StorageDead(_7)"
+      ],
+      [
+        "state:",
+        [
+          "_1",
+          "_6"
+        ],
+        "statement: StorageDead(_6)"
+      ],
+      [
+        "state:",
+        [
+          "_1"
+        ],
+        "statement: _0 = const ()"
+      ]
+    ],
+    "state before terminator:",
+    [
+      "_0",
+      "_1"
+    ],
+    "terminator: drop(_4) -> [return: bb5, unwind: bb8]",
+    {
+      "bb5": [
+        "state:",
+        [
+          "_0",
+          "_1"
+        ]
+      ],
+      "bb8": [
+        "state:",
+        []
+      ]
+    }
+  ],
+  "bb5": [
+    [
+      [
+        "state:",
+        [
+          "_0",
+          "_1"
+        ],
+        "statement: StorageDead(_4)"
+      ],
+      [
+        "state:",
+        [
+          "_0",
+          "_1"
+        ],
+        "statement: StorageDead(_1)"
+      ]
+    ],
+    "state before terminator:",
+    [
+      "_0"
+    ],
+    "terminator: return",
+    {}
+  ],
+  "bb6": [
+    [],
+    "state before terminator:",
+    [],
+    "terminator: drop(_7) -> bb7",
+    {
+      "bb7": [
+        "state:",
+        []
+      ]
+    }
+  ],
+  "bb7": [
+    [],
+    "state before terminator:",
+    [],
+    "terminator: drop(_4) -> bb8",
+    {
+      "bb8": [
+        "state:",
+        []
+      ]
+    }
+  ],
+  "bb8": [
+    [],
+    "state before terminator:",
+    [],
+    "terminator: resume",
+    {}
+  ]
+}

--- a/prusti-interface/src/environment/mir_analyses/initialization.rs
+++ b/prusti-interface/src/environment/mir_analyses/initialization.rs
@@ -71,7 +71,7 @@ pub fn compute_definitely_initialized<'a, 'tcx: 'a>(
     tcx: TyCtxt<'tcx>,
 ) -> DefinitelyInitializedAnalysisResult<'tcx> {
     let stopwatch = Stopwatch::start_debug("prusti-client", "initialization analysis");
-    let analysis = DefinitelyInitializedAnalysis::new(tcx, def_id, body);
+    let analysis = DefinitelyInitializedAnalysis::new_relaxed(tcx, def_id, body);
     let pointwise_state = analysis
         .run_fwd_analysis()
         .map_err(|e| {

--- a/prusti-tests/tests/verify/pass/issues/issue-389.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-389.rs
@@ -1,0 +1,6 @@
+fn test() {
+    let mut k: usize = 0;
+    while k - 123 > 0 { }
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/pass/no-annotations/check_in_guard.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/check_in_guard.rs
@@ -1,0 +1,12 @@
+fn foo() {}
+
+fn bar(mut i: i32) {
+    while {
+        i += 1;
+        i > 0
+    } {
+        foo();
+    }
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/fail/issues/issue-389-1.rs
+++ b/prusti-tests/tests/verify_overflow/fail/issues/issue-389-1.rs
@@ -1,0 +1,6 @@
+fn test() {
+    let mut k: usize = 0;
+    while k - 123 > 0 { } //~ ERROR attempt to subtract with overflow
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/fail/issues/issue-389-2.rs
+++ b/prusti-tests/tests/verify_overflow/fail/issues/issue-389-2.rs
@@ -1,0 +1,12 @@
+fn foo() {}
+
+fn bar(mut i: i32) {
+    while {
+        i += 1; //~ ERROR attempt to add with overflow
+        i > 0
+    } {
+        foo();
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This PR encodes the *moves* of Copy types as *copies*. As a consequence, copy types are still considered initialized even after a MIR move. This avoids an issue with the computation of the permissions of the loop invariant.

Fixes #389 