### PR TITLE
Fix exists being translated to forall

### DIFF
--- a/prusti-tests/tests/verify/pass/issues/issue-804.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-804.rs
@@ -1,0 +1,13 @@
+use prusti_contracts::*;
+
+#[pure]
+fn fun(i: i32) -> bool { i > 0 }
+
+// It is exceptionally hard to find an example
+// where a Viper `exists` succeeds but a `forall` fails.
+// This seems to do the trick though.
+#[requires(fun(_k))]
+#[ensures(exists(|k:i32| fun(k)))]
+fn test(_k: i32) { }
+
+fn main() { test(1) }

--- a/prusti-tests/tests/verify/ui/forall_verify.stderr
+++ b/prusti-tests/tests/verify/ui/forall_verify.stderr
@@ -11,12 +11,6 @@ note: the error originates here
    | ^^^^^^^^^^^^^
 
 error: [Prusti: verification error] postcondition might not hold.
-  --> $DIR/forall_verify.rs:30:27
-   |
-30 | #[ensures(exists(|x: i32| identity(x) == x + 1))]
-   |                           ^^^^^^^^^^^^^^^^^^^^
-   |
-note: the error originates here
   --> $DIR/forall_verify.rs:31:1
    |
 31 | fn test6() {}

--- a/vir/defs/polymorphic/ast/expr_transformers.rs
+++ b/vir/defs/polymorphic/ast/expr_transformers.rs
@@ -256,7 +256,7 @@ pub trait ExprFolder: Sized {
             body,
             position,
         } = expr;
-        Expr::ForAll(ForAll {
+        Expr::Exists(Exists {
             variables,
             triggers,
             body: self.fold_boxed(body),


### PR DESCRIPTION
Hmmm, well [this](https://github.com/viperproject/prusti-dev/commit/8777f800133f56b27f59ad8cf79c9a1a2d6fb23b) is embarrassing... 😄
Will add test before merging