### PR TITLE
add support for array/slice accesses in quantifier triggers

### DIFF
--- a/prusti-tests/tests/verify/fail/simple-specs/panic-in-post.rs
+++ b/prusti-tests/tests/verify/fail/simple-specs/panic-in-post.rs
@@ -1,0 +1,16 @@
+use prusti_contracts::*;
+
+#[requires(x != 0)]
+#[ensures({
+    assert!(x != 0); // OK
+    true
+})]
+fn good(x: u32) {}
+
+#[ensures({
+    assert!(x != 0); //~ ERROR postcondition might not hold
+    true
+})]
+fn bad(x: u32) {}
+
+fn main() {}

--- a/prusti-tests/tests/verify/fail/simple-specs/panic-in-pre.rs
+++ b/prusti-tests/tests/verify/fail/simple-specs/panic-in-pre.rs
@@ -1,0 +1,18 @@
+use prusti_contracts::*;
+
+#[requires({
+    assert!(x != 0);
+    true
+})]
+fn foo(x: u32) {
+    assert!(x != 0); // OK
+    assert!(false);  //~ ERROR the asserted expression might not hold
+}
+
+fn bad(x: u32) {
+    foo(x); //~ ERROR precondition might not hold
+}
+
+fn main() {
+    foo(1); // OK
+}

--- a/prusti-tests/tests/verify/pass/issues/issue-812-1.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-812-1.rs
@@ -1,0 +1,6 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+#[requires(forall(|i: usize| (0 <= i && i < slice.len()) ==> (slice[i] > 10), triggers=[(slice[i],)]))]
+fn test(slice: &[i32]) {}

--- a/prusti-tests/tests/verify/pass/issues/issue-812-2.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-812-2.rs
@@ -1,0 +1,6 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+#[requires(forall(|i: usize| (0 <= i && i < array.len()) ==> (array[i] > 10), triggers=[(array[i],)]))]
+fn test(array: &[i32; 10]) {}

--- a/prusti-tests/tests/verify/pass/issues/issue-812-3.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-812-3.rs
@@ -1,0 +1,17 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+#[requires(forall(|i: usize| (0 <= i && i < slice.len()) ==> (bar(slice[i])), triggers=[(bar(slice[i]),(slice.len()),)]))]
+fn foo(slice: &[i32]) {}
+
+#[pure]
+#[trusted]
+fn bar(a: i32) -> bool { true }
+
+#[requires(slice.len() == 1)]
+fn baz(slice: &[i32]) {
+    if bar(slice[0]) {
+        foo(slice);
+    }
+}

--- a/prusti-tests/tests/verify/pass/issues/issue-812-4.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-812-4.rs
@@ -1,0 +1,18 @@
+// ignore-test
+// FIXME: this test passes for the original encoder, but it fails on a todo!() in the new vir high encoder
+// FIXME: see https://github.com/viperproject/prusti-dev/issues/812
+
+use prusti_contracts::*;
+
+fn main() {}
+
+#[pure]
+#[requires(forall(|i: usize| (0 <= i && i < slice.len()) ==> (slice[i] > 10), triggers=[(slice[i],slice.len(),baz(slice))]))]
+fn foo(slice: &[i32]) {}
+
+#[requires(forall(|i: usize| (0 <= i && i < array.len()) ==> (array[i] > 10), triggers=[(array[i],array.len(),baz(array),)]))]
+fn bar(array: &[i32; 10]) {}
+
+#[pure]
+#[trusted]
+fn baz(slice: &[i32]) {}

