### PR TITLE
Remove unused imports.

### DIFF
--- a/prusti-interface/src/environment/borrowck/facts.rs
+++ b/prusti-interface/src/environment/borrowck/facts.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::panic::Location;
+
 
 use polonius_engine::FactTypes;
 use rustc_borrowck::consumers::{RustcFacts, LocationTable, RichLocation};

--- a/prusti-interface/src/environment/borrowck/regions.rs
+++ b/prusti-interface/src/environment/borrowck/regions.rs
@@ -4,24 +4,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///! Code for finding `rustc::ty::sty::RegionVid` associated with local
-///! reference typed variables.
-
-use rustc_borrowck::BodyWithBorrowckFacts;
-
 use std::collections::HashMap;
-use std::fs::File;
 use std::io;
-use std::io::BufRead;
-use std::path::Path;
-
 use log::debug;
 use log::trace;
-use regex::Regex;
-
-use rustc_index::vec::Idx;
 use rustc_middle::{mir, ty};
-
 use crate::environment::borrowck::facts;
 
 #[derive(Debug)]

--- a/prusti-interface/src/environment/collect_closure_defs_visitor.rs
+++ b/prusti-interface/src/environment/collect_closure_defs_visitor.rs
@@ -1,11 +1,11 @@
-use rustc_hir::intravisit::{Visitor, NestedVisitorMap, ErasedMap, walk_expr, FnKind};
+use rustc_hir::intravisit::{Visitor, NestedVisitorMap, walk_expr};
 use rustc_hir as hir;
 use rustc_middle::hir::map::Map;
 use crate::environment::Environment;
-use log::{trace, debug};
+use log::{trace};
 use rustc_hir::def_id::DefId;
-use rustc_span::Span;
-use rustc_middle::ty::TypeckResults;
+
+
 use crate::utils::has_spec_only_attr;
 
 pub struct CollectClosureDefsVisitor<'env, 'tcx: 'env> {

--- a/prusti-interface/src/environment/collect_prusti_spec_visitor.rs
+++ b/prusti-interface/src/environment/collect_prusti_spec_visitor.rs
@@ -4,16 +4,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use prusti_common::config;
+
 use crate::environment::Environment;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
 use rustc_middle::ty::TyCtxt;
-use std::collections::HashSet;
-use std::iter::FromIterator;
-use log::{trace, debug};
-use rustc_ast::ast;
+
+
+use log::{trace};
+
 use crate::utils::{has_spec_only_attr, has_extern_spec_attr};
 
 pub struct CollectPrustiSpecVisitor<'a, 'tcx: 'a> {

--- a/prusti-interface/src/environment/dump_borrowck_info.rs
+++ b/prusti-interface/src/environment/dump_borrowck_info.rs
@@ -5,29 +5,27 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::Environment;
-use super::borrowck::facts;
-use super::loops;
-use super::loops_utils::*;
-use super::mir_analyses::initialization::{
-    compute_definitely_initialized, DefinitelyInitializedAnalysisResult,
-};
-use super::polonius_info::PoloniusInfo;
-use super::procedure::Procedure;
+
+
+
+
+
+
 use crate::data::ProcedureDefId;
-use rustc_hir as hir;
-use rustc_middle::mir;
-use rustc_middle::ty::{self, TyCtxt};
-use rustc_index::vec::Idx;
-use rustc_hash::FxHashMap;
-use std::cell;
-use std::collections::{BTreeMap, BTreeSet, HashSet, HashMap};
-use std::env;
-use std::fs::File;
-use std::io::{self, BufWriter, Write};
-use std::path::PathBuf;
-use log::{trace, debug};
-use prusti_common::config;
-use crate::environment::mir_utils::RealEdges;
+
+
+
+
+
+
+
+
+
+
+
+use log::{trace};
+
+
 
 pub fn dump_borrowck_info(env: &Environment<'_>, procedures: &[ProcedureDefId]) {
     trace!("[dump_borrowck_info] enter");

--- a/prusti-interface/src/environment/loops_utils.rs
+++ b/prusti-interface/src/environment/loops_utils.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use super::borrowck::facts;
+
 use super::place_set::PlaceSet;
 use crate::utils;
 use rustc_middle::{mir, ty::TyCtxt};

--- a/prusti-interface/src/environment/mir_analyses/initialization.rs
+++ b/prusti-interface/src/environment/mir_analyses/initialization.rs
@@ -18,16 +18,10 @@
 
 use crate::environment::place_set::PlaceSet;
 use analysis::{domains::DefinitelyInitializedAnalysis};
-use csv::{ReaderBuilder, WriterBuilder};
-use log::trace;
 use prusti_common::Stopwatch;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_index::vec::Idx;
 use rustc_middle::{mir, ty::TyCtxt};
-use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::Path};
 use analysis::abstract_interpretation::{FixpointEngine, AbstractState};
 
 pub struct AnalysisResult<T> {

--- a/prusti-interface/src/environment/mir_dump/graphviz/mod.rs
+++ b/prusti-interface/src/environment/mir_dump/graphviz/mod.rs
@@ -1,8 +1,3 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    io::Write,
-};
-
 mod builders;
 mod graph;
 mod to_row;

--- a/prusti-interface/src/environment/mir_dump/lifetimes.rs
+++ b/prusti-interface/src/environment/mir_dump/lifetimes.rs
@@ -1,12 +1,9 @@
 use crate::environment::{
-    borrowck::facts::{
-        AllInputFacts, AllOutputFacts, BorrowckFacts, Loan, Point, PointIndex, Region,
-    },
+    borrowck::facts::{AllInputFacts, AllOutputFacts, BorrowckFacts, Loan, PointIndex, Region},
     mir_dump::graphviz::{loan_to_text, to_sorted_text},
-    Environment,
 };
 use rustc_borrowck::consumers::{LocationTable, RichLocation};
