### PR TITLE
Encode constant empty tuples (fixes #693)

### DIFF
--- a/prusti-tests/tests/verify/pass/issues/issue-693.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-693.rs
@@ -1,0 +1,8 @@
+use prusti_contracts::*;
+
+#[pure]
+fn foo(_a: bool, _b: bool) {}
+
+fn main() {
+    foo(true, false);
+}


### PR DESCRIPTION
This PR fixes the new bug reported in #693. The code should get much cleaner as soon as pure functions use values only.