--- a/prusti-viper/src/encoder/mir/pure/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/mod.rs
@@ -4,7 +4,8 @@ mod specifications;
 
 pub(crate) use self::{
     pure_functions::{
-        PureFunctionBackwardInterpreter, PureFunctionEncoderInterface, PureFunctionEncoderState,
+        PureEncodingContext, PureFunctionBackwardInterpreter, PureFunctionEncoderInterface,
+        PureFunctionEncoderState,
     },
     specifications::SpecificationEncoderInterface,
 };

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -10,7 +10,7 @@ use crate::encoder::{
     encoder::SubstMap,
     errors::{ErrorCtxt, SpannedEncodingError, SpannedEncodingResult, WithSpan},
     high::{generics::HighGenericsEncoderInterface, types::HighTypeEncoderInterface},
-    mir::pure::SpecificationEncoderInterface,
+    mir::pure::{PureEncodingContext, SpecificationEncoderInterface},
     mir_encoder::PlaceEncoder,
     mir_interpreter::run_backward_interpretation,
     snapshot::interface::SnapshotEncoderInterface,
@@ -45,7 +45,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         encoder: &'p Encoder<'v, 'tcx>,
         proc_def_id: DefId,
         mir: &'p mir::Body<'tcx>,
-        is_encoding_assertion: bool,
+        pure_encoding_context: PureEncodingContext,
         parent_def_id: DefId,
         tymap: &'p SubstMap<'tcx>,
     ) -> Self {
@@ -54,7 +54,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             encoder,
             mir,
             proc_def_id,
-            is_encoding_assertion,
+            pure_encoding_context,
             parent_def_id,
             tymap.clone(),
         );

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -77,7 +77,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             .unwrap_or_else(|| panic!("Procedure {:?} contains a loop", self.proc_def_id));
         let body_expr = state.into_expr().unwrap();
         debug!(
-            "Pure function {} has been encoded with expr: {}",
+            "Pure function body {} has been encoded with expr: {}",
             function_name, body_expr
         );
         let substs = &self

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -184,7 +184,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 self,
                 proc_def_id,
                 procedure.get_mir(),
-                true,
+                false, // quantifier triggers might not evaluate to boolean
                 parent_def_id,
                 substs,
             );

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -22,6 +22,26 @@ type FunctionConstructor<'v, 'tcx> = Box<
     ) -> SpannedEncodingResult<vir_high::FunctionDecl>,
 >;
 
+/// Depending on the context of the pure encoding,
+/// panics will be encoded slightly differently.
+#[derive(PartialEq, Eq)]
+pub(crate) enum PureEncodingContext {
+    /// Panics will be encoded as calls to unreachable functions
+    /// (which have a `requires false` pre-condition).
+    Code,
+    /// Indicates that a panic should be encoded to a `false` boolean value.
+    /// This flag is used to distinguish whether an assert terminators generated e.g. for an
+    /// integer overflow should be translated into `false` and when to an "unreachable" function
+    /// call with a `false` precondition.
+    Assertion,
+    /// Whether the current pure expression that's being encoded sits inside a trigger closure.
+    /// Viper limits the type of expressions that are allowed in quantifier triggers and
+    /// this requires special care when encoding array/slice accesses which may come with
+    /// bound checks included in the MIR. For this purpose, paths that might panic will
+    /// be stripped away during the trigger encoding.
+    Trigger,
+}
+
 #[derive(Default)]
 pub(crate) struct PureFunctionEncoderState<'v, 'tcx: 'v> {
     bodies_high: RefCell<FxHashMap<Key, vir_high::Expression>>,
@@ -184,8 +204,12 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 self,
                 proc_def_id,
                 procedure.get_mir(),
-                // quantifier triggers might not evaluate to boolean
-                !self.is_encoding_trigger.get(),
+                if self.is_encoding_trigger.get() {
+                    // quantifier triggers might not evaluate to boolean
+                    PureEncodingContext::Trigger
+                } else {
+                    PureEncodingContext::Assertion
+                },
                 parent_def_id,
                 substs,
             );
@@ -242,7 +266,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 self,
                 proc_def_id,
                 procedure.get_mir(),
-                false,
+                PureEncodingContext::Code,
                 proc_def_id,
                 substs,
             );
@@ -367,7 +391,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 self,
                 proc_def_id,
                 procedure.get_mir(),
-                false,
+                PureEncodingContext::Code,
                 parent_def_id,
                 substs,
             );

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -184,7 +184,8 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 self,
                 proc_def_id,
                 procedure.get_mir(),
