### PR TITLE
Move PositionManager out of ErrorManager

### DIFF
--- a/prusti-viper/src/encoder/errors/error_manager.rs
+++ b/prusti-viper/src/encoder/errors/error_manager.rs
@@ -132,10 +132,10 @@ impl<'tcx> ErrorManager<'tcx> {
     }
 
     pub fn register_span<T: Into<MultiSpan>>(&mut self, def_id: ProcedureDefId, span: T) -> Position {
-        self.position_manager.register(def_id, span)
+        self.position_manager.register_span(def_id, span)
     }
 
-    pub fn register<T: Into<MultiSpan>>(&mut self, span: T, error_ctxt: ErrorCtxt, def_id: ProcedureDefId) -> Position {
+    pub fn register_error<T: Into<MultiSpan>>(&mut self, span: T, error_ctxt: ErrorCtxt, def_id: ProcedureDefId) -> Position {
         let pos = self.register_span(def_id, span);
         trace!("Register error {:?} at position id {:?}", error_ctxt, pos.id());
         self.error_contexts.insert(pos.id(), error_ctxt);

--- a/prusti-viper/src/encoder/errors/mod.rs
+++ b/prusti-viper/src/encoder/errors/mod.rs
@@ -10,6 +10,7 @@ pub use self::error_manager::*;
 pub use self::encoding_error::*;
 pub use self::encoding_error_kind::*;
 pub use self::with_span::*;
+pub use self::position_manager::*;
 pub use rustc_span::MultiSpan;
 
 mod conversions;
@@ -18,3 +19,4 @@ mod error_manager;
 mod encoding_error;
 mod encoding_error_kind;
 mod with_span;
+mod position_manager;

--- a/prusti-viper/src/encoder/errors/position_manager.rs
+++ b/prusti-viper/src/encoder/errors/position_manager.rs
@@ -1,0 +1,84 @@
+// © 2019, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use vir_crate::polymorphic::Position;
+use rustc_hash::FxHashMap;
+use rustc_span::source_map::SourceMap;
+use rustc_span::MultiSpan;
+use log::{debug, trace};
+use prusti_interface::data::ProcedureDefId;
+
+/// Mapping from VIR locations to MIR and to the source code.
+#[derive(Clone)]
+pub struct PositionManager<'tcx> {
+    codemap: &'tcx SourceMap,
+    next_pos_id: u64,
+    pub(crate) def_id: FxHashMap<u64, ProcedureDefId>,
+    pub(crate) source_span: FxHashMap<u64, MultiSpan>,
+}
+
+impl<'tcx> PositionManager<'tcx>
+{
+    pub fn new(codemap: &'tcx SourceMap) -> Self {
+        PositionManager {
+            codemap,
+            next_pos_id: 1,
+            def_id: FxHashMap::default(),
+            source_span: FxHashMap::default(),
+        }
+    }
+
+    pub fn register<T: Into<MultiSpan>>(&mut self, def_id: ProcedureDefId, span: T) -> Position {
+        let span = span.into();
+        let pos_id = self.next_pos_id;
+        self.next_pos_id += 1;
+        trace!("Register position id {} for span {:?} in {:?}, ", pos_id, span, def_id);
+
+        let pos = if let Some(primary_span) = span.primary_span() {
+            let lines_info_res = self
+                .codemap
+                .span_to_lines(primary_span.source_callsite());
+            match lines_info_res {
+                Ok(lines_info) => {
+                    if let Some(first_line_info) = lines_info.lines.get(0) {
+                        let line = first_line_info.line_index as i32 + 1;
+                        let column = first_line_info.start_col.0 as i32 + 1;
+                        Position::new(line, column, pos_id)
+                    } else {
+                        debug!("Primary span of position id {} has no lines", pos_id);
+                        Position::new(0, 0, pos_id)
+                    }
+                }
+                Err(e) => {
+                    debug!("Error converting primary span of position id {} to lines: {:?}", pos_id, e);
+                    Position::new(0, 0, pos_id)
+                }
+            }
+        } else {
+            debug!("Position id {} has no primary span", pos_id);
+            Position::new(0, 0, pos_id)
+        };
+
+        self.def_id.insert(pos_id, def_id);
+        self.source_span.insert(pos_id, span);
+        pos
+    }
+
+    pub fn duplicate(&mut self, pos: Position) -> Position {
+        self.register(
+            self.get_def_id(pos).unwrap(),
+            self.get_span(pos).cloned().unwrap(),
+        )
+    }
+
+    pub fn get_def_id(&self, pos: Position) -> Option<ProcedureDefId> {
+        self.def_id.get(&pos.id()).copied()
+    }
+
+    pub fn get_span(&self, pos: Position) -> Option<&MultiSpan> {
+        self.source_span.get(&pos.id())
+    }
+}

--- a/prusti-viper/src/encoder/errors/position_manager.rs
+++ b/prusti-viper/src/encoder/errors/position_manager.rs
@@ -31,7 +31,7 @@ impl<'tcx> PositionManager<'tcx>
         }
     }
 
