### PR TITLE
Temporary fix for #770

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-770-1.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-770-1.rs
@@ -1,0 +1,28 @@
+use prusti_contracts::*;
+
+pub struct A {
+    b: isize,
+}
+
+impl A {
+    #[pure]
+    #[ensures(result == true)]
+    pub const fn invariant(&self) -> bool {
+        self.is_negative() != self.is_non_negative()
+    }
+
+    #[pure]
+    pub const fn is_non_negative(&self) -> bool {
+        self.b >= 0
+    }
+
+    #[pure]
+    pub const fn is_negative(&self) -> bool {
+        self.b < 0
+    }
+
+    #[requires(self.invariant())]
+    pub const fn test(&self) {}
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-770-3.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-770-3.rs
@@ -1,0 +1,27 @@
+use prusti_contracts::*;
+
+pub struct A {
+    b: isize,
+}
+
+impl A {
+    #[pure]
+    pub const fn invariant(&self) -> bool {
+        self.is_negative() != self.is_non_negative()
+    }
+
+    #[pure]
+    pub const fn is_non_negative(&self) -> bool {
+        self.b >= 0
+    }
+
+    #[pure]
+    pub const fn is_negative(&self) -> bool {
+        self.b < 0
+    }
+
+    #[requires(self.invariant())]
+    pub const fn test(&self) {}
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-770-4.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-770-4.rs
@@ -1,0 +1,28 @@
+use prusti_contracts::*;
+
+pub struct B(isize);
+
+impl B {
+    #[pure]
+    #[ensures(result <= 16)]
+    pub const fn get_non_negative(&self) -> isize {
+        match self.get_saturated() {
+            i if i < 0 => 0,
+            i => i,
+        }
+    }
+
+    #[pure]
+    pub const fn get_saturated(&self) -> isize {
+        match self.0 {
+            isize::MIN..=-17 => -16,
+            17.. => 16,
+            i => i,
+        }
+    }
+
+    #[requires(_i < self.get_non_negative())]
+    pub const fn test(&self, _i: isize) {}
+}
+
+fn main() {}


### PR DESCRIPTION
When a post-condition of a pure function depends on its `result`, then (currently) the definition collector must also directly walk its function body, otherwise Viper will fail to prove any assertions depending on the corresponding Viper function body in the case those (indirectly) depend on other missing function bodies.

This is a temporary fix until Vytautas' refactoring lands.

I also added 3 regression tests.

Closes #770.