-                false, // quantifier triggers might not evaluate to boolean
+                // quantifier triggers might not evaluate to boolean
+                !self.is_encoding_trigger.get(),
                 parent_def_id,
                 substs,
             );

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -732,7 +732,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 match self.pure_encoding_context {
                     PureEncodingContext::Trigger => {
                         // We are encoding a trigger, so all panic branches must be stripped.
-                        ExprBackwardInterpreterState::new(None)
+                        states[target].clone()
                     }
                     PureEncodingContext::Assertion => {
                         // We are encoding an assertion, so all failures should be equivalent to false.
@@ -762,20 +762,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                         ))
                     }
                 }
-
-                //     let failure_encoding = if self.encode_panic_to_false == PureEncodingContext::Assertion {
-                //         // TODO PB
-                //         // We are encoding an assertion, so all failures should be equivalent to false.
-                //         debug_assert!(matches!(self.mir.return_ty().kind(), ty::TyKind::Bool));
-                //         false.into()
-                //     } else {
-                //         // We are encoding a pure function, so all failures should be unreachable.
-                //         unreachable_expr(pos).with_span(term.source_info.span)?
-                //     };
-
-                //     ExprBackwardInterpreterState::new(states[target].expr().map(|target_expr| {
-                //         vir::Expr::ite(viper_guard.clone(), target_expr.clone(), failure_encoding)
-                //     }))
             }
 
             TerminatorKind::Yield { .. }

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -11,7 +11,8 @@ use crate::encoder::{
         generics::HighGenericsEncoderInterface, types::HighTypeEncoderInterface,
     },
     mir::{
-        generics::MirGenericsEncoderInterface, pure::specifications::SpecificationEncoderInterface,
+        generics::MirGenericsEncoderInterface,
+        pure::{specifications::SpecificationEncoderInterface, PureEncodingContext},
         types::MirTypeEncoderInterface,
     },
     mir_encoder::{MirEncoder, PlaceEncoder, PlaceEncoding, PRECONDITION_LABEL, WAND_LHS_LABEL},
@@ -36,11 +37,8 @@ pub(crate) struct PureFunctionBackwardInterpreter<'p, 'v: 'p, 'tcx: 'v> {
     mir: &'p mir::Body<'tcx>,
     /// MirEncoder of the pure function being encoded.
     mir_encoder: MirEncoder<'p, 'v, 'tcx>,
-    /// True if a panic should be encoded to a `false` boolean value.
-    /// This flag is used to distinguish whether an assert terminators generated e.g. for an
-    /// integer overflow should be translated into `false` and when to an "unreachable" function
-    /// call with a `false` precondition.
-    encode_panic_to_false: bool,
+    /// How panics are handled depending on the encoding context.
+    pure_encoding_context: PureEncodingContext,
     /// DefId of the caller. Used for error reporting.
     caller_def_id: DefId,
     tymap: SubstMap<'tcx>,
@@ -54,7 +52,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
         encoder: &'p Encoder<'v, 'tcx>,
         mir: &'p mir::Body<'tcx>,
         def_id: DefId,
-        encode_panic_to_false: bool,
+        pure_encoding_context: PureEncodingContext,
         caller_def_id: DefId,
         tymap: SubstMap<'tcx>,
     ) -> Self {
@@ -62,7 +60,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
             encoder,
             mir,
             mir_encoder: MirEncoder::new(encoder, mir, def_id),
-            encode_panic_to_false,
+            pure_encoding_context,
             caller_def_id,
             tymap,
         }
@@ -731,18 +729,53 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     self.caller_def_id,
                 );
 
