### PR TITLE
use `old` in trigger for direct array assignments

### DIFF
--- a/prusti-tests/tests/verify/pass/arrays/selection_sort-2.rs
+++ b/prusti-tests/tests/verify/pass/arrays/selection_sort-2.rs
@@ -17,9 +17,6 @@ fn selection_sort(a: &mut [i32; 10]) {
     while i < a.len() {
         body_invariant!(0 <= i && i < 10);
 
-        // this body invariant is needed in order to trigger the correct quantifiers
-        body_invariant!(a[0] <= a[i]);
-
         // sorted below i
         body_invariant!(forall(|k1: usize, k2: usize| (0 <= k1 && k1 < k2 && k2 < i)
                                 ==> a[k1] <= a[k2],
@@ -35,7 +32,6 @@ fn selection_sort(a: &mut [i32; 10]) {
         while j < a.len() {
             // these three are the same as the outer loop
             body_invariant!(0 <= i && i < 10);
-            body_invariant!(a[0] <= a[i]);
             body_invariant!(forall(|k1: usize, k2: usize| (0 <= k1 && k1 < k2 && k2 < i)
                                     ==> a[k1] <= a[k2],
                                     triggers=[(a[k1],a[k2])]));
@@ -65,9 +61,16 @@ fn selection_sort(a: &mut [i32; 10]) {
 
         let a_i = a[i];
         let a_min = a[min];
-        a[i] = a_min;
-        a[min] = a_i;
+        set(a, i,  a_min);
+        set(a, min, a_i);
 
         i += 1;
     }
+}
+
+#[requires(0 <= i && i < 10)]
+#[ensures(forall(|j: usize| (0 <= j && j < 10 && j != old(i)) ==> (a[j] == old(a[j])), triggers=[(a[j],)]))]
+#[ensures(a[old(i)] == old(v))]
+fn set(a: &mut [i32; 10], i: usize, v: i32) {
+    a[i] = v;
 }

--- a/prusti-tests/tests/verify/pass/arrays/selection_sort.rs
+++ b/prusti-tests/tests/verify/pass/arrays/selection_sort.rs
@@ -16,6 +16,7 @@ fn selection_sort(a: &mut [i32; 10]) {
 
     while i < a.len() {
         body_invariant!(0 <= i && i < 10);
+        body_invariant!(a[0] <= a[i]);
 
         // sorted below i
         body_invariant!(forall(|k1: usize, k2: usize| (0 <= k1 && k1 < k2 && k2 < i)
@@ -32,6 +33,7 @@ fn selection_sort(a: &mut [i32; 10]) {
         while j < a.len() {
             // these three are the same as the outer loop
             body_invariant!(0 <= i && i < 10);
+            body_invariant!(a[0] <= a[i]);
             body_invariant!(forall(|k1: usize, k2: usize| (0 <= k1 && k1 < k2 && k2 < i)
                                     ==> a[k1] <= a[k2],
                                     triggers=[(a[k1],a[k2])]));
@@ -61,19 +63,9 @@ fn selection_sort(a: &mut [i32; 10]) {
 
         let a_i = a[i];
         let a_min = a[min];
-        // FIXME: replace all calls to `set` with array assignments when possible
-        set(a, i,  a_min);
-        set(a, min, a_i);
-        // a[i] = a_min;
-        // a[min] = a_i;
+        a[i] = a_min;
+        a[min] = a_i;
 
         i += 1;
     }
-}
-
-#[requires(0 <= i && i < 10)]
-#[ensures(forall(|j: usize| (0 <= j && j < 10 && j != old(i)) ==> (a[j] == old(a[j])), triggers=[(a[j],)]))]
-#[ensures(a[old(i)] == old(v))]
-fn set(a: &mut [i32; 10], i: usize, v: i32) {
-    a[i] = v;
 }

--- a/prusti-tests/tests/verify/pass/issues/issue-877-1.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-877-1.rs
@@ -1,0 +1,42 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+#[ensures(result <= 3)]
+fn foo() -> usize {
+    let mut a = [1, 2, 3];
+    let mut i = 0;
+    while i < 3 {
+        body_invariant!(i < 3);
+        body_invariant!(forall(|j: usize| (0 <= j && j < i) ==> (a[j] <= j + 2),triggers=[(a[j],)]));
+        body_invariant!(forall(|j: usize| (i <= j && j < 3) ==> (a[j] <= j + 1),triggers=[(a[j],)]));
+        body_invariant!(a[i] <= i + 1);
+        let tmp = a[i] + 1;
+        a[i] = tmp;
+        i += 1;
+    }
+    a[1]
+}
+
+#[ensures(result <= 3)]
+fn bar() -> usize {
+    let mut a = [1, 2, 3];
+    let mut i= 0;
+    while i < 3 {
+        body_invariant!(i < 3);
+        body_invariant!(forall(|j: usize| (0 <= j && j < i) ==> (a[j] <= j + 2),triggers=[(a[j],)]));
+        body_invariant!(forall(|j: usize| (i <= j && j < 3) ==> (a[j] <= j + 1),triggers=[(a[j],)]));
+        body_invariant!(a[i] <= i + 1);
+        let tmp = a[i] + 1;
+        set(&mut a, i, tmp);
+        i += 1;
+    }
+    a[1]
+}
+
+#[requires(0 <= i && i < 3)]
+#[ensures(forall(|j: usize| (0 <= j && j < 3 && j != old(i)) ==> (a[j] == old(a[j])), triggers=[(a[j],)]))]
+#[ensures(a[old(i)] == old(v))]
+fn set(a: &mut [usize; 3], i: usize, v: usize) {
+    a[i] = v;
+}

--- a/prusti-viper/src/encoder/foldunfold/mod.rs
+++ b/prusti-viper/src/encoder/foldunfold/mod.rs
@@ -1616,4 +1616,34 @@ impl<'b, 'a: 'b> FallibleExprFolder for ExprReplacer<'b, 'a> {
             Ok(result)
         }
     }
+    fn fallible_fold_forall(&mut self, expr: vir::ForAll) -> Result<vir::Expr, Self::Error> {
+        let vir::ForAll {
+            variables,
+            triggers,
+            body,
+            position,
+        } = expr;
+        Ok(vir::Expr::ForAll(vir::ForAll {
+            variables,
+            // triggers should be skipped
+            triggers,
+            body: self.fallible_fold_boxed(body)?,
+            position,
+        }))
+    }
+    fn fallible_fold_exists(&mut self, expr: vir::Exists) -> Result<vir::Expr, Self::Error> {
+        let vir::Exists {
+            variables,
+            triggers,
+            body,
+            position,
+        } = expr;
+        Ok(vir::Expr::Exists(vir::Exists {
+            variables,
+            // triggers should be skipped
+            triggers,
+            body: self.fallible_fold_boxed(body)?,
+            position,
+        }))
+    }
 }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5206,10 +5206,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let idx_conditions = vir_expr!{ [zero_le_i] && ([i_lt_len] && [i_ne_idx]) };
         let tymap = FxHashMap::default();
         let lookup_ret_ty = self.encoder.encode_snapshot_type(array_types.elem_ty_rs, &tymap).with_span(span)?;
-        let lookup_array_i = array_types.encode_lookup_pure_call(self.encoder, encoded_array.clone(), i_var, lookup_ret_ty.clone());
+        let lookup_array_i = array_types.encode_lookup_pure_call(self.encoder, encoded_array.clone(), i_var.clone(), lookup_ret_ty.clone());
+        // FIXME: using `old` here is a work-around for https://github.com/viperproject/prusti-dev/issues/877
+        let lookup_array_i_old = array_types.encode_lookup_pure_call(self.encoder, old(encoded_array.clone()), i_var, lookup_ret_ty.clone());
         let lookup_same_as_old = vir_expr!{ [lookup_array_i] == [old(lookup_array_i.clone())] };
         let forall_body = vir_expr!{ [idx_conditions] ==> [lookup_same_as_old] };
-        let all_others_unchanged = vir_expr!{ forall i: Int :: { [lookup_array_i] } [ forall_body ] };
+        let all_others_unchanged = vir_expr!{ forall i: Int :: { [lookup_array_i_old] } [ forall_body ] };
 
         stmts.push(vir_stmt!{ inhale [ all_others_unchanged ]});
 

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5209,7 +5209,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let lookup_array_i = array_types.encode_lookup_pure_call(self.encoder, encoded_array.clone(), i_var.clone(), lookup_ret_ty.clone());
         // FIXME: using `old` here is a work-around for https://github.com/viperproject/prusti-dev/issues/877
         let lookup_array_i_old = array_types.encode_lookup_pure_call(self.encoder, old(encoded_array.clone()), i_var, lookup_ret_ty.clone());
-        let lookup_same_as_old = vir_expr!{ [lookup_array_i] == [old(lookup_array_i.clone())] };
+        let lookup_same_as_old = vir_expr!{ [lookup_array_i] == [old(lookup_array_i)] };
         let forall_body = vir_expr!{ [idx_conditions] ==> [lookup_same_as_old] };
         let all_others_unchanged = vir_expr!{ forall i: Int :: { [lookup_array_i_old] } [ forall_body ] };
 

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5208,6 +5208,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let lookup_ret_ty = self.encoder.encode_snapshot_type(array_types.elem_ty_rs, &tymap).with_span(span)?;
         let lookup_array_i = array_types.encode_lookup_pure_call(self.encoder, encoded_array.clone(), i_var.clone(), lookup_ret_ty.clone());
         // FIXME: using `old` here is a work-around for https://github.com/viperproject/prusti-dev/issues/877
+        // FIXME: which is due to an issue in Silicon, see https://github.com/viperproject/silicon/issues/603
         let lookup_array_i_old = array_types.encode_lookup_pure_call(self.encoder, old(encoded_array.clone()), i_var, lookup_ret_ty.clone());
         let lookup_same_as_old = vir_expr!{ [lookup_array_i] == [old(lookup_array_i)] };
         let forall_body = vir_expr!{ [idx_conditions] ==> [lookup_same_as_old] };


### PR DESCRIPTION
This PR experiments with addressing 2 things:

1. It implements the suggested work-around for #877 together with a regression test (the test suite indicated no regressions locally).
2. The `selection_sort.rs` test case was updated to use this fix in order to remove the auxiliary `set` function (#819).

Some notes apply to the approach chosen to make `selection_sort.rs` verify:

* A "dummy" `body_invariant!(a[0] <= a[i]);` was added to the outer and inner loops in order to correctly trigger the quantifiers.
* A change was made in `prusti-viper/src/encoder/foldunfold/mod.rs` to prevent Prusti from running into an encoder error when the `old` expresion was only present in the trigger, but not in the quantifier body. Without this change, `selection_sort.rs` will complain about a fold-unfold error. Since access predicates are not needed when the `old` expression is only present in the trigger, this should be sound (but please do double check this during the peer review).
* Without the auxiliary `set` function, the verification time roughly doubled, but it is still well within the `-Pverification_deadline=180` compiler parameter. Execution time now hovers around ~2 minutes on my PC.

If the chosen approach sounds good, then this PR can be merged. I'm still a bit suspicious about why the `set` function yields better performance, I could look into this deeper with some guidance (possibly in a separate PR if that makes more sense). For now I came up empty-handed for what could be causing this performance regression (if this happens to be related to how Viper gives hints to Z3 based on the Viper/Silver syntax, then my current experience may not be of much help, but am willing to learn more!).

Thanks!

p.s. Issue #877 can be left open for now in case we want to file a bug report with the Viper back-end developers to investigate the `old` trigger issue. I posted a ~30 lines example there that hopefully is small enough to investigate.