-    pub fn register<T: Into<MultiSpan>>(&mut self, def_id: ProcedureDefId, span: T) -> Position {
+    pub fn register_span<T: Into<MultiSpan>>(&mut self, def_id: ProcedureDefId, span: T) -> Position {
         let span = span.into();
         let pos_id = self.next_pos_id;
         self.next_pos_id += 1;
@@ -68,7 +68,7 @@ impl<'tcx> PositionManager<'tcx>
     }
 
     pub fn duplicate(&mut self, pos: Position) -> Position {
-        self.register(
+        self.register_span(
             self.get_def_id(pos).unwrap(),
             self.get_span(pos).cloned().unwrap(),
         )

--- a/prusti-viper/src/encoder/errors/position_manager.rs
+++ b/prusti-viper/src/encoder/errors/position_manager.rs
@@ -11,12 +11,16 @@ use rustc_span::MultiSpan;
 use log::{debug, trace};
 use prusti_interface::data::ProcedureDefId;
 
-/// Mapping from VIR locations to MIR and to the source code.
+/// Mapping from VIR positions to the source code that generated them.
+/// One VIR position can be involved in multiple errors. If an error needs to refer to a special
+/// span, that should be done by adding the span to `ErrorCtxt`, not by registering a new span.
 #[derive(Clone)]
 pub struct PositionManager<'tcx> {
     codemap: &'tcx SourceMap,
     next_pos_id: u64,
+    /// The def_id of the procedure that generated the given VIR position.
     pub(crate) def_id: FxHashMap<u64, ProcedureDefId>,
+    /// The span of the source code that generated the given VIR position.
     pub(crate) source_span: FxHashMap<u64, MultiSpan>,
 }
 

--- a/prusti-viper/src/encoder/middle/core_proof/errors/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/errors/interface.rs
@@ -21,7 +21,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ErrorsInterface for Lowerer<'p, 'v, 'tcx> {
     ) -> vir_low::Position {
         self.encoder
             .error_manager()
-            .register(
+            .register_error(
                 span,
                 error_ctxt,
                 self.encoder

--- a/prusti-viper/src/encoder/mir/errors/interface.rs
+++ b/prusti-viper/src/encoder/mir/errors/interface.rs
@@ -35,8 +35,9 @@ impl<'v, 'tcx: 'v> ErrorInterface for super::super::super::Encoder<'v, 'tcx> {
         position: vir_high::Position,
         error_ctxt: ErrorCtxt,
     ) -> vir_high::Position {
+        let new_pos = self.error_manager().duplicate_position(position.into());
         self.error_manager()
-            .change_error_context(position.into(), error_ctxt)
-            .into()
+            .register_additional_error(new_pos, error_ctxt);
+        new_pos.into()
     }
 }

--- a/prusti-viper/src/encoder/mir/errors/interface.rs
+++ b/prusti-viper/src/encoder/mir/errors/interface.rs
@@ -36,8 +36,7 @@ impl<'v, 'tcx: 'v> ErrorInterface for super::super::super::Encoder<'v, 'tcx> {
         error_ctxt: ErrorCtxt,
     ) -> vir_high::Position {
         let new_pos = self.error_manager().duplicate_position(position.into());
-        self.error_manager()
-            .register_additional_error(new_pos, error_ctxt);
+        self.error_manager().set_error(new_pos, error_ctxt);
         new_pos.into()
     }
 }

--- a/prusti-viper/src/encoder/mir/errors/interface.rs
+++ b/prusti-viper/src/encoder/mir/errors/interface.rs
@@ -27,7 +27,7 @@ impl<'v, 'tcx: 'v> ErrorInterface for super::super::super::Encoder<'v, 'tcx> {
         def_id: ProcedureDefId,
     ) -> vir_high::Position {
         self.error_manager()
-            .register(span, error_ctxt, def_id)
+            .register_error(span, error_ctxt, def_id)
             .into()
     }
     fn change_error_context(

--- a/prusti-viper/src/encoder/mir/places/interface.rs
+++ b/prusti-viper/src/encoder/mir/places/interface.rs
@@ -535,7 +535,7 @@ impl<'v, 'tcx: 'v> PlacesEncoderInterface<'tcx> for super::super::super::Encoder
                         .with_span(span)?;
                     let position = self
                         .error_manager()
-                        .register(span, ErrorCtxt::TypeCast, def_id);
+                        .register_error(span, ErrorCtxt::TypeCast, def_id);
                     let call = vir_high::Expression::function_call(
                         function_name,
                         vec![], // FIXME: This is probably wrong.

--- a/prusti-viper/src/encoder/mir/places/interface.rs
+++ b/prusti-viper/src/encoder/mir/places/interface.rs
@@ -533,9 +533,9 @@ impl<'v, 'tcx: 'v> PlacesEncoderInterface<'tcx> for super::super::super::Encoder
                     let function_name = self
                         .encode_cast_function_use(src_ty, dst_ty, tymap)
                         .with_span(span)?;
-                    let position = self
-                        .error_manager()
-                        .register_error(span, ErrorCtxt::TypeCast, def_id);
+                    let position =
+                        self.error_manager()
+                            .register_error(span, ErrorCtxt::TypeCast, def_id);
                     let call = vir_high::Expression::function_call(
                         function_name,
                         vec![], // FIXME: This is probably wrong.

--- a/prusti-viper/src/encoder/mir/procedures/encoder.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder.rs
@@ -629,7 +629,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let span = self.encoder.get_mir_location_span(self.mir, location);
         self.encoder
             .error_manager()
-            .register(span, error_ctxt, self.def_id)
+            .register_error(span, error_ctxt, self.def_id)
             .into()
     }
 }

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -547,10 +547,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
 
                     _ => ErrorCtxt::DivergingCallInPureFunction,
                 };
-                let pos =
-                    self.encoder
-                        .error_manager()
-                        .register_error(span, error_ctxt, self.caller_def_id);
+                let pos = self.encoder.error_manager().register_error(
+                    span,
+                    error_ctxt,
+                    self.caller_def_id,
+                );
                 ExprBackwardInterpreterState::new_defined(
                     self.unreachable_expr(pos.into()).with_span(span)?,
                 )

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -550,7 +550,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
                 let pos =
                     self.encoder
                         .error_manager()
-                        .register(span, error_ctxt, self.caller_def_id);
+                        .register_error(span, error_ctxt, self.caller_def_id);
                 ExprBackwardInterpreterState::new_defined(
                     self.unreachable_expr(pos.into()).with_span(span)?,
                 )
@@ -615,7 +615,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
             .encode_pure_function_use_high(def_id, self.caller_def_id, tymap, substs)
             .with_span(span)?;
         trace!("Encoding pure function call '{}'", function_name);
