### PR TITLE
Clarify fold-unfold's error messages

### DIFF
--- a/prusti-tests/tests/verify_partial/fail/issues/issue-416.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-416.rs
@@ -7,7 +7,7 @@ pub struct SafeVec<T>(Vec<T>);
 impl<T> SafeVec<T> {
     #[pure]
     // FIXME: The error is tracked in https://github.com/viperproject/prusti-dev/issues/683
-    pub unsafe fn get_unchecked_1(&self, idx: usize) -> &T //~ ERROR generating fold-unfold Viper statements failed
+    pub unsafe fn get_unchecked_1(&self, idx: usize) -> &T //~ ERROR cannot generate fold-unfold Viper statements
     {
         self.0.get_unchecked(idx) //~ ERROR use of impure function
     }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-10.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-10.rs
@@ -13,7 +13,7 @@ impl B {
     /// Mutably reference an ADT within a slice
     #[requires(index < self.inner.len())]
     pub fn get_mut(&mut self, index: usize) -> &mut A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         &mut self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-11.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-11.rs
@@ -15,7 +15,7 @@ impl B {
     /// Obtain a shared reference to an ADT within a slice
     #[requires(index < self.inner.len())]
     pub fn get(&self, index: usize) -> &A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         &self.inner[index]
     }
 
@@ -23,7 +23,7 @@ impl B {
     #[pure]
     #[requires(index < self.inner.len())]
     pub const fn get_pure(&self, index: usize) -> &A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         &self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-12.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-12.rs
@@ -16,7 +16,7 @@ impl B {
 }
 
 pub fn test(b: &mut B) {
-    //~^ ERROR generating fold-unfold Viper statements failed
+    //~^ ERROR cannot generate fold-unfold Viper statements
     b.get_mut(1)[0] = A(1);
 }
 

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-2.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-2.rs
@@ -11,7 +11,7 @@ impl B {
     /// Lookup an ADT from an array
     #[requires(index < self.0.len())]
     pub const fn get(&self, index: usize) -> A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         self.0[index]
     }
 
@@ -19,7 +19,7 @@ impl B {
     #[pure]
     #[requires(index < self.0.len())]
     pub const fn get_pure(&self, index: usize) -> A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-4.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-4.rs
@@ -11,7 +11,7 @@ impl B {
     /// Mutably reference an ADT within an array
     #[requires(index < self.0.len())]
     pub fn get_mut(&mut self, index: usize) -> &mut A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         &mut self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-5.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-5.rs
@@ -11,7 +11,7 @@ impl B {
     /// Obtain a shared reference an ADT within an array
     #[requires(index < self.0.len())]
     pub const fn get(&self, index: usize) -> &A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         &self.0[index]
     }
 
@@ -19,7 +19,7 @@ impl B {
     #[pure]
     #[requires(index < self.0.len())]
     pub const fn get_pure(&self, index: usize) -> &A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         &self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-8.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-8.rs
@@ -17,7 +17,7 @@ impl B {
     /// Lookup an ADT from a slice
     #[requires(index < self.len())]
     pub const fn get(&self, index: usize) -> A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         self.inner[index]
     }
 
@@ -25,7 +25,7 @@ impl B {
     #[pure]
     #[requires(index < self.len())]
     pub const fn get_pure(&self, index: usize) -> A {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-9.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-9.rs
@@ -17,7 +17,7 @@ impl B {
     /// Assign an ADT to a slice element directly
     #[requires(index < self.len())]
     pub fn set(&mut self, index: usize, a: A) {
-        //~^ ERROR generating fold-unfold Viper statements failed
+        //~^ ERROR cannot generate fold-unfold Viper statements
         self.inner[index] = a;
     }
 }

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -18,7 +18,7 @@ use rustc_middle::mir;
 use std::{
     self,
     collections::{HashMap, HashSet},
-    mem,
+    fmt, mem,
     ops::Deref,
 };
 use vir_crate::{
@@ -28,7 +28,6 @@ use vir_crate::{
         FallibleExprFolder, PermAmount, PermAmountError,
     },
 };
-use std::fmt;
 
 mod action;
 mod borrows;
@@ -79,13 +78,7 @@ impl fmt::Display for FoldUnfoldError {
             FoldUnfoldError::FailedToObtain(perm) => {
                 writeln!(f, "The required permission {} cannot be obtained.", perm)
             }
-            FoldUnfoldError::RequiresFolding(
-                _pred,
-                args,
-                frac,
-                _variant,
-                _pos,
-            ) => {
+            FoldUnfoldError::RequiresFolding(_pred, args, frac, _variant, _pos) => {
                 writeln!(f,
                     "A pure expression needs to fold Pred({}, {}), but Viper doesn't support 'folding .. in ..' expressions.",
                     args[0],
@@ -102,14 +95,15 @@ impl fmt::Display for FoldUnfoldError {
                 writeln!(f, "The predicate definition of {} is not available.", pred)
             }
             FoldUnfoldError::FailedToRemovePred(expr, frac) => {
-                writeln!(f,
+                writeln!(
+                    f,
                     "Tried to exhale a Pred({}, {}) permission that is not available.",
-                    expr,
-                    frac
+                    expr, frac
                 )
             }
             FoldUnfoldError::MissingLabel(label) => {
-                writeln!(f,
+                writeln!(
+                    f,
                     "An old[{}](..) expression has a label that has not been declared.",
                     label
                 )

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -104,7 +104,7 @@ impl fmt::Display for FoldUnfoldError {
             FoldUnfoldError::MissingLabel(label) => {
                 writeln!(
                     f,
-                    "An old[{}](..) expression has a label that has not been declared.",
+                    "An old[{}](..) expression uses a label that has not been declared.",
                     label
                 )
             }

--- a/prusti-viper/src/encoder/foldunfold/state.rs
+++ b/prusti-viper/src/encoder/foldunfold/state.rs
@@ -478,7 +478,7 @@ impl State {
     ) -> Result<(), FoldUnfoldError> {
         trace!("remove_pred {}, {}", place, perm);
         if !self.pred.contains_key(place) {
-            return Err(FoldUnfoldError::FailedToRemovePred(place.clone()));
+            return Err(FoldUnfoldError::FailedToRemovePred(place.clone(), perm));
         }
         if self.pred[place] == perm {
             self.pred.remove(place).unwrap();

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -498,7 +498,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
                 _ => SpannedEncodingError::internal(
                     format!(
-                        "generating fold-unfold Viper statements failed ({:?})",
+                        "cannot generate fold-unfold statements. {}",
                         foldunfold_error,
                     ),
                     mir_span,

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -498,7 +498,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
                 _ => SpannedEncodingError::internal(
                     format!(
-                        "cannot generate fold-unfold statements. {}",
+                        "cannot generate fold-unfold Viper statements. {}",
                         foldunfold_error,
                     ),
                     mir_span,


### PR DESCRIPTION
Implement `Display` for `FoldUnfoldError` to report better error messages.