### PR TITLE
Make internal errors user-friendly

### DIFF
--- a/prusti-interface/src/prusti_error.rs
+++ b/prusti-interface/src/prusti_error.rs
@@ -104,8 +104,14 @@ impl PrustiError {
     pub fn internal<S: ToString>(message: S, span: MultiSpan) -> Self {
         check_message(message.to_string());
         PrustiError::new(
-            format!("[Prusti internal error] {}", message.to_string()),
+            "[Prusti internal error] Prusti encountered an unexpected internal error".to_string(),
             span
+        ).add_note(
+            "We would appreciate a bug report: https://github.com/viperproject/prusti-dev/issues/new",
+            None
+        ).add_note(
+            format!("Details: {}", message.to_string()),
+            None
         )
     }
 

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-416.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-416.rs
@@ -7,7 +7,10 @@ pub struct SafeVec<T>(Vec<T>);
 impl<T> SafeVec<T> {
     #[pure]
     // FIXME: The error is tracked in https://github.com/viperproject/prusti-dev/issues/683
-    pub unsafe fn get_unchecked_1(&self, idx: usize) -> &T //~ ERROR cannot generate fold-unfold Viper statements
+    pub unsafe fn get_unchecked_1(&self, idx: usize) -> &T
+    //~^ ERROR Prusti encountered an unexpected internal error
+    //~| NOTE We would appreciate a bug report
+    //~| NOTE cannot generate fold-unfold Viper statements
     {
         self.0.get_unchecked(idx) //~ ERROR use of impure function
     }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-416.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-416.rs
@@ -7,11 +7,10 @@ pub struct SafeVec<T>(Vec<T>);
 impl<T> SafeVec<T> {
     #[pure]
     // FIXME: The error is tracked in https://github.com/viperproject/prusti-dev/issues/683
-    pub unsafe fn get_unchecked_1(&self, idx: usize) -> &T
-    //~^ ERROR Prusti encountered an unexpected internal error
-    //~| NOTE We would appreciate a bug report
-    //~| NOTE cannot generate fold-unfold Viper statements
-    {
+    pub unsafe fn get_unchecked_1(&self, idx: usize) -> &T {
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         self.0.get_unchecked(idx) //~ ERROR use of impure function
     }
 

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-10.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-10.rs
@@ -13,7 +13,9 @@ impl B {
     /// Mutably reference an ADT within a slice
     #[requires(index < self.inner.len())]
     pub fn get_mut(&mut self, index: usize) -> &mut A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         &mut self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-11.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-11.rs
@@ -15,7 +15,9 @@ impl B {
     /// Obtain a shared reference to an ADT within a slice
     #[requires(index < self.inner.len())]
     pub fn get(&self, index: usize) -> &A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         &self.inner[index]
     }
 
@@ -23,7 +25,9 @@ impl B {
     #[pure]
     #[requires(index < self.inner.len())]
     pub const fn get_pure(&self, index: usize) -> &A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         &self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-12.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-12.rs
@@ -16,7 +16,9 @@ impl B {
 }
 
 pub fn test(b: &mut B) {
-    //~^ ERROR cannot generate fold-unfold Viper statements
+    //~^ ERROR Prusti encountered an unexpected internal error
+    //~| NOTE We would appreciate a bug report
+    //~| NOTE cannot generate fold-unfold Viper statements
     b.get_mut(1)[0] = A(1);
 }
 

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-2.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-2.rs
@@ -11,7 +11,9 @@ impl B {
     /// Lookup an ADT from an array
     #[requires(index < self.0.len())]
     pub const fn get(&self, index: usize) -> A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        ///~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         self.0[index]
     }
 
@@ -19,7 +21,9 @@ impl B {
     #[pure]
     #[requires(index < self.0.len())]
     pub const fn get_pure(&self, index: usize) -> A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        ///~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-3.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-3.rs
@@ -1,4 +1,6 @@
-//~ ERROR Consistency error: expected the same type, but got Snap$struct$m_A and Ref
+//~ ERROR Prusti encountered an unexpected internal error
+//~| NOTE We would appreciate a bug report
+//~| NOTE Consistency error: expected the same type, but got Snap$struct$m_A and Ref
 extern crate prusti_contracts;
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-4.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-4.rs
@@ -11,7 +11,9 @@ impl B {
     /// Mutably reference an ADT within an array
     #[requires(index < self.0.len())]
     pub fn get_mut(&mut self, index: usize) -> &mut A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         &mut self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-5.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-5.rs
@@ -11,7 +11,9 @@ impl B {
     /// Obtain a shared reference an ADT within an array
     #[requires(index < self.0.len())]
     pub const fn get(&self, index: usize) -> &A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         &self.0[index]
     }
 
@@ -19,7 +21,9 @@ impl B {
     #[pure]
     #[requires(index < self.0.len())]
     pub const fn get_pure(&self, index: usize) -> &A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         &self.0[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-6.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-6.rs
@@ -1,4 +1,6 @@
-//~ ERROR consistency error in issue_709_6::B::new: Consistency error: expected the same type, but got Snap$struct$m_A and Ref
+//~ ERROR Prusti encountered an unexpected internal error
+//~| NOTE We would appreciate a bug report
+//~| NOTE consistency error in issue_709_6::B::new: Consistency error: expected the same type, but got Snap$struct$m_A and Ref
 extern crate prusti_contracts;
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-8.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-8.rs
@@ -17,7 +17,9 @@ impl B {
     /// Lookup an ADT from a slice
     #[requires(index < self.len())]
     pub const fn get(&self, index: usize) -> A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         self.inner[index]
     }
 
@@ -25,7 +27,9 @@ impl B {
     #[pure]
     #[requires(index < self.len())]
     pub const fn get_pure(&self, index: usize) -> A {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         self.inner[index]
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-709-9.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-709-9.rs
@@ -17,7 +17,9 @@ impl B {
     /// Assign an ADT to a slice element directly
     #[requires(index < self.len())]
     pub fn set(&mut self, index: usize, a: A) {
-        //~^ ERROR cannot generate fold-unfold Viper statements
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE cannot generate fold-unfold Viper statements
         self.inner[index] = a;
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-718-1.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-718-1.rs
@@ -14,7 +14,10 @@ impl B {
     #[pure]
     // FIXME: https://github.com/viperproject/prusti-dev/issues/718
     pub const fn len(&self) -> usize {
-        //~^ ERROR unhandled verification error
+        //~^ ERROR Prusti encountered an unexpected internal error
+        //~| NOTE We would appreciate a bug report
+        //~| NOTE unhandled verification error
+        //~| NOTE the failing assertion is here
         self.inner.len()
     }
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-769.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-769.rs
@@ -23,8 +23,9 @@ fn fib(n: i32) -> i32 {
     1 => 1,
     _ => fib2(n - 1) + fib2(n - 2),
 })]
-fn fib2(n: i32) -> i32 {    //~ ERROR: only trusted functions can call themselves in their contracts
-    //~^ ERROR: Prusti encountered an unexpected internal error
+fn fib2(n: i32) -> i32 {
+    //~^ ERROR: only trusted functions can call themselves in their contracts
+    //~^^ ERROR: Prusti encountered an unexpected internal error
     //~| NOTE: We would appreciate a bug report
     //~| NOTE: Rust function m_fib2 encoded both as a Viper method and function
     match n {

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-769.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-769.rs
@@ -24,7 +24,9 @@ fn fib(n: i32) -> i32 {
     _ => fib2(n - 1) + fib2(n - 2),
 })]
 fn fib2(n: i32) -> i32 {    //~ ERROR: only trusted functions can call themselves in their contracts
-    //~^ ERROR: Rust function m_fib2 encoded both as a Viper method and function
+    //~^ ERROR: Prusti encountered an unexpected internal error
+    //~| NOTE: We would appreciate a bug report
+    //~| NOTE: Rust function m_fib2 encoded both as a Viper method and function
     match n {
         0 => 0,
         1 => 1,

--- a/prusti-tests/tests/verify_partial/fail/nested-pure-fn.rs
+++ b/prusti-tests/tests/verify_partial/fail/nested-pure-fn.rs
@@ -2,7 +2,7 @@ extern crate prusti_contracts;
 use prusti_contracts::*;
 
 struct Struct {
-  field: u32
+    field: u32,
 }
 
 #[pure]
@@ -23,4 +23,4 @@ fn pred(m: &Struct) -> bool {
     //~| NOTE: There is no procedure contract for loan
 }
 
-fn main(){}
+fn main() {}

--- a/prusti-tests/tests/verify_partial/fail/nested-pure-fn.rs
+++ b/prusti-tests/tests/verify_partial/fail/nested-pure-fn.rs
@@ -17,7 +17,10 @@ fn outer(field: &u32) -> bool {
 
 #[pure]
 fn pred(m: &Struct) -> bool {
-    outer(inner(&m)) //~ ERROR There is no procedure contract for loan
+    outer(inner(&m))
+    //~^ ERROR Prusti encountered an unexpected internal error
+    //~| NOTE: We would appreciate a bug report
+    //~| NOTE: There is no procedure contract for loan
 }
 
 fn main(){}

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -184,11 +184,12 @@ fn main() {
 
     let exit_code = rustc_driver::catch_with_exit_code(move || {
         user::message(format!(
-            "{}\n{}\n{}\n\n",
+            "{}\n{}\n{}\n",
             r"  __          __        __  ___             ",
             r" |__)  _\/_  |__) |  | /__`  |   ____\/_  | ",
             r" |      /\   |  \ \__/ .__/  |       /\   | ",
         ));
+        user::message(format!("Prusti version: {}", get_prusti_version_info()));
         info!("Prusti version: {}", get_prusti_version_info());
 
         rustc_args.push("-Zpolonius".to_owned());


### PR DESCRIPTION
This PR moves the "unreadable" part of internal errors to a note of the error message. New output:
```
Verification of 2 items...
error: [Prusti internal error] Prusti encountered an unexpected internal error
  |
  = help: This could be caused by too small assertion timeout. Try increasing it by setting the configuration parameter ASSERT_TIMEOUT to a larger value.
  = note: We would appreciate a bug report: https://github.com/viperproject/prusti-dev/issues/new
  = note: Details: unregistered verification error: [inhale.failed:insufficient.permission; 0] Inhale might fail. There might be insufficient permission to access _1.val_ref.f$val (@0.0)

Verification failed
error: aborting due to previous error
```

Additionally, the Prusti version is printed to stdout such that the output of `prusti-rustc --version` is the following. This will help with https://github.com/viperproject/prusti-assistant/issues/143.
```
  __          __        __  ___             
 |__)  _\/_  |__) |  | /__`  |   ____\/_  | 
 |      /\   |  \ \__/ .__/  |       /\   | 

Prusti version: commit 94ffdae 2022-02-17 12:35:31 UTC, built on 2022-02-17 12:54:54 UTC
rustc 1.60.0-nightly (498eeb72f 2022-01-31)
```