### PR TITLE
Support None states when encoding pure expressions

### DIFF
--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -383,25 +383,24 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
 
         trace!("cfg_targets: {:?}", cfg_targets);
 
-        let final_expr = states[&refined_default_target].expr().map(|default_expr| {
-            cfg_targets
-                .iter()
-                .map(|(guard, target)|
-                    // If the default target is defined, all targets should be defined.
-                    (guard, states[target].expr().unwrap()))
-                .fold(default_expr.clone(), |else_expr, (guard, then_expr)| {
-                    if then_expr == &else_expr {
-                        // Optimization
-                        else_expr
+        let mut final_expr = states[&refined_default_target].expr().cloned();
+        for (guard, target) in cfg_targets.into_iter() {
+            if let Some(then_expr) = states[&target].expr() {
+                final_expr = Some(
+                    if let Some(else_expr) = final_expr {
+                        if then_expr == &else_expr {
+                            // Optimization
+                            else_expr
+                        } else {
+                            vir_high::Expression::conditional_no_pos(guard, then_expr.clone(), else_expr)
+                        }
                     } else {
-                        vir_high::Expression::conditional_no_pos(
-                            guard.clone(),
-                            then_expr.clone(),
-                            else_expr,
-                        )
+                        // Define `final_expr` for the first time
+                        then_expr.clone()
                     }
-                })
-        });
+                );
+            }
+        }
 
         Ok(ExprBackwardInterpreterState::new(final_expr))
     }

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -386,19 +386,21 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
         let mut final_expr = states[&refined_default_target].expr().cloned();
         for (guard, target) in cfg_targets.into_iter() {
             if let Some(then_expr) = states[&target].expr() {
-                final_expr = Some(
-                    if let Some(else_expr) = final_expr {
-                        if then_expr == &else_expr {
-                            // Optimization
-                            else_expr
-                        } else {
-                            vir_high::Expression::conditional_no_pos(guard, then_expr.clone(), else_expr)
-                        }
+                final_expr = Some(if let Some(else_expr) = final_expr {
+                    if then_expr == &else_expr {
+                        // Optimization
+                        else_expr
                     } else {
-                        // Define `final_expr` for the first time
-                        then_expr.clone()
+                        vir_high::Expression::conditional_no_pos(
+                            guard,
+                            then_expr.clone(),
+                            else_expr,
+                        )
                     }
-                );
+                } else {
+                    // Define `final_expr` for the first time
+                    then_expr.clone()
+                });
             }
         }
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -378,21 +378,25 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
                 trace!("cfg_targets: {:?}", cfg_targets);
 
-                let final_expr = states[&refined_default_target].expr().map(|default_expr| {
-                    cfg_targets
-                        .iter()
-                        .map(|(guard, target)|
-                            // If the default target is defined, all targets should be defined.
-                            (guard, states[target].expr().unwrap()))
-                        .fold(default_expr.clone(), |else_expr, (guard, then_expr)| {
-                            if then_expr == &else_expr {
-                                // Optimization
-                                else_expr
+                let mut final_expr =
+                    states[&refined_default_target].expr().cloned();
+                for (guard, target) in cfg_targets.into_iter() {
+                    if let Some(then_expr) = states[&target].expr() {
+                        final_expr = Some(
+                            if let Some(else_expr) = final_expr {
+                                if then_expr == &else_expr {
+                                    // Optimization
+                                    else_expr
+                                } else {
+                                    vir::Expr::ite(guard, then_expr.clone(), else_expr)
+                                }
                             } else {
-                                vir::Expr::ite(guard.clone(), then_expr.clone(), else_expr)
+                                // Define `final_expr` for the first time
+                                then_expr.clone()
                             }
-                        })
-                });
+                        );
+                    }
+                }
                 ExprBackwardInterpreterState::new(final_expr)
             }
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -378,23 +378,20 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
                 trace!("cfg_targets: {:?}", cfg_targets);
 
-                let mut final_expr =
-                    states[&refined_default_target].expr().cloned();
+                let mut final_expr = states[&refined_default_target].expr().cloned();
                 for (guard, target) in cfg_targets.into_iter() {
                     if let Some(then_expr) = states[&target].expr() {
-                        final_expr = Some(
-                            if let Some(else_expr) = final_expr {
-                                if then_expr == &else_expr {
-                                    // Optimization
-                                    else_expr
-                                } else {
-                                    vir::Expr::ite(guard, then_expr.clone(), else_expr)
-                                }
+                        final_expr = Some(if let Some(else_expr) = final_expr {
+                            if then_expr == &else_expr {
+                                // Optimization
+                                else_expr
                             } else {
-                                // Define `final_expr` for the first time
-                                then_expr.clone()
+                                vir::Expr::ite(guard, then_expr.clone(), else_expr)
                             }
-                        );
+                        } else {
+                            // Define `final_expr` for the first time
+                            then_expr.clone()
+                        });
                     }
                 }
                 ExprBackwardInterpreterState::new(final_expr)


### PR DESCRIPTION
This PR implements "step 2" of the changes described [here](https://github.com/viperproject/prusti-dev/pull/858#issuecomment-1039062725) to avoid the pattern matching of #858. It also avoids a `guard.clone()`.