### PR TITLE
Fixes for issue #721

### DIFF
--- a/prusti-tests/tests/verify/pass/arrays/merge.rs
+++ b/prusti-tests/tests/verify/pass/arrays/merge.rs
@@ -50,10 +50,12 @@ fn merge(a: [i32; 3], b: [i32; 3]) -> [i32; 6] {
         body_invariant!(res_pos > 0 && b_pos < 3 ==> res[res_pos - 1] <= b[b_pos]);
 
         if b_pos == 3 || a_pos < 3 && a[a_pos] <= b[b_pos] {
-            res[res_pos] = a[a_pos];
+            // res[res_pos] = a[a_pos];
+            set_res(&mut res, res_pos, a[a_pos]);
             a_pos += 1;
         } else {
-            res[res_pos] = b[b_pos];
+            // res[res_pos] = b[b_pos];
+            set_res(&mut res, res_pos, b[b_pos]);
             b_pos += 1;
         }
         res_pos += 1;
@@ -62,4 +64,14 @@ fn merge(a: [i32; 3], b: [i32; 3]) -> [i32; 6] {
     assert!(res_pos == res.len());
 
     res
+}
+
+#[requires(res_pos < 6)]
+#[requires(forall(|i: usize, j: usize| (0 <= i && i < j && j < res_pos) ==> res[i] <= res[j]))]
+#[requires(forall(|i: usize| (0 <= i && i < res_pos) ==> res[i] <= value))]
+#[ensures(forall(|i: usize| (0 <= i && i < res_pos) ==> res[i] == old(res[i])))]
+#[ensures(res[res_pos] == value)]
+#[ensures(forall(|i: usize, j: usize| (0 <= i && i < j && j <= res_pos) ==> res[i] <= res[j]))]
+fn set_res(res: &mut [i32; 6], res_pos: usize, value: i32) {
+    res[res_pos] = value
 }

--- a/prusti-tests/tests/verify/pass/arrays/selection_sort.rs
+++ b/prusti-tests/tests/verify/pass/arrays/selection_sort.rs
@@ -44,11 +44,29 @@ fn selection_sort(mut a: [i32; 10]) {
             j += 1;
         }
 
-        let a_i = a[i];
-        let a_min = a[min];
-        a[i] = a_min;
-        a[min] = a_i;
+        // let a_i = a[i];
+        // let a_min = a[min];
+        // a[i] = a_min;
+        // a[min] = a_i;
+        set_a(&mut a, i, min);
 
         i += 1;
     }
+}
+
+#[requires(i < 10)]
+#[requires(min < 10)]
+#[requires(i <= min)]
+#[requires(forall(|k1: usize, k2: usize| (0 <= k1 && k1 < k2 && k2 < i) ==> a[k1] <= a[k2]))]
+#[requires(forall(|k1: usize, k2: usize| (0 <= k1 && k1 < i && i <= k2 && k2 < 10) ==> a[k1] <= a[k2]))]
+#[ensures(forall(|k1: usize| (0 <= k1 && k1 < 10 && k1 != i && k1 != min) ==> (a[k1] == old(a[k1]))))]
+#[ensures(a[i] == old(a[min]))]
+#[ensures(a[min] == old(a[i]))]
+#[ensures(forall(|k1: usize, k2: usize| (0 <= k1 && k1 < k2 && k2 <= i) ==> a[k1] <= a[k2]))]
+#[ensures(forall(|k1: usize, k2: usize| (0 <= k1 && k1 < i && i <= k2 && k2 < 10) ==> a[k1] <= a[k2]))]
+fn set_a(a: &mut [i32; 10], i: usize, min: usize) {
+    let a_i = a[i];
+    let a_min = a[min];
+    a[i] = a_min;
+    a[min] = a_i;
 }