-                let failure_encoding = if self.encode_panic_to_false {
-                    // We are encoding an assertion, so all failures should be equivalent to false.
-                    debug_assert!(matches!(self.mir.return_ty().kind(), ty::TyKind::Bool));
-                    false.into()
-                } else {
-                    // We are encoding a pure function, so all failures should be unreachable.
-                    unreachable_expr(pos).with_span(term.source_info.span)?
-                };
+                match self.pure_encoding_context {
+                    PureEncodingContext::Trigger => {
+                        // We are encoding a trigger, so all panic branches must be stripped.
+                        ExprBackwardInterpreterState::new(None)
+                    }
+                    PureEncodingContext::Assertion => {
+                        // We are encoding an assertion, so all failures should be equivalent to false.
+                        debug_assert!(matches!(self.mir.return_ty().kind(), ty::TyKind::Bool));
+                        ExprBackwardInterpreterState::new(states[target].expr().map(
+                            |target_expr| {
+                                vir::Expr::ite(
+                                    viper_guard.clone(),
+                                    target_expr.clone(),
+                                    false.into(),
+                                )
+                            },
+                        ))
+                    }
+                    PureEncodingContext::Code => {
+                        // We are encoding a pure function, so all failures should be unreachable.
+                        let failure_encoding =
+                            unreachable_expr(pos).with_span(term.source_info.span)?;
+                        ExprBackwardInterpreterState::new(states[target].expr().map(
+                            |target_expr| {
+                                vir::Expr::ite(
+                                    viper_guard.clone(),
+                                    target_expr.clone(),
+                                    failure_encoding,
+                                )
+                            },
+                        ))
+                    }
+                }
 
-                ExprBackwardInterpreterState::new(states[target].expr().map(|target_expr| {
-                    vir::Expr::ite(viper_guard.clone(), target_expr.clone(), failure_encoding)
-                }))
+                //     let failure_encoding = if self.encode_panic_to_false == PureEncodingContext::Assertion {
+                //         // TODO PB
+                //         // We are encoding an assertion, so all failures should be equivalent to false.
+                //         debug_assert!(matches!(self.mir.return_ty().kind(), ty::TyKind::Bool));
+                //         false.into()
+                //     } else {
+                //         // We are encoding a pure function, so all failures should be unreachable.
+                //         unreachable_expr(pos).with_span(term.source_info.span)?
+                //     };
+
+                //     ExprBackwardInterpreterState::new(states[target].expr().map(|target_expr| {
+                //         vir::Expr::ite(viper_guard.clone(), target_expr.clone(), failure_encoding)
+                //     }))
             }
 
             TerminatorKind::Yield { .. }

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/mod.rs
@@ -5,5 +5,7 @@ mod interface;
 mod interpreter;
 mod new_encoder;
 
-pub(crate) use interface::{PureFunctionEncoderInterface, PureFunctionEncoderState};
+pub(crate) use interface::{
+    PureEncodingContext, PureFunctionEncoderInterface, PureFunctionEncoderState,
+};
 pub(crate) use interpreter::PureFunctionBackwardInterpreter;

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -176,7 +176,7 @@ pub(super) fn encode_quantifier<'tcx>(
                 tymap,
             );
             encoder.is_encoding_trigger.set(false);
-            let encoded_trigger = match encoded_trigger_result? {
+            let encoded_trigger = encoded_trigger_result?;/* {
                 // slice/array accesses are encoded with bound checks which need to be stripped for triggers
                 vir_crate::polymorphic::Expr::Cond(vir_crate::polymorphic::Cond {
                     then_expr:
@@ -204,7 +204,7 @@ pub(super) fn encode_quantifier<'tcx>(
                     ..
                 }) if function_name.starts_with("builtin$unreach") => then_expr,
                 encoded_trigger => encoded_trigger,
-            };
+            };*/
             check_trigger(&encoded_trigger).with_span(trigger_span)?;
             encoded_triggers.push(encoded_trigger);
             set_spans.push(trigger_span);

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -176,35 +176,15 @@ pub(super) fn encode_quantifier<'tcx>(
                 tymap,
             );
             encoder.is_encoding_trigger.set(false);