-use rustc_span::def_id::DefId;
+
 use std::{
     cell::Ref,
     collections::{BTreeMap, BTreeSet},

--- a/prusti-interface/src/environment/mir_dump/mod.rs
+++ b/prusti-interface/src/environment/mir_dump/mod.rs
@@ -1,8 +1,6 @@
 use super::Environment;
-use crate::environment::mir_dump::graphviz::Graph;
-use prusti_common::config;
+
 use rustc_span::def_id::DefId;
-use std::path::PathBuf;
 
 mod graphviz;
 pub mod lifetimes;

--- a/prusti-interface/src/environment/mir_utils/real_edges.rs
+++ b/prusti-interface/src/environment/mir_utils/real_edges.rs
@@ -5,10 +5,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use rustc_middle::mir::{self, TerminatorKind};
-use rustc_middle::ty;
+
 use rustc_index::vec::IndexVec;
-use std::collections::{HashSet, HashMap};
-use log::{trace, debug};
+
+
 
 /// A data structure to store the non-virtual CFG edges of a MIR body.
 pub struct RealEdges {

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -6,19 +6,19 @@
 
 //! This module defines the interface provided to a verifier.
 
-use rustc_ast::ast;
-use rustc_hir as hir;
+
+
 use rustc_middle::mir;
 use rustc_hir::hir_id::HirId;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_middle::ty::{self, TyCtxt, ParamEnv, WithOptConstParam};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_trait_selection::infer::{TyCtxtInferExt, InferCtxtExt};
 use std::path::PathBuf;
-use std::cell::Ref;
+
 use rustc_span::{Span, MultiSpan, symbol::Symbol};
 use std::collections::HashSet;
-use log::{debug, warn, trace};
+use log::{debug, trace};
 use std::rc::Rc;
 use std::collections::HashMap;
 use std::cell::RefCell;

--- a/prusti-interface/src/environment/place_set.rs
+++ b/prusti-interface/src/environment/place_set.rs
@@ -7,7 +7,7 @@
 use crate::utils::{self, is_prefix};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_middle::{mir, ty::TyCtxt};
-use std::mem;
+
 
 /// A set of MIR places.
 ///

--- a/prusti-interface/src/environment/polonius_info.rs
+++ b/prusti-interface/src/environment/polonius_info.rs
@@ -8,21 +8,16 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::fmt;
-use std::path::PathBuf;
-
 use datafrog;
 use log::debug;
 use log::trace;
 use polonius_engine::Algorithm;
-use polonius_engine::Atom;
 use polonius_engine::Output;
 use rustc_index::vec::Idx;
 use rustc_middle::mir;
 use rustc_middle::ty;
-use rustc_span::def_id::{DefId, LOCAL_CRATE};
+use rustc_span::def_id::{DefId};
 use rustc_span::Span;
-use rustc_index::vec::IndexVec;
-
 use crate::environment::borrowck::facts::PointType;
 use crate::environment::borrowck::regions::{PlaceRegions, PlaceRegionsError};
 use crate::environment::mir_utils::AllPlaces;
@@ -31,12 +26,9 @@ use crate::environment::mir_utils::StatementAsAssign;
 use crate::environment::mir_utils::StatementAt;
 use crate::environment::polonius_info::facts::AllInputFacts;
 use crate::utils;
-
 use super::borrowck::facts;
 use super::borrowck::regions;
 use super::loops;
-use super::mir_analyses::initialization::compute_definitely_initialized;
-use super::mir_analyses::initialization::DefinitelyInitializedAnalysisResult;
 use super::procedure::Procedure;
 use super::Environment;
 use prusti_common::config;

--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -7,16 +7,16 @@
 use super::loops;
 use crate::data::ProcedureDefId;
 use rustc_middle::mir::{self, Body as Mir, Rvalue, AggregateKind};
-use rustc_middle::mir::{BasicBlock, BasicBlockData, Terminator, TerminatorKind};
-use rustc_middle::ty::{self, Ty, TyCtxt};
-use std::cell::Ref;
+use rustc_middle::mir::{BasicBlock, BasicBlockData};
+use rustc_middle::ty::{Ty, TyCtxt};
+
 use std::rc::Rc;
 use std::collections::{HashSet, HashMap};
 use rustc_span::Span;
 use log::{trace, debug};
 use rustc_middle::mir::StatementKind;
 use rustc_hir::def_id;
-use std::iter::FromIterator;
+
 use crate::environment::mir_utils::RealEdges;
 use crate::environment::Environment;
 

--- a/prusti-interface/src/lib.rs
+++ b/prusti-interface/src/lib.rs
@@ -6,14 +6,9 @@
 
 //! Prusti Interface is an interface between Prusti and Prusti-Viper.
 
-#![allow(unused_imports)]
 #![deny(unused_must_use)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
-// #![deny(unused_imports)]
-// #![deny(unused_mut)]
-// #![deny(non_upper_case_globals)]
-// #![allow(missing_docs)]
 #![feature(rustc_private)]
 #![feature(box_syntax)]
 #![feature(box_patterns)]
@@ -37,7 +32,6 @@ extern crate rustc_trait_selection;
 extern crate polonius_engine;
 extern crate rustc_mir_dataflow;
 extern crate rustc_errors;
-#[macro_use]
 extern crate lazy_static;
 
 pub mod data;

--- a/prusti-interface/src/specs/checker.rs
+++ b/prusti-interface/src/specs/checker.rs
@@ -1,9 +1,8 @@
-use log::{debug, info};
+use log::{debug};
 use rustc_hir::{
     self as hir,
-    def_id::{DefId, LocalDefId},
+    def_id::{DefId},
     intravisit::{self, Visitor},
-    itemlikevisit::ItemLikeVisitor,
 };
 use rustc_middle::{hir::map::Map, ty::TyCtxt};
 use rustc_span::{MultiSpan, Span};

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -1,16 +1,16 @@
 use rustc_ast::ast;
-use rustc_hir::{intravisit, ItemKind};
+use rustc_hir::{intravisit};
 use rustc_middle::hir::map::Map;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, MultiSpan};
-use rustc_span::symbol::Symbol;
+
 use rustc_hir::def_id::{DefId, LocalDefId};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use crate::environment::Environment;
 use crate::PrustiError;
 use crate::utils::{
-    has_spec_only_attr, has_extern_spec_attr, read_prusti_attr, read_prusti_attrs, has_prusti_attr
+    has_extern_spec_attr, read_prusti_attr, read_prusti_attrs, has_prusti_attr
 };
 use log::debug;
 
@@ -19,7 +19,7 @@ pub mod typed;
 pub mod checker;
 
 use typed::SpecIdRef;
-use std::fmt;
+
 use crate::specs::external::ExternSpecResolver;
 use prusti_specs::specifications::common::SpecificationId;
 

--- a/prusti-interface/src/specs/typed.rs
+++ b/prusti-interface/src/specs/typed.rs
@@ -1,13 +1,13 @@
 use prusti_specs::specifications::common;
-use rustc_hir::BodyId;
+
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_middle::{mir, ty::{self, TyCtxt}};
-use rustc_span::Span;
+
+
 use std::collections::HashMap;
 
 pub use common::{SpecType, SpecificationId, SpecIdRef};
-use crate::data::ProcedureDefId;
-use crate::environment::Environment;
+
+
 
 #[derive(Debug, Clone)]
 pub enum SpecificationSet {

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -9,7 +9,6 @@
 use log::trace;
 use rustc_ast::ast;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_index::vec::Idx;
 use rustc_middle::{
     mir,
     ty::{self, TyCtxt},
@@ -333,8 +332,7 @@ pub fn read_prusti_attrs(attr_name: &str, attrs: &[ast::Attribute]) -> Vec<Strin
                 continue;
             }
             use rustc_ast::{
-                token::{DelimToken, Lit, Token, TokenKind},
-                tokenstream::{TokenStream, TokenTree},
+                token::{Lit, Token, TokenKind},
             };
             fn extract_string(token: &Token) -> String {
                 force_matches!(&token.kind, TokenKind::Literal(Lit { symbol, .. }) => {

--- a/prusti-viper/src/encoder/array_encoder.rs
+++ b/prusti-viper/src/encoder/array_encoder.rs
@@ -14,7 +14,7 @@ use crate::encoder::{
 };
 use prusti_common::vir_local;
 use vir_crate::polymorphic as vir;
-use crate::encoder::mir::types::MirTypeEncoderInterface;
+
 
 use super::high::{types::HighTypeEncoderInterface, builtin_functions::HighBuiltinFunctionEncoderInterface};
 

--- a/prusti-viper/src/encoder/borrows.rs
+++ b/prusti-viper/src/encoder/borrows.rs
@@ -11,17 +11,17 @@ use rustc_hir::{self as hir, Mutability};
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::{mir, ty::FnSig, ty::subst::SubstsRef};
 use rustc_index::vec::Idx;
-use rustc_middle::ty::{self, Ty, TyCtxt, TyKind, TypeckResults};
+use rustc_middle::ty::{self, Ty, TyCtxt, TyKind};
 // use rustc_data_structures::indexed_vec::Idx;
 use rustc_hash::{FxHashMap};
 use std::fmt;
 use crate::utils::type_visitor::{self, TypeVisitor};
 use prusti_interface::specs::typed;
-use log::{trace, debug};
+use log::{trace};
 use crate::encoder::errors::EncodingError;
 use crate::encoder::errors::EncodingResult;
-use crate::encoder::errors::SpannedEncodingResult;
-use crate::utils::is_reference;
+
+
 
 #[derive(Clone, Debug)]
 pub struct BorrowInfo<P>

--- a/prusti-viper/src/encoder/counterexample_translation.rs
+++ b/prusti-viper/src/encoder/counterexample_translation.rs
@@ -1,15 +1,15 @@
 use rustc_hash::{FxHashMap};
-use std::convert::TryFrom;
+
 
 use viper::silicon_counterexample::*;
-use viper::VerificationError;
+
 use prusti_interface::data::ProcedureDefId;
 use crate::encoder::Encoder;
-use crate::encoder::places::{Local, LocalVariableManager, Place};
+use crate::encoder::places::{Local, LocalVariableManager};
 use crate::encoder::counterexample::*;
 
 use rustc_middle::mir::{self, VarDebugInfo};
-use rustc_middle::ty::{self, Ty, AdtKind, AdtDef, TyCtxt};
+use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::Span;
 
 pub fn backtranslate(

--- a/prusti-viper/src/encoder/definition_collector.rs
+++ b/prusti-viper/src/encoder/definition_collector.rs
@@ -3,16 +3,16 @@ use super::{
     snapshot::interface::SnapshotEncoderInterface,
     Encoder,
 };
-use crate::encoder::{high::types::HighTypeEncoderInterface, mir::types::MirTypeEncoderInterface};
+use crate::encoder::high::types::HighTypeEncoderInterface;
 use prusti_common::vir_local;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_span::Span;
-use std::hash::Hash;
+
 use vir_crate::{
     common::identifier::WithIdentifier,
     polymorphic::{
         self as vir, compute_identifier, ExprWalker, FallibleExprWalker, FallibleStmtWalker,
-        FunctionIdentifier, PredicateAccessPredicate, StmtWalker,
+        StmtWalker,
     },
 };
 

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -7,14 +7,11 @@
 use ::log::{info, debug, trace};
 use crate::encoder::borrows::{compute_procedure_contract, ProcedureContract, ProcedureContractMirDef};
 use crate::encoder::builtin_encoder::BuiltinEncoder;
-use crate::encoder::builtin_encoder::BuiltinFunctionKind;
 use crate::encoder::builtin_encoder::BuiltinMethodKind;
-use crate::encoder::builtin_encoder::BuiltinDomainKind;
-use crate::encoder::errors::{ErrorCtxt, ErrorManager, SpannedEncodingError, EncodingError, WithSpan};
+use crate::encoder::errors::{ErrorManager, SpannedEncodingError, EncodingError};
 use crate::encoder::foldunfold;
 use crate::encoder::places;
 use crate::encoder::procedure_encoder::ProcedureEncoder;
-use crate::encoder::stub_function_encoder::StubFunctionEncoder;
 use crate::encoder::SpecFunctionKind;
 use crate::encoder::spec_function_encoder::SpecFunctionEncoder;
 use prusti_common::{vir_expr, vir_local};
@@ -23,35 +20,23 @@ use prusti_common::report::log;
 use prusti_interface::data::ProcedureDefId;
 use prusti_interface::environment::Environment;
 use prusti_interface::specs::typed;
-use prusti_interface::specs::typed::SpecificationId;
-use prusti_interface::utils::{has_spec_only_attr, read_prusti_attrs};
+use prusti_interface::utils::{has_spec_only_attr};
 use prusti_interface::PrustiError;
-use prusti_specs::specifications::common::SpecIdRef;
-use vir_crate::polymorphic::{self as vir, ExprIterator};
+use vir_crate::polymorphic::{self as vir};
 use vir_crate::common::identifier::WithIdentifier;
-use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
-// use rustc::middle::const_val::ConstVal;
 use rustc_middle::mir;
-// use rustc::mir::interpret::GlobalId;
 use rustc_middle::ty;
 use std::cell::{RefCell, RefMut, Ref};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap};
 use std::io::Write;
-use std::mem;
 use std::rc::Rc;
-// use viper;
 use crate::encoder::stub_procedure_encoder::StubProcedureEncoder;
 use std::ops::AddAssign;
-use std::convert::TryInto;
-use std::borrow::{Borrow, BorrowMut};
 use crate::encoder::specs_closures_collector::SpecsClosuresCollector;
-use rustc_span::MultiSpan;
 use crate::encoder::name_interner::NameInterner;
-use crate::encoder::utils::transpose;
 use crate::encoder::errors::EncodingResult;
 use crate::encoder::errors::SpannedEncodingResult;
-use crate::encoder::mirror_function_encoder;
 use crate::encoder::mirror_function_encoder::MirrorEncoder;
 use crate::encoder::snapshot::interface::{SnapshotEncoderInterface, SnapshotEncoderState};
 use crate::encoder::purifier;
@@ -63,10 +48,9 @@ use super::mir::type_layouts::MirTypeLayoutsEncoderState;
 use super::mir::{
     pure::{
         PureFunctionEncoderState, PureFunctionEncoderInterface,
-        SpecificationEncoderInterface,
     },
     types::{
-        compute_discriminant_bounds, compute_discriminant_values,
+        compute_discriminant_bounds,
         MirTypeEncoderState, MirTypeEncoderInterface,
     },
 };

--- a/prusti-viper/src/encoder/errors/error_manager.rs
+++ b/prusti-viper/src/encoder/errors/error_manager.rs
@@ -12,7 +12,7 @@ use viper::VerificationError;
 use prusti_interface::PrustiError;
 use log::{debug, trace};
 use prusti_interface::data::ProcedureDefId;
-use backtrace::trace;
+
 
 /// The cause of a panic!()
 #[derive(Clone, Debug)]

--- a/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
@@ -7,7 +7,7 @@
 use rustc_span::MultiSpan;
 use log::trace;
 use prusti_interface::PrustiError;
-use crate::encoder::errors::EncodingError;
+
 use crate::encoder::errors::EncodingErrorKind;
 use backtrace::Backtrace;
 

--- a/prusti-viper/src/encoder/foldunfold/action.rs
+++ b/prusti-viper/src/encoder/foldunfold/action.rs
@@ -6,7 +6,7 @@
 
 use crate::encoder::foldunfold::{perm::*, FoldUnfoldError};
 use std::fmt;
-use vir_crate::polymorphic::{self as vir, Expr, Fold, PermAmount, Stmt, Unfold};
+use vir_crate::polymorphic::{self as vir, Fold, Unfold};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[allow(clippy::large_enum_variant)]

--- a/prusti-viper/src/encoder/foldunfold/footprint.rs
+++ b/prusti-viper/src/encoder/foldunfold/footprint.rs
@@ -8,13 +8,10 @@ use super::{
     places_utils::{union, union3},
     Predicates,
 };
-use crate::encoder::foldunfold::{
-    perm::{Perm::*, *},
-    requirements::*,
-};
-use log::{debug, trace};
+use crate::encoder::foldunfold::perm::{Perm::*, *};
+use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::iter::FromIterator;
+
 use vir_crate::polymorphic::{self as vir, PermAmount};
 
 pub trait ExprFootprintGetter {

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -12,15 +12,15 @@ use crate::encoder::{
 #[rustfmt::skip]
 use ::log::{debug, trace};
 use super::errors::SpannedEncodingError;
-use crate::encoder::{high::types::HighTypeEncoderInterface, mir::types::MirTypeEncoderInterface};
+use crate::encoder::high::types::HighTypeEncoderInterface;
 use prusti_common::{config, report, utils::to_string::ToString, vir::ToGraphViz, Stopwatch};
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_middle::mir;
-use std::{self, fmt, mem, ops::Deref};
+use std::{self, fmt, ops::Deref};
 use vir_crate::{
     polymorphic as vir,
     polymorphic::{
-        borrows::Borrow, CfgBlockIndex, CfgReplacer, CheckNoOpAction, ExprFolder, ExprWalker,
+        borrows::Borrow, CfgBlockIndex, CfgReplacer, CheckNoOpAction, ExprWalker,
         FallibleExprFolder, PermAmount, PermAmountError,
     },
 };

--- a/prusti-viper/src/encoder/foldunfold/path_ctxt.rs
+++ b/prusti-viper/src/encoder/foldunfold/path_ctxt.rs
@@ -6,8 +6,8 @@
 
 use super::Predicates;
 use crate::encoder::foldunfold::{
-    action::*, footprint::*, log::EventLog, perm::*, places_utils::*, requirements::*,
-    semantics::ApplyOnState, state::*, FoldUnfoldError, FoldUnfoldError::FailedToObtain,
+    action::*, footprint::*, log::EventLog, perm::*, places_utils::*, semantics::ApplyOnState,
+    state::*, FoldUnfoldError, FoldUnfoldError::FailedToObtain,
 };
 use log::{debug, trace};
 use prusti_common::utils::to_string::ToString;

--- a/prusti-viper/src/encoder/foldunfold/perm.rs
+++ b/prusti-viper/src/encoder/foldunfold/perm.rs
@@ -4,7 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::encoder::foldunfold::FoldUnfoldError;
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::fmt;

--- a/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
+++ b/prusti-viper/src/encoder/foldunfold/process_expire_borrows.rs
@@ -5,7 +5,7 @@ use crate::encoder::{
 };
 use log::*;
 use prusti_common::{report, utils::to_string::ToString};
-use std::{mem, ops::Deref};
+use std::ops::Deref;
 use vir_crate::polymorphic::{self as vir, CfgReplacer, ExprFolder};
 
 impl<'p, 'v: 'p, 'tcx: 'v> FoldUnfold<'p, 'v, 'tcx> {

--- a/prusti-viper/src/encoder/foldunfold/requirements.rs
+++ b/prusti-viper/src/encoder/foldunfold/requirements.rs
@@ -4,17 +4,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use super::{
-    places_utils::{union, union3},
-    Predicates,
-};
+use super::Predicates;
 use crate::encoder::foldunfold::{
     footprint::*,
     perm::{Perm::*, *},
-    places_utils::ancestors,
 };
 use log::{debug, trace};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use std::iter::FromIterator;
 use vir_crate::polymorphic::{self as vir, PermAmount};
 

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -6,11 +6,10 @@
 
 use super::Predicates;
 use crate::encoder::foldunfold::{
-    footprint::*, path_ctxt::find_unfolded_variant, perm::*, requirements::*, state::*,
-    FoldUnfoldError,
+    footprint::*, path_ctxt::find_unfolded_variant, perm::*, state::*, FoldUnfoldError,
 };
-use log::{debug, trace};
-use rustc_hash::FxHashMap;
+use log::trace;
+
 use vir_crate::polymorphic as vir;
 
 fn inhale_expr(

--- a/prusti-viper/src/encoder/high/builtin_functions/encoder.rs
+++ b/prusti-viper/src/encoder/high/builtin_functions/encoder.rs
@@ -1,7 +1,7 @@
 use super::interface::BuiltinFunctionHighKind;
 use vir_crate::{
     common::expression::BinaryOperationHelpers,
-    high::{self as vir_high, operations::ty::Typed},
+    high::{self as vir_high},
 };
 
 pub(super) fn encode_builtin_function_def(kind: BuiltinFunctionHighKind) -> vir_high::FunctionDecl {

--- a/prusti-viper/src/encoder/high/builtin_functions/interface.rs
+++ b/prusti-viper/src/encoder/high/builtin_functions/interface.rs
@@ -1,20 +1,15 @@
 use super::{super::lower::IntoPolymorphic, encoder::encode_builtin_function_name_with_type_args};
 use crate::encoder::{
     builtin_encoder::{BuiltinEncoder, BuiltinFunctionKind},
-    encoder::SubstMap,
-    errors::{EncodingError, EncodingResult, SpannedEncodingResult, WithSpan},
     high::builtin_functions::encoder::encode_builtin_function_def,
-    mir::pure::PureFunctionEncoderInterface,
-    snapshot::interface::SnapshotEncoderInterface,
-    stub_function_encoder::StubFunctionEncoder,
 };
-use log::{debug, trace};
-use prusti_interface::{data::ProcedureDefId, environment::Environment};
+use log::trace;
+
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_middle::ty::TyCtxt;
-use std::cell::{Ref, RefCell};
+
+use std::cell::RefCell;
 use vir_crate::{
-    high::{self as vir_high, operations::ty::Typed},
+    high::{self as vir_high},
     polymorphic as vir_poly,
 };
 

--- a/prusti-viper/src/encoder/high/expressions/interface.rs
+++ b/prusti-viper/src/encoder/high/expressions/interface.rs
@@ -1,8 +1,6 @@
 use super::super::lower::IntoPolymorphic;
 use vir_crate::{
     high::{self as vir_high},
-    low as vir_low,
-    low::operations::ToLow,
     polymorphic as vir_poly,
 };
 

--- a/prusti-viper/src/encoder/high/expressions/mod.rs
+++ b/prusti-viper/src/encoder/high/expressions/mod.rs
@@ -1,5 +1,3 @@
 //! Encoder of expressions.
 
 mod interface;
-
-pub(crate) use interface::HighExpressionEncoderInterface;

--- a/prusti-viper/src/encoder/high/lower/expression.rs
+++ b/prusti-viper/src/encoder/high/lower/expression.rs
@@ -1,7 +1,7 @@
 use super::super::types::interface::HighTypeEncoderInterfacePrivate;
 
 use super::IntoPolymorphic;
-use vir_crate::{high as vir_high, legacy as vir_low, polymorphic as vir_poly};
+use vir_crate::{high as vir_high, polymorphic as vir_poly};
 
 impl IntoPolymorphic<Box<vir_poly::Expr>> for Box<vir_high::Expression> {
     fn lower(&self, encoder: &impl HighTypeEncoderInterfacePrivate) -> Box<vir_poly::Expr> {

--- a/prusti-viper/src/encoder/high/procedures/inference/ensurer.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/ensurer.rs
@@ -4,13 +4,7 @@ use super::{
     FoldUnfoldState,
 };
 use crate::encoder::errors::SpannedEncodingResult;
-use vir_crate::{
-    high as vir_high,
-    middle::{
-        self as vir_mid,
-        operations::{ToMiddleExpression, ToMiddleStatement},
-    },
-};
+use vir_crate::high as vir_high;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(in super::super) enum ExpandedPermissionKind {

--- a/prusti-viper/src/encoder/high/procedures/inference/mod.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/mod.rs
@@ -1,18 +1,9 @@
 use self::{state::FoldUnfoldState, visitor::Visitor};
-use crate::encoder::{
-    errors::{ErrorCtxt, SpannedEncodingResult},
-    high::{type_layouts::HighTypeLayoutsEncoderInterface, types::HighTypeEncoderInterface},
-    mir::{errors::ErrorInterface, types::MirTypeEncoderInterface},
-    Encoder,
-};
+use crate::encoder::{errors::SpannedEncodingResult, Encoder};
 use rustc_hir::def_id::DefId;
 use vir_crate::{
-    common::position::Positioned,
-    high::{self as vir_high, operations::ty::Typed},
-    middle::{
-        self as vir_mid,
-        operations::{ToMiddleExpression, ToMiddleStatement},
-    },
+    high::{self as vir_high},
+    middle::{self as vir_mid},
 };
 
 mod action;

--- a/prusti-viper/src/encoder/high/procedures/inference/permission.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/permission.rs
@@ -1,4 +1,4 @@
-use vir_crate::{high as vir_high, middle as vir_mid};
+use vir_crate::high as vir_high;
 
 #[derive(Debug, Clone)]
 pub(in super::super) enum Permission {

--- a/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
@@ -1,6 +1,6 @@
-use super::{permission::Permission, state::FoldUnfoldState};
+use super::permission::Permission;
 use crate::encoder::errors::SpannedEncodingResult;
-use vir_crate::{high as vir_high, middle as vir_mid};
+use vir_crate::high as vir_high;
 
 pub(in super::super) fn collect_permission_changes(
     statement: &vir_high::Statement,

--- a/prusti-viper/src/encoder/high/procedures/inference/state.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/state.rs
@@ -2,8 +2,8 @@ use super::permission::{Permission, PermissionKind};
 use crate::encoder::errors::SpannedEncodingResult;
 use log::debug;
 use rustc_hash::FxHashSet;
-use std::collections::BTreeSet;
-use vir_crate::{high as vir_high, middle as vir_mid};
+
+use vir_crate::high as vir_high;
 
 pub(in super::super) struct FoldUnfoldState {
     owned_non_aliased: FxHashSet<vir_high::Expression>,

--- a/prusti-viper/src/encoder/high/procedures/inference/visitor.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/visitor.rs
@@ -9,7 +9,6 @@ use crate::encoder::{
             action::Action, permission::PermissionKind, semantics::collect_permission_changes,
         },
         type_layouts::HighTypeLayoutsEncoderInterface,
-        types::HighTypeEncoderInterface,
     },
     mir::{errors::ErrorInterface, types::MirTypeEncoderInterface},
     Encoder,

--- a/prusti-viper/src/encoder/high/procedures/interface.rs
+++ b/prusti-viper/src/encoder/high/procedures/interface.rs
@@ -3,9 +3,8 @@ use crate::encoder::{
 };
 use log::debug;
 use rustc_hir::def_id::DefId;
-use rustc_middle::mir;
-use rustc_span::Span;
-use vir_crate::{high as vir_high, middle as vir_mid};
+
+use vir_crate::middle as vir_mid;
 
 pub(crate) trait HighProcedureEncoderInterface<'tcx> {
     fn encode_procedure_core_proof(

--- a/prusti-viper/src/encoder/high/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/high/pure_functions/interface.rs
@@ -1,20 +1,11 @@
-use super::super::lower::IntoPolymorphic;
 use crate::encoder::{
-    encoder::SubstMap,
-    errors::{EncodingError, EncodingResult, SpannedEncodingResult, WithSpan},
+    errors::{EncodingError, EncodingResult, SpannedEncodingResult},
     mir::pure::PureFunctionEncoderInterface,
-    snapshot::interface::SnapshotEncoderInterface,
-    stub_function_encoder::StubFunctionEncoder,
 };
-use log::{debug, trace};
-use prusti_interface::{data::ProcedureDefId, environment::Environment};
-use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_middle::ty::TyCtxt;
-use std::cell::{Ref, RefCell};
+
 use vir_crate::{
     high::{self as vir_high, operations::ty::Typed},
     middle::{self as vir_mid, operations::ToMiddleExpression},
-    polymorphic as vir_poly,
 };
 
 pub(crate) trait HighPureFunctionEncoderInterface<'tcx> {

--- a/prusti-viper/src/encoder/high/type_layouts/interface.rs
+++ b/prusti-viper/src/encoder/high/type_layouts/interface.rs
@@ -1,7 +1,7 @@
 use crate::encoder::{
     errors::SpannedEncodingResult, mir::type_layouts::MirTypeLayoutsEncoderInterface,
 };
-use rustc_middle::{mir, ty};
+use rustc_middle::ty;
 use vir_crate::middle::{self as vir_mid, operations::ToMiddleExpression};
 
 pub(crate) trait HighTypeLayoutsEncoderInterface<'tcx> {

--- a/prusti-viper/src/encoder/high/types/fields.rs
+++ b/prusti-viper/src/encoder/high/types/fields.rs
@@ -2,7 +2,7 @@
 
 use crate::encoder::errors::{EncodingError, EncodingResult};
 use log::trace;
-use prusti_common::vir::Field;
+
 use vir_crate::high as vir;
 
 pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl> {

--- a/prusti-viper/src/encoder/initialisation.rs
+++ b/prusti-viper/src/encoder/initialisation.rs
@@ -14,9 +14,9 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::{mir, ty::{self, TyCtxt}};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::hash::Hash;
-use crate::encoder::errors::{SpannedEncodingError, EncodingError};
+
 use crate::encoder::errors::EncodingResult;
-use crate::encoder::errors::SpannedEncodingResult;
+
 
 pub struct InitInfo {
     //mir_acc_before_block: FxHashMap<mir::BasicBlock, FxHashSet<mir::Place<'tcx>>>,

--- a/prusti-viper/src/encoder/middle/core_proof/addresses/encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/addresses/encoder.rs
@@ -1,15 +1,8 @@
 use super::{super::utils::place_domain_encoder::PlaceExpressionDomainEncoder, AddressesInterface};
-use crate::encoder::{
-    errors::SpannedEncodingResult,
-    middle::core_proof::{
-        compute_address::ComputeAddressInterface,
-        lowerer::{DomainsLowererInterface, Lowerer},
-    },
-};
+use crate::encoder::{errors::SpannedEncodingResult, middle::core_proof::lowerer::Lowerer};
 use vir_crate::{
-    common::identifier::WithIdentifier,
     low as vir_low,
-    middle::{self as vir_mid, operations::ty::Typed},
+    middle::{self as vir_mid},
 };
 
 pub(super) struct PlaceAddressEncoder {}

--- a/prusti-viper/src/encoder/middle/core_proof/addresses/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/addresses/interface.rs
@@ -6,9 +6,8 @@ use crate::encoder::{
     middle::core_proof::lowerer::{DomainsLowererInterface, Lowerer, VariablesLowererInterface},
 };
 use vir_crate::{
-    common::identifier::WithIdentifier,
     low as vir_low,
-    middle::{self as vir_mid, operations::ty::Typed},
+    middle::{self as vir_mid},
 };
 
 pub(in super::super) trait AddressesInterface {

--- a/prusti-viper/src/encoder/middle/core_proof/builtin_methods/helpers.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/builtin_methods/helpers.rs
@@ -1,13 +1,11 @@
 use crate::encoder::{
     errors::SpannedEncodingResult,
     middle::core_proof::{
-        addresses::AddressesInterface, builtin_methods::BuiltinMethodsInterface,
-        into_low::IntoLowInterface, lowerer::Lowerer, places::PlacesInterface,
-        predicates_owned::PredicatesOwnedInterface, snapshots::SnapshotsInterface,
+        addresses::AddressesInterface, lowerer::Lowerer, snapshots::SnapshotsInterface,
         utils::type_decl_encoder::TypeDeclWalker,
     },
 };
-use vir_crate::{common::identifier::WithIdentifier, low as vir_low, middle as vir_mid};
+use vir_crate::{low as vir_low, middle as vir_mid};
 use vir_low::macros::*;
 use vir_mid::{FieldDecl, Type};
 

--- a/prusti-viper/src/encoder/middle/core_proof/builtin_methods/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/builtin_methods/interface.rs
@@ -3,7 +3,6 @@ use crate::encoder::{
     errors::{BuiltinMethodKind, ErrorCtxt, SpannedEncodingResult},
     high::types::HighTypeEncoderInterface,
     middle::core_proof::{
-        addresses::AddressesInterface,
         builtin_methods::split_join::SplitJoinHelper,
         compute_address::ComputeAddressInterface,
         errors::ErrorsInterface,
@@ -16,14 +15,8 @@ use crate::encoder::{
     },
 };
 use rustc_hash::FxHashSet;
-use std::borrow::Cow;
-use vir_crate::{
-    common::{
-        expression::{ExpressionIterator, QuantifierHelpers},
-        identifier::WithIdentifier,
-    },
-    low as vir_low, middle as vir_mid,
-};
+
+use vir_crate::{common::expression::ExpressionIterator, low as vir_low, middle as vir_mid};
 
 #[derive(Default)]
 pub(in super::super) struct BuiltinMethodsState {

--- a/prusti-viper/src/encoder/middle/core_proof/builtin_methods/split_join.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/builtin_methods/split_join.rs
@@ -2,19 +2,15 @@ use crate::encoder::{
     errors::SpannedEncodingResult,
     middle::core_proof::{
         addresses::AddressesInterface,
-        builtin_methods::BuiltinMethodsInterface,
         compute_address::ComputeAddressInterface,
-        into_low::IntoLowInterface,
         lowerer::Lowerer,
-        places::PlacesInterface,
         predicates_memory_block::PredicatesMemoryBlockInterface,
-        predicates_owned::PredicatesOwnedInterface,
         snapshots::{IntoSnapshot, SnapshotsInterface},
         type_layouts::TypeLayoutsInterface,
         utils::type_decl_encoder::TypeDeclWalker,
     },
 };
-use vir_crate::{common::identifier::WithIdentifier, low as vir_low, middle as vir_mid};
+use vir_crate::{low as vir_low, middle as vir_mid};
 use vir_low::macros::*;
 use vir_mid::{FieldDecl, Type};
 

--- a/prusti-viper/src/encoder/middle/core_proof/compute_address/encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/compute_address/encoder.rs
@@ -5,13 +5,7 @@ use crate::encoder::{
         utils::type_decl_encoder::TypeDeclWalker,
     },
 };
-use vir_crate::{
-    common::{
-        expression::{BinaryOperationHelpers, QuantifierHelpers},
-        identifier::WithIdentifier,
-    },
-    low as vir_low, middle as vir_mid,
-};
+use vir_crate::{common::identifier::WithIdentifier, low as vir_low, middle as vir_mid};
 
 pub(super) struct ComputeAddressEncoder;
 

--- a/prusti-viper/src/encoder/middle/core_proof/compute_address/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/compute_address/interface.rs
@@ -1,21 +1,11 @@
 use super::encoder::ComputeAddressEncoder;
 use crate::encoder::{
     errors::SpannedEncodingResult,
-    high::types::HighTypeEncoderInterface,
-    middle::core_proof::{
-        addresses::AddressesInterface, lowerer::Lowerer, places::PlacesInterface,
-        utils::type_decl_encoder::TypeDeclWalker,
-    },
+    middle::core_proof::{lowerer::Lowerer, utils::type_decl_encoder::TypeDeclWalker},
 };
 use rustc_hash::FxHashSet;
-use std::borrow::Cow;
-use vir_crate::{
-    common::{
-        expression::{BinaryOperationHelpers, QuantifierHelpers},
-        identifier::WithIdentifier,
-    },
-    low as vir_low, middle as vir_mid,
-};
+
+use vir_crate::{low as vir_low, middle as vir_mid};
 
 #[derive(Default)]
 pub(in super::super) struct ComputeAddressState {

--- a/prusti-viper/src/encoder/middle/core_proof/errors/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/errors/interface.rs
@@ -3,7 +3,7 @@ use crate::encoder::{
     middle::core_proof::lowerer::Lowerer,
     mir::procedures::MirProcedureEncoderInterface,
 };
-use prusti_interface::data::ProcedureDefId;
+
 use vir_crate::low as vir_low;
 
 pub(in super::super) trait ErrorsInterface {

--- a/prusti-viper/src/encoder/middle/core_proof/fold_unfold/helpers.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/fold_unfold/helpers.rs
@@ -1,13 +1,12 @@
 use crate::encoder::{
     errors::SpannedEncodingResult,
     middle::core_proof::{
-        addresses::AddressesInterface, builtin_methods::BuiltinMethodsInterface,
-        into_low::IntoLowInterface, lowerer::Lowerer, places::PlacesInterface,
-        predicates_owned::PredicatesOwnedInterface, snapshots::SnapshotsInterface,
-        utils::type_decl_encoder::TypeDeclWalker,
+        addresses::AddressesInterface, builtin_methods::BuiltinMethodsInterface, lowerer::Lowerer,
+        places::PlacesInterface, predicates_owned::PredicatesOwnedInterface,
+        snapshots::SnapshotsInterface, utils::type_decl_encoder::TypeDeclWalker,
     },
 };
-use vir_crate::{common::identifier::WithIdentifier, low as vir_low, middle as vir_mid};
+use vir_crate::{low as vir_low, middle as vir_mid};
 use vir_low::macros::*;
 use vir_mid::{FieldDecl, Type};
 

--- a/prusti-viper/src/encoder/middle/core_proof/fold_unfold/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/fold_unfold/interface.rs
@@ -1,16 +1,10 @@
 use super::helpers::{MemoryBlockSplitJoiner, OwnedUnFolder};
 use crate::encoder::{
     errors::SpannedEncodingResult,
-    high::types::HighTypeEncoderInterface,
-    middle::core_proof::{
-        addresses::AddressesInterface, compute_address::ComputeAddressInterface,
-        into_low::IntoLowInterface, lowerer::Lowerer, places::PlacesInterface,
-        predicates_owned::PredicatesOwnedInterface, snapshots::SnapshotsInterface,
-        utils::type_decl_encoder::TypeDeclWalker,
-    },
+    middle::core_proof::{lowerer::Lowerer, utils::type_decl_encoder::TypeDeclWalker},
 };
-use std::borrow::Cow;
-use vir_crate::{common::identifier::WithIdentifier, low as vir_low, middle as vir_mid};
+
+use vir_crate::{low as vir_low, middle as vir_mid};
 
 pub(in super::super) trait FoldUnfoldInterface {
     fn encode_fully_fold_owned_non_aliased(

--- a/prusti-viper/src/encoder/middle/core_proof/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/interface.rs
@@ -1,16 +1,8 @@
 use crate::encoder::{
-    errors::SpannedEncodingResult,
-    high::{
-        expressions::HighExpressionEncoderInterface, procedures::HighProcedureEncoderInterface,
-    },
-    mir::procedures::MirProcedureEncoderInterface,
+    errors::SpannedEncodingResult, high::procedures::HighProcedureEncoderInterface,
 };
 use rustc_hir::def_id::DefId;
-use vir_crate::{
-    common::identifier::WithIdentifier,
-    low::{self as vir_low, operations::ToLow},
-    middle as vir_mid,
-};
+use vir_crate::low::{self as vir_low};
 
 #[derive(Default)]
 pub(crate) struct MidCoreProofEncoderState {

--- a/prusti-viper/src/encoder/middle/core_proof/into_low/cfg.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/into_low/cfg.rs
@@ -1,6 +1,5 @@
 use super::{IntoLow, IntoLowInterface};
 use crate::encoder::{
-    encoder::Encoder,
     errors::SpannedEncodingResult,
     middle::core_proof::{
         addresses::AddressesInterface, builtin_methods::BuiltinMethodsInterface, lowerer::Lowerer,
@@ -8,7 +7,7 @@ use crate::encoder::{
         predicates_owned::PredicatesOwnedInterface, snapshots::SnapshotsInterface,
     },
 };
-use std::collections::{HashMap, HashSet};
+
 use vir_crate::{
     common::identifier::WithIdentifier,
     low as vir_low,

--- a/prusti-viper/src/encoder/middle/core_proof/into_low/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/into_low/interface.rs
@@ -1,31 +1,9 @@
-use super::MidCoreProofEncoderInterface;
 use crate::encoder::{
-    errors::{BuiltinMethodKind, ErrorCtxt, SpannedEncodingResult},
-    high::{type_layouts::HighTypeLayoutsEncoderInterface, types::HighTypeEncoderInterface},
-    middle::core_proof::{
-        addresses::AddressesInterface,
-        compute_address::ComputeAddressInterface,
-        errors::ErrorsInterface,
-        fold_unfold::FoldUnfoldInterface,
-        lowerer::{FunctionsLowererInterface, Lowerer, MethodsLowererInterface},
-        predicates_memory_block::PredicatesMemoryBlockInterface,
-        predicates_owned::PredicatesOwnedInterface,
-        snapshots::{IntoSnapshot, SnapshotsInterface},
-    },
-    Encoder,
+    errors::SpannedEncodingResult,
+    middle::core_proof::{lowerer::Lowerer, snapshots::IntoSnapshot},
 };
-use rustc_data_structures::fx::FxHashSet;
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
-};
-use vir_crate::{
-    common::{
-        expression::{ExpressionIterator, QuantifierHelpers},
-        identifier::WithIdentifier,
-    },
-    low as vir_low, middle as vir_mid,
-};
+
+use vir_crate::{low as vir_low, middle as vir_mid};
 
 pub(in super::super) trait IntoLowInterface {
     fn lower_expression(

--- a/prusti-viper/src/encoder/middle/core_proof/into_low/mod.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/into_low/mod.rs
@@ -1,6 +1,5 @@
-use super::{lowerer::Lowerer, MidCoreProofEncoderInterface};
-use crate::encoder::{errors::SpannedEncodingResult, Encoder};
-use vir_crate::{low as vir_low, middle as vir_mid};
+use super::lowerer::Lowerer;
+use crate::encoder::errors::SpannedEncodingResult;
 
 mod cfg;
 mod expression;

--- a/prusti-viper/src/encoder/middle/core_proof/lowerer/domains/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lowerer/domains/interface.rs
@@ -1,12 +1,8 @@
-use crate::encoder::{
-    errors::SpannedEncodingResult,
-    high::pure_functions::HighPureFunctionEncoderInterface,
-    middle::core_proof::{into_low::IntoLow, lowerer::Lowerer},
-};
+use crate::encoder::{errors::SpannedEncodingResult, middle::core_proof::lowerer::Lowerer};
 use std::collections::{BTreeMap, BTreeSet};
 use vir_crate::{
     common::identifier::WithIdentifier,
-    low::{self as vir_low, operations::ty::Typed},
+    low::{self as vir_low},
     middle as vir_mid,
 };
 

--- a/prusti-viper/src/encoder/middle/core_proof/lowerer/functions/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lowerer/functions/interface.rs
@@ -7,10 +7,7 @@ use crate::encoder::{
     },
 };
 use std::collections::BTreeMap;
-use vir_crate::{
-    low::{self as vir_low, operations::ty::Typed},
-    middle as vir_mid,
-};
+use vir_crate::low::{self as vir_low};
 
 #[derive(Default)]
 pub(in super::super) struct FunctionsLowererState {

--- a/prusti-viper/src/encoder/middle/core_proof/lowerer/methods/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lowerer/methods/interface.rs
@@ -1,16 +1,6 @@
-use crate::encoder::{
-    errors::SpannedEncodingResult,
-    high::pure_functions::HighPureFunctionEncoderInterface,
-    middle::core_proof::{
-        into_low::IntoLow,
-        lowerer::{DomainsLowererInterface, Lowerer},
-    },
-};
+use crate::encoder::{errors::SpannedEncodingResult, middle::core_proof::lowerer::Lowerer};
 use std::collections::BTreeMap;
-use vir_crate::{
-    low::{self as vir_low, operations::ty::Typed},
-    middle as vir_mid,
-};
+use vir_crate::low::{self as vir_low};
 
 #[derive(Default)]
 pub(in super::super) struct MethodsLowererState {

--- a/prusti-viper/src/encoder/middle/core_proof/lowerer/mod.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lowerer/mod.rs
@@ -10,10 +10,8 @@ use super::{
     predicates_owned::{PredicatesOwnedInterface, PredicatesOwnedState},
     snapshots::SnapshotsState,
 };
-use crate::encoder::{
-    errors::SpannedEncodingResult, high::pure_functions::HighPureFunctionEncoderInterface, Encoder,
-};
-use std::collections::{BTreeMap, BTreeSet};
+use crate::encoder::{errors::SpannedEncodingResult, Encoder};
+
 use vir_crate::{
     low::{self as vir_low, operations::ty::Typed},
     middle as vir_mid,

--- a/prusti-viper/src/encoder/middle/core_proof/lowerer/predicates/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lowerer/predicates/interface.rs
@@ -1,13 +1,6 @@
-use crate::encoder::{
-    errors::SpannedEncodingResult,
-    high::pure_functions::HighPureFunctionEncoderInterface,
-    middle::core_proof::{into_low::IntoLow, lowerer::Lowerer},
-};
-use std::collections::{BTreeMap, BTreeSet};
-use vir_crate::{
-    low::{self as vir_low, operations::ty::Typed},
-    middle as vir_mid,
-};
+use crate::encoder::{errors::SpannedEncodingResult, middle::core_proof::lowerer::Lowerer};
+use std::collections::BTreeMap;
+use vir_crate::low::{self as vir_low};
 
 #[derive(Default)]
 pub(in super::super) struct PredicatesLowererState {

--- a/prusti-viper/src/encoder/middle/core_proof/lowerer/variables/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lowerer/variables/interface.rs
@@ -4,7 +4,7 @@ use crate::encoder::{
 };
 use std::collections::BTreeMap;
 use vir_crate::{
-    low::{self as vir_low, operations::ty::Typed},
+    low::{self as vir_low},
     middle as vir_mid,
 };
 

--- a/prusti-viper/src/encoder/middle/core_proof/places/encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/places/encoder.rs
@@ -7,9 +7,8 @@ use crate::encoder::{
     },
 };
 use vir_crate::{
-    common::identifier::WithIdentifier,
     low as vir_low,
-    middle::{self as vir_mid, operations::ty::Typed},
+    middle::{self as vir_mid},
 };
 
 pub(super) struct PlaceEncoder {}

--- a/prusti-viper/src/encoder/middle/core_proof/places/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/places/interface.rs
@@ -6,9 +6,8 @@ use crate::encoder::{
     middle::core_proof::lowerer::{DomainsLowererInterface, Lowerer},
 };
 use vir_crate::{
-    common::identifier::WithIdentifier,
     low as vir_low,
-    middle::{self as vir_mid, operations::ty::Typed},
+    middle::{self as vir_mid},
 };
 
 pub(in super::super) trait PlacesInterface {

--- a/prusti-viper/src/encoder/middle/core_proof/places/mod.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/places/mod.rs
@@ -1,17 +1,3 @@
-use super::lowerer::Lowerer;
-use crate::encoder::{
-    errors::SpannedEncodingResult,
-    middle::core_proof::{
-        addresses::AddressesInterface, compute_address::ComputeAddressInterface,
-        lowerer::DomainsLowererInterface,
-    },
-};
-use vir_crate::{
-    common::identifier::WithIdentifier,
-    low as vir_low,
-    middle::{self as vir_mid, operations::ty::Typed},
-};
-
 mod encoder;
 mod interface;
 

--- a/prusti-viper/src/encoder/middle/core_proof/predicates_memory_block/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/predicates_memory_block/interface.rs
@@ -5,15 +5,11 @@ use crate::encoder::{
         lowerer::{
             DomainsLowererInterface, FunctionsLowererInterface, Lowerer, PredicatesLowererInterface,
         },
-        snapshots::IntoSnapshot,
         type_layouts::TypeLayoutsInterface,
     },
 };
 use rustc_hash::FxHashSet;
-use vir_crate::{
-    common::{expression::ExpressionIterator, identifier::WithIdentifier},
-    low as vir_low, middle as vir_mid,
-};
+use vir_crate::low as vir_low;
 
 #[derive(Default)]
 pub(in super::super) struct PredicatesMemoryBlockState {

--- a/prusti-viper/src/encoder/middle/core_proof/predicates_owned/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/predicates_owned/interface.rs
@@ -3,7 +3,6 @@ use crate::encoder::{
     high::types::HighTypeEncoderInterface,
     middle::core_proof::{
         compute_address::ComputeAddressInterface,
-        into_low::IntoLowInterface,
         lowerer::Lowerer,
         places::PlacesInterface,
         predicates_memory_block::PredicatesMemoryBlockInterface,
@@ -13,10 +12,7 @@ use crate::encoder::{
 };
 use rustc_hash::FxHashSet;
 use std::borrow::Cow;
-use vir_crate::{
-    common::{expression::ExpressionIterator, identifier::WithIdentifier},
-    low as vir_low, middle as vir_mid,
-};
+use vir_crate::{common::expression::ExpressionIterator, low as vir_low, middle as vir_mid};
 
 #[derive(Default)]
 pub(in super::super) struct PredicatesOwnedState {

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/expression.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/expression.rs
@@ -4,9 +4,7 @@ use crate::encoder::{
     middle::core_proof::{
         into_low::IntoLowInterface,
         lowerer::{DomainsLowererInterface, Lowerer},
-        MidCoreProofEncoderInterface,
     },
-    Encoder,
 };
 use vir_crate::{
     common::identifier::WithIdentifier,

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/mod.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/mod.rs
@@ -1,12 +1,5 @@
 use super::lowerer::Lowerer;
-use crate::encoder::{
-    errors::SpannedEncodingResult, middle::core_proof::MidCoreProofEncoderInterface, Encoder,
-};
-use vir_crate::{
-    common::identifier::WithIdentifier,
-    low as vir_low,
-    middle::{self as vir_mid, operations::ty::Typed},
-};
+use crate::encoder::errors::SpannedEncodingResult;
 
 mod expression;
 mod interface;

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/ty.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/ty.rs
@@ -1,13 +1,8 @@
 use super::{IntoSnapshot, SnapshotsInterface};
-use crate::encoder::{
-    errors::SpannedEncodingResult,
-    middle::core_proof::{lowerer::Lowerer, MidCoreProofEncoderInterface},
-    Encoder,
-};
+use crate::encoder::{errors::SpannedEncodingResult, middle::core_proof::lowerer::Lowerer};
 use vir_crate::{
-    common::identifier::WithIdentifier,
     low as vir_low,
-    middle::{self as vir_mid, operations::ty::Typed},
+    middle::{self as vir_mid},
 };
 
 impl IntoSnapshot for vir_mid::Type {

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/variable.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/variable.rs
@@ -4,9 +4,8 @@ use crate::encoder::{
     middle::core_proof::{lowerer::Lowerer, snapshots::interface::SnapshotsInterface},
 };
 use vir_crate::{
-    common::identifier::WithIdentifier,
     low::{self as vir_low},
-    middle::{self as vir_mid, operations::ty::Typed},
+    middle::{self as vir_mid},
 };
 
 impl IntoSnapshot for vir_mid::VariableDecl {

--- a/prusti-viper/src/encoder/middle/core_proof/type_layouts/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/type_layouts/interface.rs
@@ -3,13 +3,7 @@ use crate::encoder::{
     high::{type_layouts::HighTypeLayoutsEncoderInterface, types::HighTypeEncoderInterface},
     middle::core_proof::{into_low::IntoLowInterface, lowerer::Lowerer, snapshots::IntoSnapshot},
 };
-use vir_crate::{
-    common::{
-        expression::{ExpressionIterator, QuantifierHelpers},
-        identifier::WithIdentifier,
-    },
-    low as vir_low, middle as vir_mid,
-};
+use vir_crate::{low as vir_low, middle as vir_mid};
 
 pub(in super::super) trait TypeLayoutsInterface {
     fn size_type(&mut self) -> SpannedEncodingResult<vir_low::Type>;

--- a/prusti-viper/src/encoder/middle/core_proof/utils/place_domain_encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/utils/place_domain_encoder.rs
@@ -3,7 +3,6 @@ use crate::encoder::{
     middle::core_proof::lowerer::{DomainsLowererInterface, Lowerer},
 };
 use vir_crate::{
-    common::identifier::WithIdentifier,
     low as vir_low,
     middle::{self as vir_mid, operations::ty::Typed},
 };

--- a/prusti-viper/src/encoder/middle/core_proof/utils/type_decl_encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/utils/type_decl_encoder.rs
@@ -1,14 +1,9 @@
 use crate::encoder::{
-    errors::SpannedEncodingResult,
-    high::types::HighTypeEncoderInterface,
-    middle::core_proof::lowerer::{DomainsLowererInterface, Lowerer},
+    errors::SpannedEncodingResult, high::types::HighTypeEncoderInterface,
+    middle::core_proof::lowerer::Lowerer,
 };
 use std::borrow::Cow;
-use vir_crate::{
-    common::identifier::WithIdentifier,
-    low as vir_low,
-    middle::{self as vir_mid, operations::ty::Typed},
-};
+use vir_crate::middle::{self as vir_mid};
 
 pub(in super::super) trait TypeDeclWalker {
     type Parameters;

--- a/prusti-viper/src/encoder/mir/casts/interface.rs
+++ b/prusti-viper/src/encoder/mir/casts/interface.rs
@@ -1,14 +1,8 @@
 use log::{debug, trace};
-use rustc_middle::{mir, span_bug, ty};
-use vir_crate::{
-    common::expression::BinaryOperationHelpers,
-    high::{self as vir_high, operations::ty::Typed},
-};
+use rustc_middle::ty;
+use vir_crate::high::{self as vir_high};
 
-use crate::encoder::{
-    errors::{EncodingError, EncodingResult},
-    mir::types::MirTypeEncoderInterface,
-};
+use crate::encoder::errors::{EncodingError, EncodingResult};
 
 pub(crate) trait CastsEncoderInterface<'tcx> {
     fn encode_int_cast_high(

--- a/prusti-viper/src/encoder/mir/constants/interface.rs
+++ b/prusti-viper/src/encoder/mir/constants/interface.rs
@@ -1,9 +1,6 @@
 use log::debug;
-use rustc_middle::{mir, span_bug, ty};
-use vir_crate::{
-    common::expression::BinaryOperationHelpers,
-    high::{self as vir_high, operations::ty::Typed},
-};
+use rustc_middle::{mir, ty};
+use vir_crate::high::{self as vir_high};
 
 use crate::encoder::{
     errors::{EncodingError, EncodingResult},

--- a/prusti-viper/src/encoder/mir/generics/interface.rs
+++ b/prusti-viper/src/encoder/mir/generics/interface.rs
@@ -2,17 +2,13 @@ use crate::encoder::{
     encoder::SubstMap,
     errors::{EncodingError, EncodingResult},
     mir::types::MirTypeEncoderInterface,
-    utils::transpose,
 };
-use log::debug;
+
 use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
-use rustc_middle::{mir, span_bug, ty};
+use rustc_middle::ty;
 use rustc_span::symbol::Symbol;
-use vir_crate::{
-    common::expression::BinaryOperationHelpers,
-    high::{self as vir_high, operations::ty::Typed},
-};
+use vir_crate::high::{self as vir_high};
 
 pub(crate) trait MirGenericsEncoderInterface<'tcx> {
     fn update_substitution_map(

--- a/prusti-viper/src/encoder/mir/places/interface.rs
+++ b/prusti-viper/src/encoder/mir/places/interface.rs
@@ -9,7 +9,7 @@ use crate::encoder::{
 };
 use log::debug;
 use rustc_hir::def_id::DefId;
-use rustc_middle::{mir, span_bug, ty};
+use rustc_middle::{mir, ty};
 use rustc_span::Span;
 use vir_crate::{
     common::expression::{BinaryOperationHelpers, UnaryOperationHelpers},

--- a/prusti-viper/src/encoder/mir/procedures/encoder.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder.rs
@@ -11,11 +11,10 @@ use crate::encoder::{
 use prusti_interface::environment::{mir_dump::lifetimes::Lifetimes, Procedure};
 use rustc_data_structures::graph::WithStartNode;
 use rustc_hir::def_id::DefId;
-use rustc_middle::{mir, ty};
+use rustc_middle::mir;
 use vir_crate::high::{
     self as vir_high,
     builders::procedure::{BasicBlockBuilder, ProcedureBuilder},
-    operations::ty::Typed,
 };
 
 pub(super) fn encode_procedure<'v, 'tcx: 'v>(

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -4,13 +4,11 @@ pub(super) mod state;
 
 use self::state::ExprBackwardInterpreterState;
 use crate::encoder::{
-    builtin_encoder::BuiltinFunctionKind,
     encoder::SubstMap,
     errors::{EncodingResult, ErrorCtxt, SpannedEncodingError, SpannedEncodingResult, WithSpan},
     high::{
         builtin_functions::{BuiltinFunctionHighKind, HighBuiltinFunctionEncoderInterface},
         pure_functions::HighPureFunctionEncoderInterface,
-        types::HighTypeEncoderInterface,
     },
     mir::{
         casts::CastsEncoderInterface,
@@ -27,9 +25,9 @@ use log::{debug, trace};
 use prusti_common::vir_high_local;
 use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
-use rustc_middle::{mir, span_bug, ty};
+use rustc_middle::{mir, ty};
 use rustc_span::Span;
-use std::fmt::{self, Display};
+
 use vir_crate::{
     common::expression::{BinaryOperationHelpers, UnaryOperationHelpers},
     high::{self as vir_high},

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -6,35 +6,25 @@
 
 use super::interpreter::PureFunctionBackwardInterpreter;
 use crate::encoder::{
-    borrows::{compute_procedure_contract, ProcedureContract},
-    builtin_encoder::BuiltinFunctionKind,
+    borrows::ProcedureContract,
     encoder::SubstMap,
-    errors::{
-        EncodingError, EncodingResult, ErrorCtxt, PanicCause, SpannedEncodingError,
-        SpannedEncodingResult, WithSpan,
-    },
-    foldunfold,
+    errors::{ErrorCtxt, SpannedEncodingError, SpannedEncodingResult, WithSpan},
     high::{generics::HighGenericsEncoderInterface, types::HighTypeEncoderInterface},
-    mir::{
-        generics::MirGenericsEncoderInterface, pure::SpecificationEncoderInterface,
-        types::MirTypeEncoderInterface,
-    },
-    mir_encoder::{MirEncoder, PlaceEncoder, PlaceEncoding, PRECONDITION_LABEL, WAND_LHS_LABEL},
-    mir_interpreter::{
-        run_backward_interpretation, BackwardMirInterpreter, ExprBackwardInterpreterState,
-    },
-    snapshot::{self, interface::SnapshotEncoderInterface},
+    mir::pure::SpecificationEncoderInterface,
+    mir_encoder::PlaceEncoder,
+    mir_interpreter::run_backward_interpretation,
+    snapshot::interface::SnapshotEncoderInterface,
     Encoder,
 };
 use log::{debug, trace};
 use prusti_common::{config, vir::optimizations::functions::Simplifier, vir_local};
-use prusti_interface::{specs::typed, PrustiError};
+
 use rustc_hash::FxHashMap;
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_middle::{mir, span_bug, ty};
+use rustc_middle::{mir, ty};
 use rustc_span::Span;
-use std::mem;
+
 use vir_crate::{
     common::identifier::WithIdentifier,
     high as vir_high,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -4,16 +4,15 @@ use super::encoder::{FunctionCallInfo, FunctionCallInfoHigh, PureFunctionEncoder
 use crate::encoder::{
     encoder::SubstMap,
     errors::{SpannedEncodingResult, WithSpan},
-    high::generics::HighGenericsEncoderInterface,
     mir::generics::MirGenericsEncoderInterface,
     snapshot::interface::SnapshotEncoderInterface,
     stub_function_encoder::StubFunctionEncoder,
 };
 use log::{debug, trace};
-use prusti_interface::{data::ProcedureDefId, environment::Environment};
+use prusti_interface::data::ProcedureDefId;
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_middle::ty::TyCtxt;
-use std::cell::{Ref, RefCell};
+
+use std::cell::RefCell;
 use vir_crate::{common::identifier::WithIdentifier, high as vir_high, polymorphic as vir_poly};
 
 type Key = (ProcedureDefId, Vec<vir_high::Type>);

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -1,13 +1,11 @@
 use super::interface::PureFunctionEncoderInterface;
 use crate::encoder::{
-    borrows::{compute_procedure_contract, ProcedureContract},
     builtin_encoder::BuiltinFunctionKind,
     encoder::SubstMap,
     errors::{
-        EncodingError, EncodingResult, ErrorCtxt, PanicCause, SpannedEncodingError,
-        SpannedEncodingResult, WithSpan,
+        EncodingError, EncodingResult, ErrorCtxt, SpannedEncodingError, SpannedEncodingResult,
+        WithSpan,
     },
-    foldunfold,
     high::{
         builtin_functions::HighBuiltinFunctionEncoderInterface,
         generics::HighGenericsEncoderInterface, types::HighTypeEncoderInterface,
@@ -17,22 +15,20 @@ use crate::encoder::{
         types::MirTypeEncoderInterface,
     },
     mir_encoder::{MirEncoder, PlaceEncoder, PlaceEncoding, PRECONDITION_LABEL, WAND_LHS_LABEL},
-    mir_interpreter::{
-        run_backward_interpretation, BackwardMirInterpreter, ExprBackwardInterpreterState,
-    },
-    snapshot::{self, interface::SnapshotEncoderInterface},
+    mir_interpreter::{BackwardMirInterpreter, ExprBackwardInterpreterState},
+    snapshot::interface::SnapshotEncoderInterface,
     Encoder,
 };
 use log::{debug, trace};
-use prusti_common::{config, vir::optimizations::functions::Simplifier, vir_local};
-use prusti_interface::{specs::typed, PrustiError};
+use prusti_common::vir_local;
+
 use rustc_hash::FxHashMap;
-use rustc_hir as hir;
+
 use rustc_hir::def_id::DefId;
 use rustc_middle::{mir, span_bug, ty};
-use rustc_span::Span;
+
 use std::{convert::TryInto, mem};
-use vir_crate::polymorphic::{self as vir, ExprIterator};
+use vir_crate::polymorphic::{self as vir};
 
 pub(crate) struct PureFunctionBackwardInterpreter<'p, 'v: 'p, 'tcx: 'v> {
     encoder: &'p Encoder<'v, 'tcx>,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -18,7 +18,7 @@ use crate::encoder::{
 use log::{debug, trace};
 use prusti_common::vir_high_local;
 use rustc_hir::def_id::DefId;
-use rustc_middle::{mir, span_bug, ty};
+use rustc_middle::mir;
 use rustc_span::Span;
 use vir_crate::{
     common::expression::ExpressionIterator,

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs
@@ -6,8 +6,7 @@
 
 use crate::encoder::{
     encoder::SubstMap,
-    errors::{EncodingError, EncodingResult, SpannedEncodingResult, WithSpan},
-    high::types::HighTypeEncoderInterface,
+    errors::SpannedEncodingResult,
     mir::{
         pure::{specifications::utils::extract_closure_from_ty, PureFunctionEncoderInterface},
         types::MirTypeEncoderInterface,
@@ -16,14 +15,12 @@ use crate::encoder::{
     Encoder,
 };
 use prusti_common::config;
-use rustc_hash::FxHashSet;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty;
-use rustc_span::{MultiSpan, Span};
+use rustc_span::Span;
 use vir_crate::{
     common::expression::{BinaryOperationHelpers, ExpressionIterator, QuantifierHelpers},
     high::{Expression, FieldDecl, Trigger, VariableDecl},
-    polymorphic::ExprIterator,
 };
 
 fn inline_closure_high<'tcx>(

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -20,11 +20,7 @@ use rustc_hash::FxHashSet;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty;
 use rustc_span::{MultiSpan, Span};
-use vir_crate::{
-    common::expression::{BinaryOperationHelpers, ExpressionIterator, QuantifierHelpers},
-    high::{Expression, FieldDecl, Trigger, VariableDecl},
-    polymorphic::ExprIterator,
-};
+use vir_crate::polymorphic::ExprIterator;
 
 // TODO: this variant (poly) should not need to exist, eventually should be
 //       replaced by the high variant + lowering

--- a/prusti-viper/src/encoder/mir/type_layouts/interface.rs
+++ b/prusti-viper/src/encoder/mir/type_layouts/interface.rs
@@ -1,12 +1,9 @@
 use crate::encoder::{
     errors::SpannedEncodingResult,
-    mir::{
-        places::PlacesEncoderInterface, pure::PureFunctionEncoderInterface,
-        types::MirTypeEncoderInterface,
-    },
+    mir::{pure::PureFunctionEncoderInterface, types::MirTypeEncoderInterface},
 };
 use rustc_hash::FxHashSet;
-use rustc_middle::{mir, ty};
+use rustc_middle::ty;
 use std::cell::RefCell;
 use vir_crate::{common::identifier::WithIdentifier, high as vir_high};
 

--- a/prusti-viper/src/encoder/mir/types/encoder.rs
+++ b/prusti-viper/src/encoder/mir/types/encoder.rs
@@ -4,38 +4,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use super::{
-    helpers::{compute_discriminant_bounds, compute_discriminant_values},
-    interface::MirTypeEncoderInterface,
-};
+use super::{helpers::compute_discriminant_values, interface::MirTypeEncoderInterface};
 use crate::encoder::{
-    builtin_encoder::BuiltinFunctionKind,
-    errors::{EncodingError, EncodingResult, SpannedEncodingError, SpannedEncodingResult},
-    foldunfold,
+    errors::{EncodingResult, SpannedEncodingError, SpannedEncodingResult},
     high::types::HighTypeEncoderInterface,
     mir::{
         generics::MirGenericsEncoderInterface, types::helpers::compute_discriminant_bounds_high,
     },
-    utils::{range_extract, PlusOne},
     Encoder,
 };
-use log::{debug, trace};
-use prusti_common::{config, vir_local};
-use prusti_interface::specs::typed;
-use rustc_attr::IntType::SignedInt;
-use rustc_hash::FxHashMap;
+use log::debug;
+use prusti_common::config;
+
 use rustc_hir::def_id::DefId;
-use rustc_middle::{ty, ty::layout::IntegerExt};
+use rustc_middle::ty;
 use rustc_span::MultiSpan;
-use rustc_target::{abi, abi::Integer};
-use std::{
-    convert::TryInto,
-    hash::{Hash, Hasher},
-};
-use vir_crate::{
-    common::expression::{less_equals, ExpressionIterator},
-    high::{self as vir, visitors::ExpressionFolder},
-};
+
+use vir_crate::high::{self as vir};
 
 pub struct TypeEncoder<'p, 'v: 'p, 'tcx: 'v> {
     encoder: &'p Encoder<'v, 'tcx>,

--- a/prusti-viper/src/encoder/mir/types/helpers.rs
+++ b/prusti-viper/src/encoder/mir/types/helpers.rs
@@ -1,25 +1,12 @@
-use crate::encoder::{
-    builtin_encoder::BuiltinFunctionKind,
-    errors::{EncodingError, EncodingResult},
-    foldunfold,
-    utils::{range_extract, PlusOne},
-    Encoder,
-};
-use log::{debug, trace};
-use prusti_common::{config, vir_local};
-use prusti_interface::specs::typed;
-use rustc_attr::IntType::SignedInt;
-use rustc_hash::FxHashMap;
+use crate::encoder::utils::{range_extract, PlusOne};
+
 use rustc_middle::{ty, ty::layout::IntegerExt};
-use rustc_target::{abi, abi::Integer};
-use std::{
-    convert::TryInto,
-    hash::{Hash, Hasher},
-};
+use rustc_target::abi::Integer;
+
 use vir_crate::{
     common::expression::{and, equals, less_equals},
     high as vir_high,
-    polymorphic::{self as vir, ExprFolder},
+    polymorphic::{self as vir},
 };
 
 /// Compute the values that a discriminant can take.

--- a/prusti-viper/src/encoder/mir/types/interface.rs
+++ b/prusti-viper/src/encoder/mir/types/interface.rs
@@ -1,14 +1,12 @@
 use super::TypeEncoder;
 use crate::encoder::{
-    encoder::SubstMap,
     errors::{EncodingError, EncodingResult, SpannedEncodingResult},
     high::types::HighTypeEncoderInterface,
-    utils::transpose,
 };
-use rustc_hir::def_id::DefId;
+
 #[rustfmt::skip]
 use ::log::trace;
-use prusti_common::{config, report::log};
+
 use rustc_hash::FxHashMap;
 use rustc_middle::{mir, ty};
 use rustc_span::MultiSpan;

--- a/prusti-viper/src/encoder/mir/types/mod.rs
+++ b/prusti-viper/src/encoder/mir/types/mod.rs
@@ -5,7 +5,7 @@ mod helpers;
 mod interface;
 
 pub(crate) use self::{
-    helpers::{compute_discriminant_bounds, compute_discriminant_values},
+    helpers::compute_discriminant_bounds,
     interface::{MirTypeEncoderInterface, MirTypeEncoderState},
 };
 

--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -4,10 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-mod downcast_detector;
-mod place_encoding;
-
-use crate::encoder::builtin_encoder::BuiltinFunctionKind;
 use crate::encoder::errors::{
     ErrorCtxt, PanicCause, SpannedEncodingError, EncodingError, WithSpan,
     SpannedEncodingResult, EncodingResult
@@ -21,18 +17,18 @@ use prusti_common::config;
 use rustc_target::abi;
 use rustc_hir::def_id::DefId;
 use rustc_middle::{mir, ty};
-use rustc_index::vec::{Idx, IndexVec};
+use rustc_index::vec::IndexVec;
 use rustc_span::{Span, DUMMY_SP};
 use log::{trace, debug};
-use rustc_hash::{FxHashMap};
-use std::convert::TryInto;
 use prusti_interface::environment::mir_utils::MirPlace;
 use crate::encoder::mir::types::MirTypeEncoderInterface;
-
-pub use place_encoding::{PlaceEncoding, ExprOrArrayBase};
-
 use super::encoder::SubstMap;
 use super::high::types::HighTypeEncoderInterface;
+
+mod downcast_detector;
+mod place_encoding;
+
+pub use place_encoding::{PlaceEncoding, ExprOrArrayBase};
 
 pub static PRECONDITION_LABEL: &str = "pre";
 pub static WAND_LHS_LABEL: &str = "lhs";

--- a/prusti-viper/src/encoder/mir_encoder/place_encoding.rs
+++ b/prusti-viper/src/encoder/mir_encoder/place_encoding.rs
@@ -11,7 +11,6 @@ use rustc_middle::ty;
 use vir_crate::polymorphic as vir;
 
 use crate::encoder::{
-    Encoder,
     errors::{EncodingError, EncodingResult},
 };
 

--- a/prusti-viper/src/encoder/mir_interpreter.rs
+++ b/prusti-viper/src/encoder/mir_interpreter.rs
@@ -12,7 +12,7 @@ use std::iter::FromIterator;
 use std::marker::Sized;
 use log::trace;
 use std::mem;
-use crate::encoder::errors::EncodingError;
+
 
 /// Backward interpreter for a loop-less MIR
 pub trait BackwardMirInterpreter<'tcx> {

--- a/prusti-viper/src/encoder/mirror_function_encoder.rs
+++ b/prusti-viper/src/encoder/mirror_function_encoder.rs
@@ -4,12 +4,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashSet};
 use rustc_hir::def_id::DefId;
-use vir_crate::common::identifier::WithIdentifier;
-use vir_crate::polymorphic::{self as vir, ExprIterator};
-use prusti_interface::environment::borrowck::facts::Loan;
-use crate::encoder::encoder::Encoder;
+
+use vir_crate::polymorphic::{self as vir};
+
+
 
 const MIRROR_DOMAIN_NAME: &str = "MirrorDomain";
 

--- a/prusti-viper/src/encoder/places.rs
+++ b/prusti-viper/src/encoder/places.rs
@@ -7,7 +7,7 @@
 use rustc_middle::mir;
 use rustc_middle::ty::Ty;
 use rustc_index::vec::{Idx, IndexVec};
-use std::{iter, ops};
+use std::{iter};
 
 /// A local variable used as an abstraction over both real Rust MIR local
 /// variables and temporary variables used in encoder.

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5,9 +5,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::encoder::borrows::ProcedureContract;
-use crate::encoder::builtin_encoder::{BuiltinMethodKind, BuiltinFunctionKind};
+use crate::encoder::builtin_encoder::{BuiltinMethodKind};
 use crate::encoder::errors::{
-    SpannedEncodingError, ErrorCtxt, PanicCause, EncodingError, WithSpan,
+    SpannedEncodingError, ErrorCtxt, EncodingError, WithSpan,
     EncodingResult, SpannedEncodingResult
 };
 use crate::encoder::foldunfold;
@@ -22,7 +22,6 @@ use crate::encoder::Encoder;
 use crate::encoder::snapshot::interface::SnapshotEncoderInterface;
 use prusti_common::{
     config,
-    report::log,
     utils::to_string::ToString,
     vir::{ToGraphViz, fixes::fix_ghost_vars},
     vir_local, vir_expr, vir_stmt
@@ -46,30 +45,21 @@ use prusti_interface::{
     },
 };
 use prusti_interface::utils;
-// use prusti_common::report::log;
-// use prusti_interface::specifications::*;
 use rustc_middle::mir::Mutability;
 use rustc_middle::mir;
-use rustc_middle::mir::{TerminatorKind, AssertKind};
-use rustc_middle::ty::{self, layout, layout::IntegerExt, ParamEnv};
+use rustc_middle::mir::{TerminatorKind};
+use rustc_middle::ty::{self, layout::IntegerExt, ParamEnv};
 use rustc_target::abi::Integer;
 use rustc_hir::def_id::LocalDefId;
-use rustc_index::vec::Idx;
-// use rustc_data_structures::indexed_vec::Idx;
-// use std;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_attr::IntType::SignedInt;
-// use syntax::codemap::{MultiSpan, Span};
 use rustc_span::{MultiSpan, Span};
 use prusti_interface::specs::typed;
 use ::log::{trace, debug};
-use std::borrow::Borrow as StdBorrow;
 use prusti_interface::environment::borrowck::regions::PlaceRegionsError;
 use crate::encoder::errors::EncodingErrorKind;
-use crate::encoder::snapshot;
 use std::convert::TryInto;
 use vir_crate::polymorphic::Float;
-use vir_crate::common::expression::ExpressionIterator;
 use crate::utils::is_reference;
 use crate::encoder::mir::pure::PureFunctionEncoderInterface;
 use crate::encoder::mir::types::MirTypeEncoderInterface;

--- a/prusti-viper/src/encoder/purifier.rs
+++ b/prusti-viper/src/encoder/purifier.rs
@@ -5,11 +5,11 @@
 
 use vir_crate::polymorphic::{self as vir, ExprWalker, ExprFolder, StmtWalker, StmtFolder};
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::collections::{BTreeMap, BTreeSet};
+
 use log::{debug, trace};
 use crate::encoder::Encoder;
 use crate::encoder::high::types::HighTypeEncoderInterface;
-use crate::encoder::mir::types::MirTypeEncoderInterface;
+
 use crate::encoder::snapshot::interface::SnapshotEncoderInterface;
 
 use super::encoder::SubstMap;

--- a/prusti-viper/src/encoder/snapshot/decls.rs
+++ b/prusti-viper/src/encoder/snapshot/decls.rs
@@ -5,8 +5,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use rustc_hash::FxHashMap;
-use rustc_middle::ty;
-use vir_crate::polymorphic::{self as vir, Expr, Type};
+
+use vir_crate::polymorphic::{self as vir, Type};
 
 /// Snapshot of a VIR type. This enum is internal to the snapshot encoding and
 /// should not need to be exposed to the encoder in general.

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -5,10 +5,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::encoder::{
-    array_encoder::{EncodedArrayTypes, EncodedSliceTypes},
-    builtin_encoder::BuiltinFunctionKind,
     encoder::{encode_field_name, SubstMap},
-    errors::{EncodingError, EncodingResult, SpannedEncodingResult},
+    errors::{EncodingError, EncodingResult},
     foldunfold,
     high::types::HighTypeEncoderInterface,
     mir::types::MirTypeEncoderInterface,
@@ -16,19 +14,18 @@ use crate::encoder::{
     utils::range_extract,
     Encoder,
 };
-use log::{debug, trace};
+use log::debug;
 use prusti_common::{vir_expr, vir_local};
-use prusti_specs::predicate;
+
 use rustc_hash::FxHashMap;
 use rustc_middle::{ty, ty::layout::IntegerExt};
 use rustc_target::abi::Integer;
-use std::{convert::TryInto, rc::Rc};
+use std::rc::Rc;
 use vir_crate::{
     common::identifier::WithIdentifier,
     polymorphic as vir,
     polymorphic::{
-        ContainerOpKind, EnumVariantIndex, Expr, ExprIterator, FallibleExprFolder,
-        FallibleStmtFolder,
+        ContainerOpKind, Expr, ExprIterator, FallibleExprFolder, FallibleStmtFolder,
         Float::{F32, F64},
         PermAmount, Type,
     },

--- a/prusti-viper/src/encoder/snapshot/interface.rs
+++ b/prusti-viper/src/encoder/snapshot/interface.rs
@@ -2,7 +2,7 @@ use super::encoder::SnapshotEncoder;
 use crate::encoder::{encoder::SubstMap, errors::EncodingResult};
 use rustc_middle::{mir, ty};
 use std::{cell::RefCell, rc::Rc};
-use vir_crate::{high as vir_high, polymorphic as vir_poly};
+use vir_crate::polymorphic as vir_poly;
 
 #[derive(Default)]
 pub(crate) struct SnapshotEncoderState {

--- a/prusti-viper/src/encoder/snapshot/patcher.rs
+++ b/prusti-viper/src/encoder/snapshot/patcher.rs
@@ -8,7 +8,6 @@ use crate::encoder::{
     encoder::SubstMap,
     errors::{EncodingError, EncodingResult},
     high::types::HighTypeEncoderInterface,
-    mir::types::MirTypeEncoderInterface,
     snapshot::encoder::SnapshotEncoder,
     Encoder,
 };

--- a/prusti-viper/src/encoder/spec_function_encoder.rs
+++ b/prusti-viper/src/encoder/spec_function_encoder.rs
@@ -6,18 +6,17 @@ use crate::encoder::mir_encoder::{MirEncoder, PlaceEncoder};
 use crate::encoder::mir::pure::SpecificationEncoderInterface;
 use prusti_interface::{
     environment::{
-        Procedure,
-        Environment
+        Procedure
     },
     data::ProcedureDefId,
     specs::typed,
 };
 use vir_crate::polymorphic as vir;
 use vir_crate::polymorphic::ExprIterator;
-use rustc_middle::{ty, mir};
+use rustc_middle::{mir};
 use rustc_span::Span;
-use log::{debug, trace};
-use rustc_hir as hir;
+
+
 
 use super::encoder::SubstMap;
 

--- a/prusti-viper/src/encoder/specs_closures_collector.rs
+++ b/prusti-viper/src/encoder/specs_closures_collector.rs
@@ -6,7 +6,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use log::{debug, trace};
-use rustc_hir as hir;
+
 use rustc_middle::mir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::ty;

--- a/prusti-viper/src/encoder/stub_function_encoder.rs
+++ b/prusti-viper/src/encoder/stub_function_encoder.rs
@@ -13,11 +13,11 @@ use vir_crate::polymorphic as vir;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir;
 use log::{trace, debug};
-use crate::encoder::errors::SpannedEncodingError;
+
 use crate::encoder::errors::WithSpan;
-use crate::encoder::errors::EncodingResult;
+
 use crate::encoder::errors::SpannedEncodingResult;
-use crate::encoder::mir::types::MirTypeEncoderInterface;
+
 
 use super::encoder::SubstMap;
 

--- a/prusti-viper/src/encoder/stub_procedure_encoder.rs
+++ b/prusti-viper/src/encoder/stub_procedure_encoder.rs
@@ -15,7 +15,7 @@ use prusti_common::report::log;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir;
 use ::log::trace;
-use crate::encoder::mir::types::MirTypeEncoderInterface;
+
 
 pub struct StubProcedureEncoder<'p, 'v: 'p, 'tcx: 'v>
  {

--- a/prusti-viper/src/lib.rs
+++ b/prusti-viper/src/lib.rs
@@ -11,7 +11,6 @@
 #![feature(try_blocks)]
 #![feature(never_type)]
 
-#![allow(unused_imports)]
 #![deny(unused_must_use)]
 #![deny(unreachable_patterns)]
 // #![deny(unused_mut)]
@@ -27,7 +26,6 @@ extern crate rustc_ast;
 extern crate rustc_target;
 extern crate rustc_attr;
 extern crate rustc_data_structures;
-#[macro_use]
 extern crate lazy_static;
 
 pub mod encoder;

--- a/prusti-viper/src/utils/mod.rs
+++ b/prusti-viper/src/utils/mod.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use rustc_middle::ty;
-use rustc_middle::mir;
+
 
 pub mod to_string;
 pub mod type_visitor;

--- a/prusti-viper/src/utils/type_visitor.rs
+++ b/prusti-viper/src/utils/type_visitor.rs
@@ -6,7 +6,7 @@
 
 use rustc_hir::Mutability;
 use rustc_middle::ty::{
-    AdtDef, FieldDef, ParamTy, ProjectionTy, Region, Slice, Ty, TyCtxt,
+    AdtDef, FieldDef, ParamTy, ProjectionTy, Region, Ty, TyCtxt,
     TypeFlags, TyKind, IntTy, UintTy, FloatTy, VariantDef, subst::SubstsRef, Const
 };
 use rustc_hir::def_id::DefId;

--- a/prusti-viper/src/verifier.rs
+++ b/prusti-viper/src/verifier.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use prusti_common::vir::{self, optimizations::optimize_program, ToViper, ToViperDecl};
+use prusti_common::vir::{optimizations::optimize_program};
 use prusti_common::{
     config, report::log, Stopwatch, vir::program::Program,
 };
@@ -16,14 +16,14 @@ use prusti_interface::data::VerificationTask;
 use prusti_interface::environment::Environment;
 use prusti_interface::PrustiError;
 // use prusti_interface::specifications::TypedSpecificationMap;
-use std::time::Instant;
-use viper::{self, PersistentCache, VerificationBackend, Viper};
-use std::path::PathBuf;
-use std::fs;
-use std::ffi::OsString;
+
+use viper::{self, PersistentCache, Viper};
+
+
+
 use prusti_interface::specs::typed;
 use ::log::{info, debug, error};
-use prusti_server::{VerificationRequest, ViperBackendConfig, PrustiClient, process_verification_request_cache, spawn_server_thread};
+use prusti_server::{VerificationRequest, PrustiClient, process_verification_request_cache, spawn_server_thread};
 use rustc_span::DUMMY_SP;
 use prusti_server::tokio::runtime::Builder;
 

--- a/vir/defs/polymorphic/utils.rs
+++ b/vir/defs/polymorphic/utils.rs
@@ -61,40 +61,6 @@ impl Stmt {
     }
 }
 
-/// Substitute (map) old expressions in an expression
-impl Expr {
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn map_old_expr<F>(self, substitutor: F) -> Self
-    where
-        F: Fn(&str, Expr) -> Expr,
-    {
-        trace!("Expr::map_old_expr {}", self);
-        struct ExprOldExprSubstitutor<T>
-        where
-            T: Fn(&str, Expr) -> Expr,
-        {
-            substitutor: T,
-        }
-        impl<T> ExprFolder for ExprOldExprSubstitutor<T>
-        where
-            T: Fn(&str, Expr) -> Expr,
-        {
-            fn fold_labelled_old(
-                &mut self,
-                LabelledOld {
-                    label,
-                    base,
-                    position,
-                }: LabelledOld,
-            ) -> Expr {
-                (self.substitutor)(&label, *base).set_pos(position)
-            }
-        }
-        ExprOldExprSubstitutor { substitutor }.fold(self)
-    }
-}
-
 /// In an expression, substitute labels of old expressions
 impl Expr {
     #[must_use]

--- a/vir/src/legacy/utils.rs
+++ b/vir/src/legacy/utils.rs
@@ -61,33 +61,6 @@ impl Stmt {
     }
 }
 
-/// Substitute (map) old expressions in an expression
-impl Expr {
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn map_old_expr<F>(self, substitutor: F) -> Self
-    where
-        F: Fn(&str, Expr) -> Expr,
-    {
-        trace!("Expr::map_old_expr {}", self);
-        struct ExprOldExprSubstitutor<T>
-        where
-            T: Fn(&str, Expr) -> Expr,
-        {
-            substitutor: T,
-        }
-        impl<T> ExprFolder for ExprOldExprSubstitutor<T>
-        where
-            T: Fn(&str, Expr) -> Expr,
-        {
-            fn fold_labelled_old(&mut self, x: String, y: Box<Expr>, p: Position) -> Expr {
-                (self.substitutor)(&x, *y).set_pos(p)
-            }
-        }
-        ExprOldExprSubstitutor { substitutor }.fold(self)
-    }
-}
-
 /// In an expression, substitute labels of old expressions
 impl Expr {
     #[must_use]


### PR DESCRIPTION
Removes `#![allow(unused_imports)]` and fixes the warnings.