--- a/prusti-tests/tests/verify/pass/issues/issue-721-1.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-721-1.rs
@@ -1,0 +1,41 @@
+//! See https://github.com/viperproject/prusti-dev/issues/721
+use prusti_contracts::*;
+
+pub const MAX_DEPTH: usize = usize::BITS as usize;
+
+pub struct Path {
+    current: usize,
+    depth: usize,
+    entries: [usize; MAX_DEPTH],
+    max_counts: [usize; MAX_DEPTH],
+}
+
+impl Path {
+    #[pure]
+    pub fn invariant(&self) -> bool {
+        self.entries.len() == MAX_DEPTH
+            && self.max_counts.len() == MAX_DEPTH
+            && self.entries.len() == self.max_counts.len()
+            && self.current < MAX_DEPTH
+            && self.depth < MAX_DEPTH
+            && self.current <= self.depth
+    }
+
+    #[requires(self.invariant())]
+    #[ensures(self.current == 0)]
+    #[ensures(self.depth == 0)]
+    #[ensures(self.entries[0] == 0)]
+    #[ensures(self.invariant())]
+    pub fn reset(&mut self) {
+        self.current = 0;
+        self.depth = 0;
+        self.entries[0] = 0;
+        assert!(self.entries.len() == self.max_counts.len());
+        assert!(self.current < MAX_DEPTH);
+        assert!(self.depth < MAX_DEPTH);
+        assert!(self.current <= self.depth);
+        assert!(self.entries[0] == 0);
+    }
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/pass/issues/issue-721-2.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-721-2.rs
@@ -1,0 +1,20 @@
+use prusti_contracts::*;
+use std::convert::TryFrom;
+
+#[trusted]
+#[requires(s.len() == 16)]
+#[ensures(forall(|i: usize| (0 <= i && i < 16) ==> (old(s[i]) == result[i] )))]
+#[ensures(result[0] > 100)]
+pub fn slice_to_array16(s: &[i32]) -> [i32; 16] {
+     <[i32; 16]>::try_from(s).unwrap()
+}
+
+#[requires(forall(|i: usize| (0 <= i && i < 16) ==> (a[i] > 100)))]
+#[requires(a[0] > 100)]
+pub fn foo(a: [i32; 16]) {
+    let s: &[i32] = &a;
+    let a2: [i32; 16] = slice_to_array16(s);
+    assert!(a2[0] > 100);
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/pass/issues/issue-721-3.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-721-3.rs
@@ -1,0 +1,10 @@
+use prusti_contracts::*;
+
+#[requires(forall(|i: usize| (0 <= i && i < 16) ==> (array[i] > 100) ))]
+#[requires(array[4] <= usize::MAX)]
+#[ensures(result[0] > 100)]
+pub fn example(array: &[usize; 16]) -> &[usize] {
+    &array[4..8]
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/pass/issues/issue-721-4.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-721-4.rs
@@ -1,0 +1,5 @@
+fn main() {
+    const SIZE: usize = 1_000_000;
+    let array = [0u8; SIZE];
+    assert!(array.len() == SIZE);
+}

--- a/prusti-tests/tests/verify/pass/issues/issue-721-5.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-721-5.rs
@@ -1,0 +1,28 @@
+use prusti_contracts::*;
+
+const SIZE: usize = 64;
+
+#[trusted]
+#[pure]
+#[requires(index < array.len())]
+#[ensures(result == array[index])]
+const fn get(array: &[isize; SIZE], index: usize) -> isize {
+    unimplemented!()
+}
+
+pub struct A {
+    inner: [isize; SIZE],
+}
+
+impl A {
+    #[pure]
+    pub const fn start(&self) -> isize {
+        get(&self.inner, 0)
+    }
+
+    pub const fn test(&self) -> isize {
+        self.start()
+    }
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/pass/slices/simple-equality.rs
+++ b/prusti-tests/tests/verify/pass/slices/simple-equality.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let a = [0; 3];
+    let b: &[_] = &a;
+    let c: &[_] = &a;
+    
+    assert!(b == c);
+}

--- a/prusti-tests/tests/verify/pass/slices/slice-split.rs
+++ b/prusti-tests/tests/verify/pass/slices/slice-split.rs
@@ -7,6 +7,11 @@ fn main() {
     assert!(s0.len() == 7);
     assert!(s1.len() == 6);
 
+    // these 2 dummy assertions are needed to trigger the quantifiers from split_at().
+    // without it, the next block of assertions won't be verified by Prusti.
+    assert!(a[2] == s0[2]);
+    assert!(a[9] == s1[2]);
+
     assert!(s0[2] == 0);
     assert!(s1[2] == 0);
 }

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -718,6 +718,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             | ty::TyKind::Tuple(_)
             | ty::TyKind::Never
             | ty::TyKind::Array(..)
+            | ty::TyKind::Slice(..)
             | ty::TyKind::Param(_) => true,
             ty::TyKind::Adt(_, _) => {
                 self.env().tcx().has_structural_eq_impls(ty)

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2704,8 +2704,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             )
         };
 
-        // TODO: maybe don't bother with a complicated forall if the array length is less than some
-        // reasonable bound
         // forall i: Int, j: Int :: { lhs_lookup(i), rhs_lookup(j) } 0 <= i && i < slice$len && j == i + start && start <= j && j < end ==> lhs_lookup(i) == rhs_lookup(j)
         stmts.push(vir_stmt!{
             inhale [
@@ -5897,10 +5895,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
         let indices = vir_expr! { ([Expr::from(0)] <= [i]) && ([i] < [Expr::from(array_types.array_len)]) };
 
-        // TODO: maybe don't bother with a complicated forall if the array length is less than some
-        // reasonable bound. This should also consider other quantifiers in existance which may be
-        // explicitly instantiated when emitting trigger expressions not nested under a quantifier.
-        // Note: instantiating too many quantifiers will lead to bad performance.
         stmts.push(vir::Stmt::Inhale( vir::Inhale {
             expr: vir_expr! {
                 forall i: Int ::

--- a/prusti-viper/src/encoder/snapshot/decls.rs
+++ b/prusti-viper/src/encoder/snapshot/decls.rs
@@ -35,6 +35,7 @@ pub(super) enum Snapshot {
         predicate_type: Type,
         _domain: String,
         _snap_func: vir::FunctionIdentifier,
+        _array_collect_func: vir::FunctionIdentifier,
         slice_helper: vir::FunctionIdentifier,
         cons: vir::DomainFunc,
         read: vir::DomainFunc,

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -428,7 +428,17 @@ impl SnapshotEncoder {
                 // the caller must have created a vir::Expr::Seq already
                 assert_eq!(args.len(), 1);
                 assert!(
-                    matches!(args[0], Expr::Seq(..)),
+                    matches!(args[0], Expr::Seq(..))
+                        || matches!(
+                            args[0],
+                            Expr::Local(vir::Local {
+                                variable: vir::LocalVar {
+                                    typ: vir::Type::Seq(..),
+                                    ..
+                                },
+                                ..
+                            })
+                        ),
                     "Seq expected for array snapshot"
                 );
 
@@ -439,7 +449,17 @@ impl SnapshotEncoder {
                 assert_eq!(args.len(), 1);
                 // args[0] is the `Seq` of elements
                 assert!(
-                    matches!(args[0], Expr::Seq(..)),
+                    matches!(args[0], Expr::Seq(..))
+                        || matches!(
+                            args[0],
+                            Expr::Local(vir::Local {
+                                variable: vir::LocalVar {
+                                    typ: vir::Type::Seq(..),
+                                    ..
+                                },
+                                ..
+                            })
+                        ),
                     "Seq expected for slice snapshot"
                 );
 
@@ -789,21 +809,19 @@ impl SnapshotEncoder {
                     domain_name: domain_name.clone(),
                 };
 
-                let snap_body = cons.apply(vec![Expr::Seq(vir::Seq {
-                    typ: seq_type.clone(),
-                    elements: (0..array_types.array_len)
-                        .into_iter()
-                        .map(|idx| {
-                            array_types.encode_lookup_pure_call(
-                                encoder,
-                                arg_expr.clone(),
-                                idx.into(),
-                                elem_snap_ty.clone(),
-                            )
-                        })
-                        .collect(),
-                    position: vir::Position::default(),
-                })]);
+                let array_collect_func = self.encode_seq_collect_func(
+                    array_types.array_pred_type.clone(),
+                    elem_snap_ty.clone(),
+                    Expr::from(array_types.array_len),
+                    |self_expr, idx, elem_snap_ty| {
+                        array_types.encode_lookup_pure_call(encoder, self_expr, idx, elem_snap_ty)
+                    },
+                );
+
+                let array_collect_func_app =
+                    array_collect_func.apply(vec![arg_expr.clone(), 0.into()]);
+
+                let snap_body = cons.apply(vec![array_collect_func_app]);
 
                 let read = vir::DomainFunc {
                     name: format!("read${}$", domain_name),
@@ -951,6 +969,7 @@ impl SnapshotEncoder {
                     predicate_type: predicate_type.convert_to_snapshot(),
                     _domain: self.insert_domain(domain),
                     _snap_func: self.insert_function(snap_func),
+                    _array_collect_func: self.insert_function(array_collect_func),
                     slice_helper: self.insert_function(slice_helper),
                     cons,
                     read,
@@ -993,135 +1012,20 @@ impl SnapshotEncoder {
                     domain_name: domain_name.clone(),
                 };
 
-                let slice_collect_funcname =
-                    format!("slice_collect${}$", slice_types.slice_pred_type.name());
-
-                let start = vir_local! { start: Int };
-                let start_expr: Expr = start.clone().into();
-                let result_expr: Expr = vir_local! { __result: {seq_type.clone()} }.into();
-                let i = vir_local! { i: Int };
-                let i_expr: Expr = i.clone().into();
-                let j = vir_local! { j: Int };
-                let j_expr: Expr = j.clone().into();
-
-                let slice_len_call = slice_types.encode_slice_len_call(encoder, arg_expr.clone());
-                let empty_seq = Expr::Seq(vir::Seq {
-                    typ: seq_type.clone(),
-                    elements: vec![],
-                    position: vir::Position::default(),
-                });
-                let start_lt_len = vir_expr! { [start_expr] < [slice_len_call] };
-                let result_len = Expr::ContainerOp(vir::ContainerOp {
-                    op_kind: ContainerOpKind::SeqLen,
-                    left: box result_expr.clone(),
-                    right: box Expr::from(0),
-                    position: vir::Position::default(),
-                });
-                let result_0 = Expr::ContainerOp(vir::ContainerOp {
-                    op_kind: ContainerOpKind::SeqIndex,
-                    left: box result_expr.clone(),
-                    right: box Expr::from(0),
-                    position: vir::Position::default(),
-                });
-                let result_j = Expr::ContainerOp(vir::ContainerOp {
-                    op_kind: ContainerOpKind::SeqIndex,
-                    left: box result_expr.clone(),
-                    right: box j_expr.clone(),
-                    position: vir::Position::default(),
-                });
-                let slice_lookup_i = slice_types.encode_lookup_pure_call(
-                    encoder,
-                    arg_expr.clone(),
-                    i_expr.clone(),
+                let slice_len = slice_types.encode_slice_len_call(encoder, arg_expr.clone());
+                let slice_collect_func = self.encode_seq_collect_func(
+                    slice_types.slice_pred_type.clone(),
                     elem_snap_ty.clone(),
+                    slice_len.clone(),
+                    |self_expr, idx, elem_snap_ty| {
+                        slice_types.encode_lookup_pure_call(encoder, self_expr, idx, elem_snap_ty)
+                    },
                 );
-                let slice_lookup_start = slice_types.encode_lookup_pure_call(
-                    encoder,
-                    arg_expr.clone(),
-                    start_expr.clone(),
-                    elem_snap_ty.clone(),
-                );
-
-                // forall i: Int, j: Int :: { slice$lookup_pure(slice, i), result[j] } idx <= i && i < slice$len(slice) && 0 <= j && j < slice$len(slice)-idx && i == j + idx ==> slice$lookup_pure(slice, i) == result[j]
-                let rest_eq_lookup = {
-                    let indices = vir_expr! { (([start_expr] <= [i_expr]) && ([i_expr] < [slice_len_call]))
-                    && ((([Expr::from(0)] <= [j_expr]) && ([j_expr] < ([slice_len_call] - [start_expr])))
-                    && ([i_expr] == ([j_expr] + [start_expr]))) };
-
-                    Expr::forall(
-                        vec![i, j],
-                        vec![vir::Trigger::new(vec![
-                            slice_lookup_i.clone(),
-                            result_j.clone(),
-                        ])],
-                        vir_expr! { [indices] ==> ([slice_lookup_i] == [result_j]) },
-                    )
-                };
-
-                let slice_collect_func = vir::Function {
-                    name: slice_collect_funcname.clone(),
-                    formal_args: vec![
-                        vir_local! { self: {slice_types.slice_pred_type.clone()} },
-                        start.clone(),
-                    ],
-                    return_type: seq_type.clone(),
-                    pres: vec![
-                        Expr::predicate_access_predicate(
-                            slice_types.slice_pred_type.clone(),
-                            arg_expr.clone(),
-                            PermAmount::Read,
-                        ),
-                        vir_expr! { [Expr::from(0)] <= [start_expr] },
-                    ],
-                    posts: vec![
-                        vir_expr! { ([start_expr] >= [slice_len_call]) ==> ([result_expr] == [empty_seq]) },
-                        vir_expr! { [start_lt_len] ==> ([result_len] == ([slice_len_call] - [start_expr])) },
-                        vir_expr! { [start_lt_len] ==> ([result_0] == [slice_lookup_start]) },
-                        vir_expr! { [start_lt_len] ==> [rest_eq_lookup] },
-                    ],
-                    body: Some(Expr::ite(
-                        vir_expr! { [start_expr] >= [slice_len_call] },
-                        Expr::Seq(vir::Seq {
-                            typ: seq_type.clone(),
-                            elements: vec![],
-                            position: vir::Position::default(),
-                        }),
-                        Expr::ContainerOp(vir::ContainerOp {
-                            op_kind: ContainerOpKind::SeqConcat,
-                            left: box Expr::Seq(vir::Seq {
-                                typ: seq_type.clone(),
-                                elements: vec![slice_types.encode_lookup_pure_call(
-                                    encoder,
-                                    arg_expr.clone(),
-                                    start_expr.clone(),
-                                    elem_snap_ty.clone(),
-                                )],
-                                position: vir::Position::default(),
-                            }),
-                            right: box Expr::func_app(
-                                slice_collect_funcname,
-                                vec![
-                                    arg_expr.clone(),
-                                    vir_expr! { [start_expr] + [Expr::from(1)] },
-                                ],
-                                vec![
-                                    vir_local! { slice: {slice_types.slice_pred_type.clone()} },
-                                    start,
-                                ],
-                                seq_type.clone(),
-                                vir::Position::default(),
-                            ),
-                            position: vir::Position::default(),
-                        }),
-                    )),
-                };
 
                 let slice_collect_func_app =
                     slice_collect_func.apply(vec![arg_expr.clone(), 0.into()]);
 
                 let snap_body = cons.apply(vec![slice_collect_func_app]);
-
-                let slice_len = slice_types.encode_slice_len_call(encoder, arg_expr.clone());
 
                 let result_expr: Expr = vir_local! { __result: {slice_snap_ty.clone()} }.into();
 
@@ -1302,6 +1206,129 @@ impl SnapshotEncoder {
 
             // Param(_) and unsupported types
             _ => self.encode_abstract(predicate_type),
+        }
+    }
+
+    /// Originally called the "slice_collect" function from Johannes' thesis,
+    /// this method now encodes this function for both arrays and slices
+    /// for code re-use purposes.
+    fn encode_seq_collect_func(
+        &self,
+        // Whether we're dealing with a slice or an array
+        seq_pred_ty: Type,
+        // The snapshot type of the element in the sequence
+        elem_snap_ty: Type,
+        // The length of a sequence (a function call for a slice, a number for an array)
+        seq_len: Expr,
+        // Arguments are: snap sequence (array or slice), index, snap element return type
+        lookup_pure: impl Fn(Expr, Expr, Type) -> Expr,
+    ) -> vir::Function {
+        assert!(matches!(seq_pred_ty, Type::TypedRef(..)));
+        assert!(matches!(seq_len, Expr::FuncApp(..) | Expr::Const(..)));
+        let seq_collect_funcname = format!("seq_collect${}$", seq_pred_ty.name());
+
+        let self_expr: Expr = vir_local! { self: {seq_pred_ty.clone()} }.into();
+        let seq_type = Type::Seq(vir::SeqType {
+            typ: box elem_snap_ty.clone(),
+        });
+        let start = vir_local! { start: Int };
+        let start_expr: Expr = start.clone().into();
+        let result_expr: Expr = vir_local! { __result: {seq_type.clone()} }.into();
+        let i = vir_local! { i: Int };
+        let i_expr: Expr = i.clone().into();
+        let j = vir_local! { j: Int };
+        let j_expr: Expr = j.clone().into();
+
+        let empty_seq = Expr::Seq(vir::Seq {
+            typ: seq_type.clone(),
+            elements: vec![],
+            position: vir::Position::default(),
+        });
+        let start_lt_len = vir_expr! { [start_expr] < [seq_len] };
+        let result_len = Expr::ContainerOp(vir::ContainerOp {
+            op_kind: ContainerOpKind::SeqLen,
+            left: box result_expr.clone(),
+            right: box Expr::from(0),
+            position: vir::Position::default(),
+        });
+        let result_0 = Expr::ContainerOp(vir::ContainerOp {
+            op_kind: ContainerOpKind::SeqIndex,
+            left: box result_expr.clone(),
+            right: box Expr::from(0),
+            position: vir::Position::default(),
+        });
+        let result_j = Expr::ContainerOp(vir::ContainerOp {
+            op_kind: ContainerOpKind::SeqIndex,
+            left: box result_expr.clone(),
+            right: box j_expr.clone(),
+            position: vir::Position::default(),
+        });
+        let slice_lookup_i = lookup_pure(self_expr.clone(), i_expr.clone(), elem_snap_ty.clone());
+        let slice_lookup_start =
+            lookup_pure(self_expr.clone(), start_expr.clone(), elem_snap_ty.clone());
+
+        // forall i: Int, j: Int :: { slice$lookup_pure(slice, i), result[j] } idx <= i && i < slice$len(slice) && 0 <= j && j < slice$len(slice)-idx && i == j + idx ==> slice$lookup_pure(slice, i) == result[j]
+        let rest_eq_lookup = {
+            let indices = vir_expr! { (([start_expr] <= [i_expr]) && ([i_expr] < [seq_len]))
+            && ((([Expr::from(0)] <= [j_expr]) && ([j_expr] < ([seq_len] - [start_expr])))
+            && ([i_expr] == ([j_expr] + [start_expr]))) };
+
+            Expr::forall(
+                vec![i, j],
+                vec![vir::Trigger::new(vec![
+                    slice_lookup_i.clone(),
+                    result_j.clone(),
+                ])],
+                vir_expr! { [indices] ==> ([slice_lookup_i] == [result_j]) },
+            )
+        };
+
+        vir::Function {
+            name: seq_collect_funcname.clone(),
+            formal_args: vec![vir_local! { self: {seq_pred_ty.clone()} }, start.clone()],
+            return_type: seq_type.clone(),
+            pres: vec![
+                Expr::predicate_access_predicate(
+                    seq_pred_ty.clone(),
+                    self_expr.clone(),
+                    PermAmount::Read,
+                ),
+                vir_expr! { [Expr::from(0)] <= [start_expr] },
+            ],
+            posts: vec![
+                vir_expr! { ([start_expr] >= [seq_len]) ==> ([result_expr] == [empty_seq]) },
+                vir_expr! { [start_lt_len] ==> ([result_len] == ([seq_len] - [start_expr])) },
+                vir_expr! { [start_lt_len] ==> ([result_0] == [slice_lookup_start]) },
+                vir_expr! { [start_lt_len] ==> [rest_eq_lookup] },
+            ],
+            body: Some(Expr::ite(
+                vir_expr! { [start_expr] >= [seq_len] },
+                Expr::Seq(vir::Seq {
+                    typ: seq_type.clone(),
+                    elements: vec![],
+                    position: vir::Position::default(),
+                }),
+                Expr::ContainerOp(vir::ContainerOp {
+                    op_kind: ContainerOpKind::SeqConcat,
+                    left: box Expr::Seq(vir::Seq {
+                        typ: seq_type.clone(),
+                        elements: vec![lookup_pure(
+                            self_expr.clone(),
+                            start_expr.clone(),
+                            elem_snap_ty,
+                        )],
+                        position: vir::Position::default(),
+                    }),
+                    right: box Expr::func_app(
+                        seq_collect_funcname,
+                        vec![self_expr, vir_expr! { [start_expr] + [Expr::from(1)] }],
+                        vec![vir_local! { slice: {seq_pred_ty} }, start],
+                        seq_type,
+                        vir::Position::default(),
+                    ),
+                    position: vir::Position::default(),
+                }),
+            )),
         }
     }
 


### PR DESCRIPTION
This PR got a little bigger than I anticipated, so here is a little explanation of what was changed and tested and why :)

I set out to implement [this idea](https://github.com/viperproject/prusti-dev/issues/721#issuecomment-997446669) from #721 in Prusti, but had to slightly deviate from the initial plan regarding the `Snap$Array` domain:

```
domain Snap$Array$64$usize {

  function cast$Snap$Array$64$usize$__$TY$__Snap$Slice$usize(array: Snap$Array$64$usize): Snap$Slice$usize
  
  // ...

  axiom Snap$Array$64$usize$unsize {
    (forall data: Seq[Int] ::
      { cast$Snap$Array$64$usize$__$TY$__Snap$Slice$usize(cons$Snap$Array$64$usize$__$TY$__Seq$$int$$Snap$Array$64$usize(data)) }
      cast$Snap$Array$64$usize$__$TY$__Snap$Slice$usize(cons$Snap$Array$64$usize$__$TY$__Seq$$int$$Snap$Array$64$usize(data)) == cons$Snap$Slice$usize$__$TY$__Seq$$int$$Snap$Slice$usize(data)
    )
  }
}
```

Shortly after working on it I realized that this would create a dependency on `Snap$Slice`, but there is no guarantee a program contains the slice type, so in some corner cases this could lead to a consistency error. Another problem I ran into is that when we're building the `Snap$Array` domain, we don't have access to a slice type (i.e. a `rustc_middle::ty::Ty`). There exists [`mk_slice`](https://doc.rust-lang.org/stable/nightly-rustc/rustc_middle/ty/context/struct.TyCtxt.html#method.mk_slice) that could help out here, but instead I chose to use an abstract function instead which is automatically generated when unsizing an array (where both the array and slice types are readily available):

```
function builtin$unsize$Array$64$usize$Slice$usize__$TY$__Snap$Array$64$usize$Snap$Slice$usize(array: Snap$Array$64$usize): Snap$Slice$usize
  ensures (exists data: Seq[Int] ::
		array == cons$Snap$Array$64$usize$__$TY$__Seq$$int$$Snap$Array$64$usize(data)
		&& result == cons$Snap$Slice$usize$__$TY$__Seq$$int$$Snap$Slice$usize(data)
  )
```

Using this abstract function instead of an axiom had a another benefit, namely that I was able to use one quantifier less in snapshot encoding of an array (note that the `ensures [exists data: Seq[Int] :: result == cons$Snap$Array$64$usize$__$TY$__Seq$$int$$Snap$Array$64$usize(data) && |data| == 64, true]` post-condition is intentionally left out on `function snap$__$TY$__Array$64$usize$Snap$Array$64$usize()`, this works okay):

```
function seq_collect$Array$64$usize$__$TY$__Array$64$usize$$int$$Seq$$int$(self: Ref, start: Int): Seq[Int]
  requires acc(Array$64$usize(self), read$())
  requires 0 <= start
  ensures start >= 64 ==> result == Seq[Int]()
  ensures start < 64 ==> |result| == 64 - start
  ensures start < 64 ==> result[0] == lookup_pure__$TY$__Array$64$usize$$int$$$int$(self, start)
  ensures start < 64 ==> (forall i: Int, j: Int :: { lookup_pure__$TY$__Array$64$usize$$int$$$int$(self, i),result[j] } start <= i && i < 64 && (0 <= j && j < 64 - start && i == j + start) ==> lookup_pure__$TY$__Array$64$usize$$int$$$int$(self, i) == result[j])
{
  (start >= 64 ? Seq[Int]() : Seq(lookup_pure__$TY$__Array$64$usize$$int$$$int$(self, start)) ++ seq_collect$Array$64$usize$__$TY$__Array$64$usize$$int$$Seq$$int$(self, start + 1))
}

function snap$__$TY$__Array$64$usize$Snap$Array$64$usize(self: Ref): Snap$Array$64$usize
  requires acc(Array$64$usize(self), read$())
  ensures (forall i: Int :: { read$Snap$Array$64$usize$__$TY$__Snap$Array$64$usize$$int$$$int$(result, i) } { lookup_pure__$TY$__Array$64$usize$$int$$$int$(self, i) } 0 <= i && i < 64 ==> read$Snap$Array$64$usize$__$TY$__Snap$Array$64$usize$$int$$$int$(result, i) == lookup_pure__$TY$__Array$64$usize$$int$$$int$(self, i))
{
  cons$Snap$Array$64$usize$__$TY$__Seq$$int$$Snap$Array$64$usize(seq_collect$Array$64$usize$__$TY$__Array$64$usize$$int$$Seq$$int$(self, 0))
}
```

The `seq_collect` function is based on Johannes' `slice_collect` function, but slightly renamed in order to benefit from the code re-use between arrays and slices (through `SnapshotEncoder::encode_seq_collect_func()`).

After using a single quantifier for all array operations (instantiate, construct, cast) the example program from #721 was passing verification, but there were 4 regressions in the test suite. The most interesting case was `prusti-tests/tests/verify/pass/arrays/simple-equality.rs`:

```rust
fn main() {
    let a = [0; 3];
    let b = [0, 0, 0];

    assert!(a == b);
}
```

Now that Prusti no longer triggered all the quantifiers for arrays upon its first use, this test case was failing. The reason for this was as surprising as interesting, to understand it better I'll have to back-up my explanation with footnote 6 on page 15 of Johannes' thesis: "*In practice the injectivity axiom seems sufficient, so an axiom for surjectivity, encoding that all values of type Snap$T must correspond to an application of the cons function, is currently not generated.*". My theory is that the surjectivity axiom was not required at the time, because all array quantifiers were fully instantiated for all elements everywhere. Z3 was then able to infer the surjectivity of array constructors somehow. But now that the cascade of quantifier instantiations was stopped, this no longer worked. So, I implemented the surjectivity axiom for both arrays and slices and added a `simple-equality` test case for slices, too (this one was missing still, I had to make one additional fix in `prusti-viper/src/encoder/encoder.rs` to make it pass for slices as well).

The 3 other test cases were all failing for the same reason: these no longer could benefit from the information made available by the many inhale statements (now replaced by a single quantifier) and the program was not complete enough to trigger to right quantifiers. I added extra [dummy statements](https://github.com/viperproject/prusti-dev/issues/721#issuecomment-992472952) to help the test cases pass, without changing the intended functionality:

* `prusti-tests/tests/verify/pass/arrays/merge.rs`
* `prusti-tests/tests/verify/pass/arrays/selection_sort.rs`
* `prusti-tests/tests/verify/pass/slices/slice-split.rs`

Last but not least, I also added the example programs that came up during the in discussions in #721 as additional regression tests.

I also gave some thought to the question whether we should create multiple inhale statements instead of a single quantifier for small array lengths ([relevant comment](https://github.com/viperproject/prusti-dev/issues/721#issuecomment-948495663)). I think we should always use quantifiers instead of multiple statements for the following reasons:

* Encoding individual inhales for every element will trigger a lot of quantifiers, which may not be needed for every program, leading to performance loss instead of performance gain.
* If we would not use quantifiers for small array lengths, this could lead to different verification results for different array sizes, as witnessed in the `prusti-tests/tests/verify/pass/arrays/simple-equality.rs` test case. There may exist other corner cases as well. This would not be not a good user experience.

Finally, I also removed one FIXME here:

https://github.com/viperproject/prusti-dev/blob/69325d35ec51a45118ec93ed4e46957e1d08f903/prusti-viper/src/encoder/snapshot/encoder.rs#L846-L857

Now that the performance problem with large arrays is adressed, this FIXME was resolved.

That about summarizes all the changes and tests. Thanks for all the tips, examples and pointers so far, it has been a great help in attempting this! All feedback is very much welcome :-)

Closes #721.