-            let encoded_trigger = encoded_trigger_result?;/* {
-                // slice/array accesses are encoded with bound checks which need to be stripped for triggers
-                vir_crate::polymorphic::Expr::Cond(vir_crate::polymorphic::Cond {
-                    then_expr:
-                        box vir_crate::polymorphic::Expr::Field(vir_crate::polymorphic::FieldExpr {
-                            base: box base @ vir_crate::polymorphic::Expr::DomainFuncApp(..),
-                            ..
-                        }),
-                    else_expr:
-                        box ref _else_expr @ vir_crate::polymorphic::Expr::FuncApp(
-                            vir_crate::polymorphic::FuncApp {
-                                ref function_name, ..
-                            },
-                        ),
+            let encoded_trigger = match encoded_trigger_result? {
+                // slice accesses are encoded like `read$Snap(arg).val_X`, but for triggers we
+                // need to strip the field because these are never accessed in snap expressions.
+                vir_crate::polymorphic::Expr::Field(vir_crate::polymorphic::FieldExpr {
+                    base: box base @ vir_crate::polymorphic::Expr::DomainFuncApp(..),
                     ..
-                }) if function_name.starts_with("builtin$unreach") => base,
-                // slice/array accesses nested in functions also need their outer bound checks removed
-                vir_crate::polymorphic::Expr::Cond(vir_crate::polymorphic::Cond {
-                    then_expr: box then_expr @ vir_crate::polymorphic::Expr::FuncApp(..),
-                    else_expr:
-                        box ref _else_expr @ vir_crate::polymorphic::Expr::FuncApp(
-                            vir_crate::polymorphic::FuncApp {
-                                ref function_name, ..
-                            },
-                        ),
-                    ..
-                }) if function_name.starts_with("builtin$unreach") => then_expr,
+                }) => base,
                 encoded_trigger => encoded_trigger,
-            };*/
+            };
             check_trigger(&encoded_trigger).with_span(trigger_span)?;
             encoded_triggers.push(encoded_trigger);
             set_spans.push(trigger_span);

--- a/prusti-viper/src/encoder/mir/pure/specifications/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/interface.rs
@@ -12,7 +12,7 @@ use crate::encoder::{
             encoder_high::{encode_quantifier_high, inline_spec_item_high},
             encoder_poly::{encode_quantifier, inline_closure, inline_spec_item},
         },
-        PureFunctionBackwardInterpreter,
+        PureEncodingContext, PureFunctionBackwardInterpreter,
     },
     mir_encoder::{MirEncoder, PlaceEncoder, PRECONDITION_LABEL},
     mir_interpreter::{run_backward_interpretation_point_to_point, ExprBackwardInterpreterState},
@@ -257,7 +257,7 @@ impl<'v, 'tcx: 'v> SpecificationEncoderInterface<'tcx> for crate::encoder::Encod
             self,
             mir,
             parent_def_id,
-            false,
+            PureEncodingContext::Code,
             parent_def_id,
             tymap.clone(),
         );


### PR DESCRIPTION
This PR adds support for using slice/array access in quantifier triggers (issue #812). These are encoded including bound checks, but the bound checks are not needed (nor allowed) inside the triggers. The fix/hack applied here removes those bound checks from the triggers.

This seems to fix the encoding problem, but it doesn't appear to be a full solution for `prusti-tests/tests/verify/pass/arrays/selection_sort.rs` (see #819). If I replace all the triggers there with direct array accesses (but not the lookup and the assignment statements in the loop body wrapped in `get`/`set`), then the verification time for this test jumps from 1 minute to 4 minutes on my PC. If I also replace the lookup and assign statements in the loop bodies with direct array accesses, then the verification times out. I suspect this is a matter of adding a few dummy assert statements here and there, but as long as #796 hasn't landed yet this does not seem to improve the situation (it still times out, even with dummy assertions atm). I tried adding `body_invariant`s instead of assert statements, but this also still results in timeouts. For these reasons, I decided not to include the updated version of `selection_sort.rs`. Using a custom pure lookup function such as `get` still yields superior performance over interactions with `lookup_pure` array/slice accesses, even with the fix from this PR, unfortunately :)

The test `prusti-tests/tests/verify/pass/issues/issue-812-4.rs` is currently ignored because it triggers a `todo!()` in the new vir high encoder here:

https://github.com/viperproject/prusti-dev/blob/66c90d5dae9040eb68b2f0d2689faa480b10e8d6/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs#L26-L35

I included the test anyway so that it can be enabled later when that part is implemented during the refactoring.

I'd like to investigate deeper what is the best way to trigger the quantifiers (which are snap encoded) from a Viper method body (where Rust statements are not snap encoded, unless routed through a pure Rust function), but I thought I'd first do a check-in first to see if the proposed fix is heading in the right direction and inquire about if there are any other alternatives than #796 or custom pure lookup functions to work-around the performance issues that seem to be caused by the mixed snap/non-snap encoding :) 

Thanks!



