### PR TITLE
Make vir_low fully monomorphic.

### DIFF
--- a/vir/src/converter/polymorphic_to_legacy.rs
+++ b/vir/src/converter/polymorphic_to_legacy.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, fmt};
 
+use crate::polymorphic::WithIdentifier;
+
 use super::super::{legacy, polymorphic};
 use uuid::Uuid;
 
@@ -130,7 +132,7 @@ impl From<polymorphic::Domain> for legacy::Domain {
 impl From<polymorphic::DomainFunc> for legacy::DomainFunc {
     fn from(domain_func: polymorphic::DomainFunc) -> legacy::DomainFunc {
         legacy::DomainFunc {
-            name: domain_func.name,
+            name: domain_func.get_identifier(),
             formal_args: domain_func
                 .formal_args
                 .into_iter()
@@ -402,7 +404,7 @@ impl From<polymorphic::Const> for legacy::Const {
 impl From<polymorphic::Function> for legacy::Function {
     fn from(function: polymorphic::Function) -> legacy::Function {
         legacy::Function {
-            name: function.name,
+            name: function.get_identifier(),
             formal_args: function
                 .formal_args
                 .into_iter()

--- a/vir/src/legacy/ast/domain.rs
+++ b/vir/src/legacy/ast/domain.rs
@@ -84,7 +84,8 @@ impl fmt::Display for DomainFunc {
 
 impl WithIdentifier for DomainFunc {
     fn get_identifier(&self) -> String {
-        compute_identifier(&self.name, &self.formal_args, &self.return_type)
+        // The functions in `low` should be already monomorphised.
+        self.name.clone()
     }
 }
 

--- a/vir/src/legacy/ast/function.rs
+++ b/vir/src/legacy/ast/function.rs
@@ -113,7 +113,8 @@ pub fn compute_identifier(name: &str, formal_args: &[LocalVar], return_type: &Ty
 
 impl WithIdentifier for Function {
     fn get_identifier(&self) -> String {
-        compute_identifier(&self.name, &self.formal_args, &self.return_type)
+        // The functions in `low` should be already monomorphised.
+        self.name.clone()
     }
 }
 


### PR DESCRIPTION
This PR makes `vir_low` (`legacy`) assume that function names are unique. Before we had `vir_poly`, function names were mixed with argument and return type to ensure the uniqueness of the function names. Now that responsibility is moved to `vir_poly`.