-        let pos = self.encoder.error_manager().register(
+        let pos = self.encoder.error_manager().register_error(
             span,
             ErrorCtxt::PureFunctionCall,
             self.caller_def_id,
@@ -690,7 +690,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         let state = match &terminator.kind {
             TerminatorKind::Unreachable => {
                 assert!(states.is_empty());
-                let pos = self.encoder.error_manager().register(
+                let pos = self.encoder.error_manager().register_error(
                     span,
                     ErrorCtxt::Unexpected,
                     self.caller_def_id,
@@ -705,7 +705,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 let pos = self
                     .encoder
                     .error_manager()
-                    .register(span, ErrorCtxt::Unexpected, self.caller_def_id)
+                    .register_error(span, ErrorCtxt::Unexpected, self.caller_def_id)
                     .into();
                 ExprBackwardInterpreterState::new_defined(
                     self.unreachable_expr(pos).with_span(span)?,
@@ -792,7 +792,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     ErrorCtxt::PureFunctionAssertTerminator(assert_msg)
                 };
 
-                let pos = self.encoder.error_manager().register(
+                let pos = self.encoder.error_manager().register_error(
                     terminator.source_info.span,
                     error_ctxt,
                     self.caller_def_id,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -176,7 +176,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             &encoded_args,
             None,
             true,
-            ErrorCtxt::GenericExpression,
             self.parent_def_id,
             self.tymap,
             self.substs,
@@ -342,7 +341,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 &encoded_args,
                 None,
                 true,
-                ErrorCtxt::GenericExpression,
                 self.parent_def_id,
                 self.tymap,
                 self.substs,
@@ -379,7 +377,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 &encoded_args,
                 Some(&encoded_return.clone().into()),
                 true,
-                ErrorCtxt::GenericExpression,
                 self.parent_def_id,
                 self.tymap,
                 self.substs,
@@ -393,7 +390,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         // TODO: use a better span
         let postcondition_pos = self.encoder.error_manager().register(
             self.mir.span,
-            ErrorCtxt::GenericExpression,
+            ErrorCtxt::PureFunctionDefinition,
             self.parent_def_id,
         );
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -180,7 +180,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             self.tymap,
             self.substs,
         )?;
-        self.encoder.error_manager().register_additional_error(
+        self.encoder.error_manager().set_error(
             predicate_body_encoded.pos(),
             ErrorCtxt::PureFunctionDefinition,
         );
@@ -351,7 +351,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             )?;
             self.encoder
                 .error_manager()
-                .register_additional_error(assertion.pos(), ErrorCtxt::PureFunctionDefinition);
+                .set_error(assertion.pos(), ErrorCtxt::PureFunctionDefinition);
             func_spec.push(assertion);
         }
 
@@ -389,10 +389,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 self.tymap,
                 self.substs,
             )?;
-            self.encoder.error_manager().register_additional_error(
-                encoded_postcond.pos(),
-                ErrorCtxt::PureFunctionDefinition,
-            );
+            self.encoder
+                .error_manager()
+                .set_error(encoded_postcond.pos(), ErrorCtxt::PureFunctionDefinition);
             func_spec.push(encoded_postcond);
         }
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -217,7 +217,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let formal_args = self.encode_formal_args()?;
         let return_type = self.encode_function_return_type()?;
 
-        let res_value_range_pos = self.encoder.error_manager().register(
+        let res_value_range_pos = self.encoder.error_manager().register_error(
             self.mir.span,
             ErrorCtxt::PureFunctionPostconditionValueRangeOfResult,
             self.parent_def_id,
@@ -388,7 +388,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let post = func_spec.into_iter().conjoin();
 
         // TODO: use a better span
-        let postcondition_pos = self.encoder.error_manager().register(
+        let postcondition_pos = self.encoder.error_manager().register_error(
             self.mir.span,
             ErrorCtxt::PureFunctionDefinition,
             self.parent_def_id,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -1282,7 +1282,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
             expr = expr.set_default_pos(
                 self.encoder
                     .error_manager()
-                    .register_span(self.caller_def_id, span),
+                    .register_error(span, ErrorCtxt::PureFunctionDefinition, self.caller_def_id),
             );
             let _ = mem::replace(state_expr, expr);
         }

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -1279,11 +1279,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
         if let Some(state_expr) = state.expr_mut() {
             let mut expr = mem::replace(state_expr, true.into());
-            expr = expr.set_default_pos(
-                self.encoder
-                    .error_manager()
-                    .register_error(span, ErrorCtxt::PureFunctionDefinition, self.caller_def_id),
-            );
+            expr = expr.set_default_pos(self.encoder.error_manager().register_error(
+                span,
+                ErrorCtxt::PureFunctionDefinition,
+                self.caller_def_id,
+            ));
             let _ = mem::replace(state_expr, expr);
         }
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -257,7 +257,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         let mut state = match term.kind {
             TerminatorKind::Unreachable => {
                 assert!(states.is_empty());
-                let pos = self.encoder.error_manager().register(
+                let pos = self.encoder.error_manager().register_error(
                     term.source_info.span,
                     ErrorCtxt::Unexpected,
                     self.caller_def_id,
@@ -269,7 +269,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
             TerminatorKind::Abort | TerminatorKind::Resume { .. } => {
                 assert!(states.is_empty());
-                let pos = self.encoder.error_manager().register(
+                let pos = self.encoder.error_manager().register_error(
                     term.source_info.span,
                     ErrorCtxt::Unexpected,
                     self.caller_def_id,
@@ -658,7 +658,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     .collect::<Result<_, _>>()
                                     .with_span(term.source_info.span)?;
 
-                                let pos = self.encoder.error_manager().register(
+                                let pos = self.encoder.error_manager().register_error(
                                     term.source_info.span,
                                     ErrorCtxt::PureFunctionCall,
                                     self.caller_def_id,
@@ -712,7 +712,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
                                     _ => ErrorCtxt::DivergingCallInPureFunction,
                                 };
-                                let pos = self.encoder.error_manager().register(
+                                let pos = self.encoder.error_manager().register_error(
                                     term.source_info.span,
                                     error_ctxt,
                                     self.caller_def_id,
@@ -757,7 +757,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     ErrorCtxt::PureFunctionAssertTerminator(assert_msg)
                 };
 
-                let pos = self.encoder.error_manager().register(
+                let pos = self.encoder.error_manager().register_error(
                     term.source_info.span,
                     error_ctxt,
                     self.caller_def_id,
@@ -1133,7 +1133,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                     let pos = self
                                         .encoder
                                         .error_manager()
-                                        .register(stmt.source_info.span, ErrorCtxt::Unexpected, self.caller_def_id);
+                                        .register_error(stmt.source_info.span, ErrorCtxt::Unexpected, self.caller_def_id);
                                     let (function_name, type_arguments) = self.encoder.encode_builtin_function_use(
                                         BuiltinFunctionKind::Unreachable(vir::Type::Int),
                                     );

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -809,11 +809,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
         if let Some(state_expr) = state.expr_mut() {
             let mut expr = mem::replace(state_expr, true.into());
-            expr = expr.set_default_pos(self.encoder.error_manager().register(
-                span,
-                ErrorCtxt::GenericExpression,
-                self.caller_def_id,
-            ));
+            expr = expr.set_default_pos(
+                self.encoder
+                    .error_manager()
+                    .register_span(self.caller_def_id, span),
+            );
             let _ = mem::replace(state_expr, expr);
         }
 
@@ -1279,11 +1279,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
         if let Some(state_expr) = state.expr_mut() {
             let mut expr = mem::replace(state_expr, true.into());
-            expr = expr.set_default_pos(self.encoder.error_manager().register(
-                span,
-                ErrorCtxt::GenericExpression,
-                self.caller_def_id,
-            ));
+            expr = expr.set_default_pos(
+                self.encoder
+                    .error_manager()
+                    .register_span(self.caller_def_id, span),
+            );
             let _ = mem::replace(state_expr, expr);
         }
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -1,3 +1,4 @@
+use super::encoder::FunctionCallInfoHigh;
 use crate::encoder::{
     borrows::ProcedureContractMirDef,
     encoder::SubstMap,
@@ -21,11 +22,9 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::mir;
 use rustc_span::Span;
 use vir_crate::{
-    common::expression::ExpressionIterator,
+    common::{expression::ExpressionIterator, position::Positioned},
     high::{self as vir_high},
 };
-
-use super::encoder::FunctionCallInfoHigh;
 
 pub(super) fn encode_function_decl<'p, 'v: 'p, 'tcx: 'v>(
     encoder: &'p Encoder<'v, 'tcx>,
@@ -302,14 +301,19 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let parameter_expressions = self.convert_parameters_into_expressions(parameters);
         let mut conjuncts = Vec::new();
         for item in contract.functional_precondition() {
-            conjuncts.push(self.encoder.encode_assertion_high(
+            let assertion = self.encoder.encode_assertion_high(
                 item,
                 None,
                 &parameter_expressions,
                 None,
                 self.parent_def_id,
                 self.tymap,
-            )?);
+            )?;
+            self.encoder.error_manager().register_additional_error(
+                assertion.position().into(),
+                ErrorCtxt::PureFunctionDefinition,
+            );
+            conjuncts.push(assertion);
         }
         Ok(conjuncts.into_iter().conjoin())
     }
@@ -323,14 +327,19 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let mut conjuncts = Vec::new();
         let encoded_return = self.encode_mir_local(contract.returned_value)?;
         for item in contract.functional_postcondition() {
-            conjuncts.push(self.encoder.encode_assertion_high(
+            let assertion = self.encoder.encode_assertion_high(
                 item,
                 None,
                 &parameter_expressions,
                 Some(&vir_high::Expression::local_no_pos(encoded_return.clone())),
                 self.parent_def_id,
                 self.tymap,
-            )?);
+            )?;
+            self.encoder.error_manager().register_additional_error(
+                assertion.position().into(),
+                ErrorCtxt::PureFunctionDefinition,
+            );
+            conjuncts.push(assertion);
         }
         let post = conjuncts.into_iter().conjoin();
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -335,7 +335,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let post = conjuncts.into_iter().conjoin();
 
         // TODO: use a better span
-        let postcondition_pos = self.encoder.error_manager().register(
+        let postcondition_pos = self.encoder.error_manager().register_error(
             self.mir.span,
             ErrorCtxt::PureFunctionDefinition,
             self.parent_def_id,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -309,7 +309,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
                 self.parent_def_id,
                 self.tymap,
             )?;
-            self.encoder.error_manager().register_additional_error(
+            self.encoder.error_manager().set_error(
                 assertion.position().into(),
                 ErrorCtxt::PureFunctionDefinition,
             );
@@ -335,7 +335,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
                 self.parent_def_id,
                 self.tymap,
             )?;
-            self.encoder.error_manager().register_additional_error(
+            self.encoder.error_manager().set_error(
                 assertion.position().into(),
                 ErrorCtxt::PureFunctionDefinition,
             );

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -307,7 +307,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
                 None,
                 &parameter_expressions,
                 None,
-                ErrorCtxt::GenericExpression,
                 self.parent_def_id,
                 self.tymap,
             )?);
@@ -329,7 +328,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
                 None,
                 &parameter_expressions,
                 Some(&vir_high::Expression::local_no_pos(encoded_return.clone())),
-                ErrorCtxt::GenericExpression,
                 self.parent_def_id,
                 self.tymap,
             )?);
@@ -339,7 +337,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         // TODO: use a better span
         let postcondition_pos = self.encoder.error_manager().register(
             self.mir.span,
-            ErrorCtxt::GenericExpression,
+            ErrorCtxt::PureFunctionDefinition,
             self.parent_def_id,
         );
 

--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -478,7 +478,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
             //             .encode_builtin_function_use(BuiltinFunctionKind::Unreachable(
             //                 encoded_type.clone(),
             //             ));
-            //     let pos = self.encoder.error_manager().register(
+            //     let pos = self.encoder.error_manager().register_error(
             //         // TODO: use a proper span
             //         self.mir.span,
             //         ErrorCtxt::PureFunctionCall,
@@ -855,7 +855,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
     }
 
     pub fn register_error<T: Into<MultiSpan>>(&self, span: T, error_ctxt: ErrorCtxt) -> vir::Position {
-        self.encoder.error_manager().register(span, error_ctxt, self.def_id)
+        self.encoder.error_manager().register_error(span, error_ctxt, self.def_id)
     }
 
     /// Return the cause of a call to `begin_panic`

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1410,7 +1410,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ];
 
         if self.check_foldunfold_state {
-            let new_pos = self.encoder.error_manager().change_error_context(pos, ErrorCtxt::Unexpected);
+            let new_pos = self.encoder.error_manager().duplicate_position(pos);
+            self.encoder.error_manager().register_additional_error(new_pos, ErrorCtxt::Unexpected);
             stmts.push(vir::Stmt::Assert( vir::Assert {
                 expr,
                 position: new_pos,

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1411,7 +1411,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
         if self.check_foldunfold_state {
             let new_pos = self.encoder.error_manager().duplicate_position(pos);
-            self.encoder.error_manager().register_additional_error(new_pos, ErrorCtxt::Unexpected);
+            self.encoder.error_manager().set_error(new_pos, ErrorCtxt::Unexpected);
             stmts.push(vir::Stmt::Assert( vir::Assert {
                 expr,
                 position: new_pos,

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -308,7 +308,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             let executed_flag_var = self.cfg_method.add_fresh_local_var(vir::Type::Bool);
             let bb_pos = self
                 .mir_encoder
-                .encode_expr_pos(self.mir_encoder.get_span_of_basic_block(bbi));
+                .register_span(self.mir_encoder.get_span_of_basic_block(bbi));
             self.cfg_method.add_stmt(
                 start_cfg_block,
                 vir::Stmt::Assign( vir::Assign {
@@ -394,10 +394,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             .iter()
             .map(|(loan, location)| (loan.index().into(), *location))
             .collect();
-        let method_pos = self
-            .encoder
-            .error_manager()
-            .register(self.mir.span, ErrorCtxt::Unexpected, self.proc_def_id);
+        let method_pos = self.register_error(
+                self.mir.span,
+                ErrorCtxt::Unexpected
+            );
         let method_with_fold_unfold = foldunfold::add_fold_unfold(
             self.encoder,
             self.cfg_method,
@@ -911,7 +911,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     ) -> SpannedEncodingResult<()> {
         let pos = self
             .mir_encoder
-            .encode_expr_pos(self.mir_encoder.get_span_of_basic_block(bbi));
+            .register_span(self.mir_encoder.get_span_of_basic_block(bbi));
         let executed_flag_var = self.cfg_block_has_been_executed[&bbi].clone();
         self.cfg_method.add_stmt(
             cfg_block,
@@ -977,6 +977,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     ) -> SpannedEncodingResult<(Vec<vir::Stmt>, Option<MirSuccessor>)> {
         debug!("Encode location {:?}", location);
 
+        let span = self.mir_encoder.get_span_of_location(location);
         let bb_data = &self.mir[location.block];
         let index = location.statement_index;
         let stmts_succ_res = if index < bb_data.statements.len() {
@@ -990,8 +991,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         };
 
         // Intercept encoding error caused by an unsupported feature
-        match stmts_succ_res {
-            Ok(stmts_succ) => Ok(stmts_succ),
+        let (stmts, successor) = match stmts_succ_res {
+            Ok(stmts_succ) => stmts_succ,
             Err(err) => {
                 let unsupported_msg = match err.kind() {
                     EncodingErrorKind::Unsupported(msg)
@@ -1004,9 +1005,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     }
                 };
                 // TODO: How to combine this with the span of the encoding error?
-                let span = self.mir_encoder.get_span_of_location(location);
                 let err_ctxt = ErrorCtxt::Unsupported(unsupported_msg.clone());
-                let pos = self.encoder.error_manager().register(span, err_ctxt, self.proc_def_id);
+                let pos = self.register_error(span, err_ctxt);
                 let head_stmt = if index < bb_data.statements.len() {
                     format!("[mir] {:?}", &bb_data.statements[index])
                 } else {
@@ -1022,9 +1022,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         position: pos,
                     })
                 ];
-                Ok((stmts, Some(MirSuccessor::Kill)))
+                (stmts, Some(MirSuccessor::Kill))
             }
-        }
+        };
+        Ok((self.set_stmts_default_pos(stmts, span), successor))
     }
 
     /// Note: it's better to call `encode_statement_at` instead of this method.
@@ -1081,21 +1082,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(self.set_stmts_default_pos(stmts, stmt.source_info.span))
     }
 
-    fn set_stmts_default_pos(&self, stmts: Vec<vir::Stmt>, default_pos_span: Span) -> Vec<vir::Stmt> {
-        let expr_pos = self
-            .encoder
-            .error_manager()
-            .register(default_pos_span, ErrorCtxt::GenericExpression, self.proc_def_id);
-        let stmt_pos = self
-            .encoder
-            .error_manager()
-            .register(default_pos_span, ErrorCtxt::GenericStatement, self.proc_def_id);
-
+    fn set_stmts_default_pos(&self, stmts: Vec<vir::Stmt>, default_span: Span) -> Vec<vir::Stmt> {
+        let pos = self.encoder.error_manager().register_span(self.proc_def_id, default_span);
         stmts
             .into_iter()
-            .map(|s| {
-                s.set_default_expr_pos(expr_pos).set_default_pos(stmt_pos)
-            })
+            .map(|s| s.set_default_pos(pos))
             .collect()
     }
 
@@ -1183,7 +1174,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     encoded_lhs,
                     ty,
                     location,
-                    span,
                 )?
             }
             mir::Rvalue::Len(ref place) => {
@@ -1401,10 +1391,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         };
 
         if self.check_foldunfold_state && !is_in_package_stmt {
-            let pos = self
-                .encoder
-                .error_manager()
-                .register(self.mir.source_info(location).span, ErrorCtxt::Unexpected, self.proc_def_id);
+            let pos = self.register_error(self.mir.source_info(location).span, ErrorCtxt::Unexpected);
             stmts.push(vir::Stmt::Assert( vir::Assert {
                 expr: vir::Expr::eq_cmp(lhs, rhs),
                 position: pos,
@@ -1423,15 +1410,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ];
 
         if self.check_foldunfold_state {
-            let pos = self.encoder.error_manager().register(
-                // TODO: use a better span
-                self.mir.span,
-                ErrorCtxt::Unexpected,
-                self.proc_def_id,
-            );
+            let new_pos = self.encoder.error_manager().change_error_context(pos, ErrorCtxt::Unexpected);
             stmts.push(vir::Stmt::Assert( vir::Assert {
                 expr,
-                position: pos,
+                position: new_pos,
             }));
         }
 
@@ -1758,12 +1740,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             }
         }
 
-        let pos = self.encoder.error_manager().register(
+        let pos = self.register_error(
             //self.mir.span,
             // TODO change to where the loan expires?
             self.mir.source_info(loan_location).span, // the source of the ref
             ErrorCtxt::ApplyMagicWandOnExpiry,
-            self.proc_def_id,
         );
         // Inhale the magic wand.
         let magic_wand = vir::Expr::MagicWand( vir::MagicWand {
@@ -1839,7 +1820,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     {
         debug!("encode_expiring_borrows_at '{:?}'", location);
         let (all_dying_loans, zombie_loans) = self.polonius_info().get_all_loans_dying_at(location);
-        self.encode_expiration_of_loans(all_dying_loans, &zombie_loans, location, None, false)
+        let stmts = self.encode_expiration_of_loans(all_dying_loans, &zombie_loans, location, None, false)?;
+        Ok(self.set_stmts_default_pos(stmts, self.mir_encoder.get_span_of_location(location)))
     }
 
     /// Note: it's better to call `encode_statement_at` instead of this method.
@@ -1992,7 +1974,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
             TerminatorKind::Unreachable => {
                 // Asserting `false` here does not work. See issue #158
-                //let pos = self.encoder.error_manager().register(
+                //let pos = self.register_error(
                 //    term.source_info.span,
                 //    ErrorCtxt::UnreachableTerminator
                 //);
@@ -2003,10 +1985,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             }
 
             TerminatorKind::Abort => {
-                let pos = self
-                    .encoder
-                    .error_manager()
-                    .register(term.source_info.span, ErrorCtxt::AbortTerminator, self.proc_def_id);
+                let pos = self.register_error(term.source_info.span, ErrorCtxt::AbortTerminator);
                 stmts.push(vir::Stmt::Assert( vir::Assert {
                     expr: false.into(),
                     position: pos,
@@ -2089,13 +2068,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                             let panic_cause = self.mir_encoder.encode_panic_cause(
                                 term.source_info.span
                             );
-                            let pos = self
-                                .encoder
-                                .error_manager()
-                                .register(
+                            let pos = self.register_error(
                                     term.source_info.span,
                                     ErrorCtxt::Panic(panic_cause),
-                                    self.proc_def_id,
                                 );
 
                             if self.check_panics {
@@ -2365,10 +2340,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 if self.check_panics {
                     stmts.push(vir::Stmt::Assert( vir::Assert {
                         expr: viper_guard,
-                        position: self.encoder.error_manager().register(
+                        position: self.register_error(
                             term.source_info.span,
                             error_ctxt,
-                            self.proc_def_id,
                         ),
                     }));
                 } else {
@@ -2993,10 +2967,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             pre_invs_spec,
             pre_func_spec,
         ) = self.encode_precondition_expr(&procedure_contract, &tymap, &substs, fake_expr_spans)?;
-        let pos = self
-            .encoder
-            .error_manager()
-            .register(call_site_span, ErrorCtxt::ExhaleMethodPrecondition, self.proc_def_id);
+        let pos = self.register_error(call_site_span, ErrorCtxt::ExhaleMethodPrecondition);
         stmts.push(vir::Stmt::Assert( vir::Assert {
             expr: replace_fake_exprs(pre_func_spec),
             position: pos,
@@ -3179,10 +3150,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             .collect::<Result<_, _>>()
             .with_span(call_site_span)?;
 
-        let pos = self
-            .encoder
-            .error_manager()
-            .register(call_site_span, ErrorCtxt::PureFunctionCall, self.proc_def_id);
+        let pos = self.register_error(call_site_span, ErrorCtxt::PureFunctionCall);
 
         let type_arguments = self.encoder.encode_generic_arguments(called_def_id, &tymap).with_span(call_site_span)?;
 
@@ -3474,7 +3442,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 &encoded_args,
                 None,
                 false,
-                ErrorCtxt::GenericExpression,
                 self.proc_def_id,
                 tymap,
                 substs,
@@ -3575,7 +3542,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                                 &encoded_args,
                                 None,
                                 false,
-                                ErrorCtxt::GenericExpression,
                                 self.proc_def_id,
                                 &tymap,
                                 &substs,
@@ -3592,7 +3558,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                                 &encoded_args,
                                 None,
                                 false,
-                                ErrorCtxt::GenericExpression,
                                 self.proc_def_id,
                                 &tymap,
                                 &substs,
@@ -3627,7 +3592,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                                 &encoded_args,
                                 Some(&encoded_return),
                                 false,
-                                ErrorCtxt::GenericExpression,
                                 self.proc_def_id,
                                 &tymap,
                                 &substs,
@@ -3644,7 +3608,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                                 &encoded_args,
                                 Some(&encoded_return),
                                 false,
-                                ErrorCtxt::GenericExpression,
                                 self.proc_def_id,
                                 &tymap,
                                 &substs,
@@ -3836,7 +3799,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         &encoded_args,
                         Some(&encoded_return),
                         false,
-                        ErrorCtxt::GenericExpression,
                         self.proc_def_id,
                         tymap,
                         substs,
@@ -3850,7 +3812,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     &encoded_args,
                     Some(&encoded_return),
                     false,
-                    ErrorCtxt::GenericExpression,
                     self.proc_def_id,
                     tymap,
                     substs,
@@ -4072,23 +4033,23 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 &encoded_args,
                 Some(&encoded_return),
                 false,
-                ErrorCtxt::GenericExpression,
                 self.proc_def_id,
                 tymap,
                 substs,
             )?;
-            func_spec_spans.push(self.encoder.env().tcx().def_span(typed_assertion.to_def_id()));
+            let assertion_span = self.encoder.env().tcx().def_span(typed_assertion.to_def_id());
+            func_spec_spans.push(assertion_span);
+            let assertion_pos = self.mir_encoder.register_span(assertion_span);
             assertion = self.wrap_arguments_into_old(
                 assertion,
                 pre_label,
                 contract,
                 &encoded_args,
             )?;
-            func_spec.push(assertion);
+            func_spec.push(assertion.set_default_pos(assertion_pos));
         }
         let postcondition_span = MultiSpan::from_spans(func_spec_spans);
-        let func_spec_pos = self.encoder.error_manager()
-            .register_span(postcondition_span.clone());
+        let func_spec_pos = self.mir_encoder.register_span(postcondition_span.clone());
 
         // Encode invariant for return value
         invs_spec.push(
@@ -4098,8 +4059,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             ).with_span(postcondition_span)?
         );
 
-        let full_func_spec = func_spec.into_iter()
-            .conjoin()
+        let full_func_spec = func_spec.into_iter().conjoin()
             .set_default_pos(func_spec_pos);
 
         Ok((
@@ -4197,10 +4157,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             &tymap,
             &substs,
         ).with_span(span)? {
-            let pos = self
-                .encoder
-                .error_manager()
-                .register(self.mir.span, ErrorCtxt::PackageMagicWandForPostcondition, self.proc_def_id);
+            let pos = self.register_error(self.mir.span, ErrorCtxt::PackageMagicWandForPostcondition);
 
             let blocker = mir::RETURN_PLACE;
             // TODO: Check if it really is always start and not the mid point.
@@ -4345,10 +4302,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             &substs,
         )?;
 
-        let type_inv_pos = self.encoder.error_manager().register(
+        let type_inv_pos = self.register_error(
             self.mir.span,
             ErrorCtxt::AssertMethodPostconditionTypeInvariants,
-            self.proc_def_id,
         );
 
         // Find which arguments are blocked by the returned reference.
@@ -4495,10 +4451,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             return_cfg_block,
             vir::Stmt::comment("Assert functional specification of postcondition"),
         );
-        let func_pos = self
-            .encoder
-            .error_manager()
-            .register(self.mir.span, ErrorCtxt::AssertMethodPostcondition, self.proc_def_id);
+        let func_pos = self.register_error(self.mir.span, ErrorCtxt::AssertMethodPostcondition);
         let patched_func_spec = self.replace_old_places_with_ghost_vars(None, func_spec);
         self.cfg_method.add_stmt(
             return_cfg_block,
@@ -4527,10 +4480,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             return_cfg_block,
             vir::Stmt::comment("Exhale permissions of postcondition (1/3)"),
         );
-        let perm_pos = self
-            .encoder
-            .error_manager()
-            .register(self.mir.span, ErrorCtxt::ExhaleMethodPostcondition, self.proc_def_id);
+        let perm_pos = self.register_error(self.mir.span, ErrorCtxt::ExhaleMethodPostcondition);
         let patched_type_spec = self.replace_old_places_with_ghost_vars(None, type_spec);
         debug_assert!(!perm_pos.is_default());
         self.cfg_method.add_stmt(
@@ -4963,7 +4913,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         // TODO: use different positions, and generate different error messages, for the exhale
         // before the loop and after the loop body
 
-        let assert_pos = self.encoder.error_manager().register(
+        let assert_pos = self.register_error(
             // TODO: choose a proper error span
             func_spec_span.clone(),
             if after_loop_iteration {
@@ -4971,10 +4921,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             } else {
                 ErrorCtxt::AssertLoopInvariantOnEntry
             },
-            self.proc_def_id,
         );
 
-        let exhale_pos = self.encoder.error_manager().register(
+        let exhale_pos = self.register_error(
             // TODO: choose a proper error span
             func_spec_span,
             if after_loop_iteration {
@@ -4982,7 +4931,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             } else {
                 ErrorCtxt::ExhaleLoopInvariantOnEntry
             },
-            self.proc_def_id,
         );
 
         let mut stmts = vec![vir::Stmt::comment(format!(
@@ -5811,7 +5759,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         encoded_lhs: vir::Expr,
         ty: ty::Ty<'tcx>,
         location: mir::Location,
-        span: Span,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
         trace!(
             "[enter] encode_cast(operand={:?}, dst_ty={:?})",
@@ -5819,6 +5766,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             dst_ty
         );
         let tymap = FxHashMap::default();
+        let span = self.mir_encoder.get_span_of_location(location);
         let encoded_val = self.mir_encoder.encode_cast_expr(operand, dst_ty, span, &tymap)?;
         self.encode_copy_value_assign(encoded_lhs, encoded_val, ty, location)
     }
@@ -6644,6 +6592,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 (res, stmts)
             }
         })
+    }
+
+    fn register_error<T: Into<MultiSpan>>(&self, span: T, error_ctxt: ErrorCtxt) -> vir::Position {
+        self.mir_encoder.register_error(span, error_ctxt)
     }
 }
 

--- a/prusti-viper/src/encoder/spec_function_encoder.rs
+++ b/prusti-viper/src/encoder/spec_function_encoder.rs
@@ -99,7 +99,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecFunctionEncoder<'p, 'v, 'tcx> {
                 self.tymap,
                 self.substs,
             )?;
-            self.encoder.error_manager().register_additional_error(
+            self.encoder.error_manager().set_error(
                 assertion.pos(),
                 ErrorCtxt::PureFunctionDefinition,
             );
@@ -148,7 +148,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecFunctionEncoder<'p, 'v, 'tcx> {
                 self.tymap,
                 self.substs,
             )?;
-            self.encoder.error_manager().register_additional_error(
+            self.encoder.error_manager().set_error(
                 assertion.pos(),
                 ErrorCtxt::PureFunctionDefinition,
             );

--- a/prusti-viper/src/encoder/spec_function_encoder.rs
+++ b/prusti-viper/src/encoder/spec_function_encoder.rs
@@ -1,6 +1,6 @@
 use crate::encoder::snapshot::interface::SnapshotEncoderInterface;
 use crate::encoder::{Encoder, borrows::ProcedureContract};
-use crate::encoder::errors::{SpannedEncodingResult, ErrorCtxt, WithSpan};
+use crate::encoder::errors::{SpannedEncodingResult, WithSpan};
 use crate::encoder::borrows::compute_procedure_contract;
 use crate::encoder::mir_encoder::{MirEncoder, PlaceEncoder};
 use crate::encoder::mir::pure::SpecificationEncoderInterface;
@@ -98,7 +98,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecFunctionEncoder<'p, 'v, 'tcx> {
                     .map(|e| -> vir::Expr { e.into() }).collect::<Vec<_>>(),
                 None,
                 true,
-                ErrorCtxt::GenericExpression,
                 self.proc_def_id,
                 self.tymap,
                 self.substs,
@@ -143,7 +142,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> SpecFunctionEncoder<'p, 'v, 'tcx> {
                     .map(|e| -> vir::Expr { e.into() }).collect::<Vec<_>>(),
                 Some(&encoded_return.clone().into()),
                 true,
-                ErrorCtxt::GenericExpression,
                 self.proc_def_id,
                 self.tymap,
                 self.substs,

--- a/prusti-viper/src/lib.rs
+++ b/prusti-viper/src/lib.rs
@@ -28,6 +28,7 @@ extern crate rustc_target;
 extern crate rustc_attr;
 extern crate rustc_data_structures;
 extern crate lazy_static;
+extern crate rustc_hash;
 
 pub mod encoder;
 mod utils;

--- a/prusti-viper/src/verifier.rs
+++ b/prusti-viper/src/verifier.rs
@@ -321,7 +321,7 @@ impl<'v, 'tcx> Verifier<'v, 'tcx> {
                     if let Some(def_id) = error_manager.get_def_id(&verification_error) {
                         let counterexample = counterexample_translation::backtranslate(
                             &self.encoder,
-                            *def_id,
+                            def_id,
                             silicon_counterexample,
                         );
                         prusti_error = counterexample.annotate_error(prusti_error);

--- a/vir/defs/high/operations_internal/position/expressions.rs
+++ b/vir/defs/high/operations_internal/position/expressions.rs
@@ -1,0 +1,128 @@
+use super::super::super::ast::expression::*;
+use crate::common::position::Positioned;
+
+impl Positioned for Expression {
+    fn position(&self) -> Position {
+        match self {
+            Self::Local(expression) => expression.position(),
+            Self::Constructor(expression) => expression.position(),
+            Self::Variant(expression) => expression.position(),
+            Self::Field(expression) => expression.position(),
+            Self::Deref(expression) => expression.position(),
+            Self::AddrOf(expression) => expression.position(),
+            Self::LabelledOld(expression) => expression.position(),
+            Self::Constant(expression) => expression.position(),
+            Self::UnaryOp(expression) => expression.position(),
+            Self::BinaryOp(expression) => expression.position(),
+            Self::ContainerOp(expression) => expression.position(),
+            Self::Seq(expression) => expression.position(),
+            Self::Conditional(expression) => expression.position(),
+            Self::Quantifier(expression) => expression.position(),
+            Self::LetExpr(expression) => expression.position(),
+            Self::FuncApp(expression) => expression.position(),
+            Self::Downcast(expression) => expression.position(),
+        }
+    }
+}
+
+impl Positioned for Local {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Constructor {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Variant {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Field {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Deref {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for AddrOf {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for LabelledOld {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Constant {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for UnaryOp {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for BinaryOp {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for ContainerOp {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Seq {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Conditional {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Quantifier {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for LetExpr {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for FuncApp {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for Downcast {
+    fn position(&self) -> Position {
+        self.position
+    }
+}

--- a/vir/defs/high/operations_internal/position/mod.rs
+++ b/vir/defs/high/operations_internal/position/mod.rs
@@ -1,1 +1,2 @@
+mod expressions;
 mod statement;


### PR DESCRIPTION
This PR is a refactoring that extracts a `PositionManager` from the `ErrorManager`. In order to translate VIR back to MIR and to the source code (see the discussion at https://github.com/viperproject/prusti-dev/issues/884), each VIR expression and statement should have their own unique position id. This could be done by a future VIR factory that generates positions via a reference to the `PositionManager`.

Notes:
* `ErrorManager::register` becomes `ErrorManager::register_error`
* `Encoder::encode_assertion` loses its `ErrorCtxt` argument. The caller should use `ErrorManager::set_error` on the returned expression to set the error context.
* Ideally, each expression should have its own `Position` obtained via `ErrorManager::register_span`. This is not mandatory, but it would make error reporting and the back-translation from VIR to source code more precise.