### PR TITLE
add `no_verify_deps` configuration flag to disable verification for local dependencies

### DIFF
--- a/prusti-common/src/config.rs
+++ b/prusti-common/src/config.rs
@@ -88,6 +88,7 @@ lazy_static! {
         settings.set_default("skip_unsupported_features", false).unwrap();
         settings.set_default("allow_unreachable_unsupported_code", false).unwrap();
         settings.set_default("no_verify", false).unwrap();
+        settings.set_default("no_verify_deps", false).unwrap();
         settings.set_default("full_compilation", false).unwrap();
         settings.set_default("json_communication", false).unwrap();
         settings.set_default("optimizations","all").unwrap();
@@ -449,6 +450,11 @@ pub fn allow_unreachable_unsupported_code() -> bool {
 /// Skip the verification
 pub fn no_verify() -> bool {
     read_setting("no_verify")
+}
+
+/// Skip the verification of dependencies
+pub fn no_verify_deps() -> bool {
+    read_setting("no_verify_deps")
 }
 
 /// Continue the compilation and generate the binary after Prusti terminates

--- a/prusti-tests/tests/cargo_verify/no_deps/.gitignore
+++ b/prusti-tests/tests/cargo_verify/no_deps/.gitignore
@@ -1,0 +1,1 @@
+!Prusti.toml

--- a/prusti-tests/tests/cargo_verify/no_deps/Cargo.toml
+++ b/prusti-tests/tests/cargo_verify/no_deps/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "no_deps"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+prusti-contracts = { path = "prusti-contracts" } # The test suite will prepare a symbolic link for this
+bad_dependency = { path = "bad_dependency" }
+
+# Declare that this crate is not part of a workspace
+[workspace]
+exclude = ["bad_dependency"]

--- a/prusti-tests/tests/cargo_verify/no_deps/Prusti.toml
+++ b/prusti-tests/tests/cargo_verify/no_deps/Prusti.toml
@@ -1,0 +1,5 @@
+check_overflows = true
+check_panics = true
+
+# Test that dependencies are not verified against Prusti
+no_verify_deps = true

--- a/prusti-tests/tests/cargo_verify/no_deps/bad_dependency/Cargo.toml
+++ b/prusti-tests/tests/cargo_verify/no_deps/bad_dependency/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "bad_dependency"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+# Declare that this crate is not part of a workspace
+[workspace]

--- a/prusti-tests/tests/cargo_verify/no_deps/bad_dependency/src/lib.rs
+++ b/prusti-tests/tests/cargo_verify/no_deps/bad_dependency/src/lib.rs
@@ -1,0 +1,6 @@
+/// This function will never pass verification.
+#[allow(arithmetic_overflow)]
+pub fn evil() {
+    let _ : usize = 1 - 2;
+    panic!();
+}

--- a/prusti-tests/tests/cargo_verify/no_deps/src/lib.rs
+++ b/prusti-tests/tests/cargo_verify/no_deps/src/lib.rs
@@ -1,0 +1,7 @@
+use prusti_contracts::*;
+
+#[requires(true)]
+#[ensures(true)]
+pub fn test() {
+    bad_dependency::evil();
+}

--- a/prusti-tests/tests/cargotest.rs
+++ b/prusti-tests/tests/cargotest.rs
@@ -186,6 +186,11 @@ fn test_failing_crate() {
 }
 
 #[cargo_test]
+fn test_no_deps() {
+    test_local_project("no_deps");
+}
+
+#[cargo_test]
 fn test_prusti_toml() {
     test_local_project("prusti_toml");
 }

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -133,13 +133,13 @@ fn main() {
     let prusti_be_rustc = config::be_rustc();
     // This environment variable will not be set when building dependencies.
     let is_primary_package = env::var("CARGO_PRIMARY_PACKAGE").is_ok();
-    let are_lints_disabled = arg_value(&original_rustc_args, "--cap-lints", |val| val == "allow")
-        .is_some()
-        || (!is_primary_package && config::no_verify_deps());
+    let is_no_verify_crate = !is_primary_package && config::no_verify_deps();
+    let are_lints_disabled =
+        arg_value(&original_rustc_args, "--cap-lints", |val| val == "allow").is_some();
     let is_prusti_package = env::var("CARGO_PKG_NAME")
         .map(|name| PRUSTI_PACKAGES.contains(&name.as_str()))
         .unwrap_or(false);
-    if prusti_be_rustc || are_lints_disabled || is_prusti_package {
+    if prusti_be_rustc || is_no_verify_crate || are_lints_disabled || is_prusti_package {
         rustc_driver::main();
     }
 

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -131,8 +131,11 @@ fn main() {
     // If the environment asks us to actually be rustc, or if lints have been disabled (which
     // indicates that an upstream dependency is being compiled), then run `rustc` instead of Prusti.
     let prusti_be_rustc = config::be_rustc();
-    let are_lints_disabled =
-        arg_value(&original_rustc_args, "--cap-lints", |val| val == "allow").is_some();
+    // This environment variable will not be set when building dependencies.
+    let is_primary_package = env::var("CARGO_PRIMARY_PACKAGE").is_ok();
+    let are_lints_disabled = arg_value(&original_rustc_args, "--cap-lints", |val| val == "allow")
+        .is_some()
+        || (!is_primary_package && config::no_verify_deps());
     let is_prusti_package = env::var("CARGO_PKG_NAME")
         .map(|name| PRUSTI_PACKAGES.contains(&name.as_str()))
         .unwrap_or(false);


### PR DESCRIPTION
Adds a new `no_verify_deps` configuration flag to disable verification for local dependencies.
Includes a `cargo_verify/no_deps` regression test case to verify that the flag is correctly recognized.

Closes #713.