### PR TITLE
Fix for first example of issue #815, plus regression test case

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-815-1.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-815-1.rs
@@ -1,0 +1,23 @@
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+pub struct A {
+    inner: isize,
+}
+
+impl A {
+    #[pure]
+    #[requires(num < isize::MAX as usize)]
+    pub fn new(num: usize) -> Self {
+        Self {
+            inner: num as isize + isize::MIN,
+        }
+    }
+
+    #[pure]
+    pub fn test(&self) {
+        let _ = Self::new(2);
+    }
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -1046,22 +1046,16 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                         let value_field = self.encoder
                             .encode_raw_ref_field("tuple_0".to_string(), field_types[0].expect_ty())
                             .with_span(span)?;
-                        let value_field_value = self.encoder
-                            .encode_value_field(field_types[0].expect_ty()).with_span(span)?;
                         let check_field = self.encoder
                             .encode_raw_ref_field("tuple_1".to_string(), field_types[1].expect_ty())
                             .with_span(span)?;
-                        let check_field_value = self.encoder
-                            .encode_value_field(field_types[1].expect_ty()).with_span(span)?;
 
                         let lhs_value = encoded_lhs
                             .clone()
-                            .field(value_field)
-                            .field(value_field_value);
+                            .field(value_field);
                         let lhs_check = encoded_lhs
                             .clone()
-                            .field(check_field)
-                            .field(check_field_value);
+                            .field(check_field);
 
                         // Substitute a place of a value with an expression
                         state.substitute_value(&lhs_value, encoded_value);


### PR DESCRIPTION
The `PureFunctionBackwardInterpreter` contained a bug during the `CheckedBinaryOp` case:

https://github.com/viperproject/prusti-dev/blob/e9edf18d1c6fa99cb4eaac1180d67e3837a661c1/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs#L983-L994

Here accessing the `value_field_value`/`check_field_value` of the respective fields is not necessary and this is causing the substitution to fail. The "new" encoder already seems to handle this correctly:

https://github.com/viperproject/prusti-dev/blob/9a30632bec36724fbef5e0d82526acfce15991dd/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs#L213-L222

And now `PureFunctionBackwardInterpreter` does, too :)

I also added a regression test for good measure. This PR does not close the related issue just yet, but already fixes one of the two known cases.