### PR TITLE
Dump viper on cache hit (version 2)

### DIFF
--- a/prusti-launch/tests/test_binaries.rs
+++ b/prusti-launch/tests/test_binaries.rs
@@ -169,7 +169,6 @@ fn test_prusti_rustc_with_server() {
     // Preserve SYSTEMROOT on Windows.
     // See: https://travis-ci.community/t/socket-the-requested-service-provider-could-not-be-loaded-or-initialized/1127
     let mut server_child = Command::new(&prusti_server)
-        .arg("--port=0")
         .env("PRUSTI_LOG", "warn")
         .env("RUST_BACKTRACE", "1")
         .stdout(Stdio::piped())

--- a/prusti-server/src/driver.rs
+++ b/prusti-server/src/driver.rs
@@ -15,7 +15,7 @@ fn main() {
                 .short("p")
                 .long("port")
                 .help("Sets the port on which to listen for incoming verification requests. Pass 0 to get a free one assigned by the OS.")
-                .required(true)
+                .default_value("0")
                 .takes_value(true)
                 .value_name("PORT"),
         )

--- a/prusti-server/src/process_verification.rs
+++ b/prusti-server/src/process_verification.rs
@@ -10,67 +10,70 @@ use prusti_common::{config, report::log::report, vir::ToViper, Stopwatch};
 use std::{fs::create_dir_all, path::PathBuf};
 use viper::{Cache, VerificationBackend, VerificationContext};
 
-pub fn process_verification_request_cache<'v, 't: 'v>(
+pub fn process_verification_request<'v, 't: 'v>(
     verification_context: &'v VerificationContext<'t>,
     request: VerificationRequest,
     cache: impl Cache,
 ) -> viper::VerificationResult {
-    if !config::enable_cache() || config::print_hash() {
-        process_verification_request(verification_context, request)
-    } else {
-        let hash = request.get_hash();
-        info!("Verification request hash: {}", hash);
-        // Try to load from cache and return `result`
-        if let Some(result) = cache.get(hash) {
-            info!("Using verification result from the cache");
-            return result;
-        }
-        let result = process_verification_request(verification_context, request);
-        // Save `result` to cache
-        cache.insert(hash, result.clone());
-        result
-    }
-}
-
-pub fn process_verification_request<'v, 't: 'v>(
-    verification_context: &'v VerificationContext<'t>,
-    request: VerificationRequest,
-) -> viper::VerificationResult {
-    // Print hash of the `VerificationRequest`
-    if config::print_hash() {
-        println!(
-            "Received verification request for: {}",
-            request.program.get_name()
-        );
-        println!("Hash of the request is: {}", request.get_hash());
-        // Skip actual verification
-        if !config::dump_viper_program() {
-            return viper::VerificationResult::Success;
-        }
-    }
-
     let ast_utils = verification_context.new_ast_utils();
     ast_utils.with_local_frame(16, || {
+        let hash = request.get_hash();
+        info!("Verification request hash: {}", hash);
+
+        let build_or_dump_viper_program = || {
+            let mut stopwatch = Stopwatch::start("prusti-server", "construction of JVM objects");
+            let ast_factory = verification_context.new_ast_factory();
+            let viper_program = request.program.to_viper(&ast_factory);
+
+            if config::dump_viper_program() {
+                stopwatch.start_next("dumping viper program");
+                dump_viper_program(&ast_utils, viper_program, request.program.get_name());
+            }
+
+            viper_program
+        };
+
+        // Print the hash and skip verification. Used for testing.
+        if config::print_hash() {
+            println!(
+                "Received verification request for: {}",
+                request.program.get_name()
+            );
+            println!("Hash of the request is: {}", hash);
+            // Some tests need the dump to report a diff of the Viper programs.
+            let _ = build_or_dump_viper_program();
+            return viper::VerificationResult::Success;
+        }
+
+        // Early return in case of cache hit
+        if config::enable_cache() {
+            if let Some(result) = cache.get(hash) {
+                if config::dump_viper_program() {
+                    let _ = build_or_dump_viper_program();
+                }
+                return result;
+            }
+        };
+
+        let viper_program = build_or_dump_viper_program();
+
         // Create a new verifier each time.
         // Workaround for https://github.com/viperproject/prusti-dev/issues/744
         let mut stopwatch = Stopwatch::start("prusti-server", "verifier startup");
         let verifier = new_viper_verifier(verification_context, request.backend_config);
-        stopwatch.start_next("construction of JVM objects");
-        let ast_factory = verification_context.new_ast_factory();
-        let viper_program = request.program.to_viper(&ast_factory);
-        if config::dump_viper_program() {
-            stopwatch.start_next("dumping viper program");
-            dump_program(&ast_utils, viper_program, request.program.get_name());
-            if config::print_hash() {
-                return viper::VerificationResult::Success;
-            }
-        }
+
         stopwatch.start_next("verification");
-        verifier.verify(viper_program)
+        let result = verifier.verify(viper_program);
+
+        if config::enable_cache() {
+            cache.insert(hash, result.clone());
+        }
+
+        result
     })
 }
 
-fn dump_program(ast_utils: &viper::AstUtils, program: viper::Program, program_name: &str) {
+fn dump_viper_program(ast_utils: &viper::AstUtils, program: viper::Program, program_name: &str) {
     let namespace = "viper_program";
     let filename = format!("{}.vpr", program_name);
     info!("Dumping Viper program to '{}/{}'", namespace, filename);

--- a/prusti-server/src/server.rs
+++ b/prusti-server/src/server.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{process_verification_request_cache, VerificationRequest};
+use crate::{process_verification_request, VerificationRequest};
 use log::info;
 use prusti_common::{config, Stopwatch};
 use std::{
@@ -61,7 +61,7 @@ where
             let stopwatch = Stopwatch::start("prusti-server", "attach thread to JVM");
             let viper_thread = viper_arc.attach_current_thread();
             stopwatch.finish();
-            process_verification_request_cache(&viper_thread, request, &cache)
+            process_verification_request(&viper_thread, request, &cache)
         }
     };
 

--- a/prusti-viper/src/verifier.rs
+++ b/prusti-viper/src/verifier.rs
@@ -23,7 +23,7 @@ use viper::{self, PersistentCache, Viper};
 
 use prusti_interface::specs::typed;
 use ::log::{info, debug, error};
-use prusti_server::{VerificationRequest, PrustiClient, process_verification_request_cache, spawn_server_thread};
+use prusti_server::{VerificationRequest, PrustiClient, process_verification_request, spawn_server_thread};
 use rustc_span::DUMMY_SP;
 use prusti_server::tokio::runtime::Builder;
 
@@ -422,7 +422,7 @@ fn verify_programs(env: &Environment, programs: Vec<Program>)
         stopwatch.finish();
         let mut cache = PersistentCache::load_cache(config::cache_path());
         verification_requests.map(|(program_name, request)| {
-            let result = process_verification_request_cache(&viper_thread, request, &mut cache);
+            let result = process_verification_request(&viper_thread, request, &mut cache);
             (program_name, result)
         }).collect()
     }


### PR DESCRIPTION
Fixes https://github.com/viperproject/prusti-dev/issues/843.

An alternative to https://github.com/viperproject/prusti-dev/pull/845.