### PR TITLE
Remove POLONIUS_ALGORITHM

### DIFF
--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -186,7 +186,6 @@ fn main() {
         ));
         info!("Prusti version: {}", get_prusti_version_info());
 
-        env::set_var("POLONIUS_ALGORITHM", "Naive");
         rustc_args.push("-Zpolonius".to_owned());
         rustc_args.push("-Zalways-encode-mir".to_owned());
         rustc_args.push("-Zcrate-attr=feature(register_tool)".to_owned());


### PR DESCRIPTION
Since we don't read Polonius' output facts computed by the compiler, we might no longer need to the compiler to use the slow "Naive" algorithm.