### PR TITLE
Dynamically link the C runtime on Windows

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,1 @@
-[target.x86_64-pc-windows-msvc]
-# Statically link the C runtime, such that installing the Visual C++ Build Tools is not a requirement for Prusti
-rustflags = ["-Ctarget-feature=+crt-static"]
+


### PR DESCRIPTION
Other tools (rustup, cargo, rustc) require the Microsoft C++ build tools anyway.

