### PR TITLE
Better support for generics (in traits / impls)

### DIFF
--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -22,6 +22,7 @@ use log::{debug, trace};
 use std::rc::Rc;
 use std::collections::HashMap;
 use std::cell::RefCell;
+use rustc_hash::FxHashMap;
 
 pub mod borrowck;
 mod collect_prusti_spec_visitor;
@@ -388,5 +389,47 @@ impl<'tcx> Environment<'tcx> {
                 .type_implements_trait(trait_def_id, ty, ty::List::empty(), param_env)
                 .must_apply_considering_regions()
         )
+    }
+
+    // TODO hansenj: Docs
+    // TODO hansenj: Only useful for traits?
+    // TODO hansenj: Debugging
+    pub fn map_generics_to_substs(&self, def_id: ProcedureDefId, call_substs: SubstsRef<'tcx>) -> FxHashMap<ty::Ty<'tcx>, ty::Ty<'tcx>> {
+        let mut generic_mapping = FxHashMap::default();
+
+        if call_substs.len() == 0 { // TODO: Why?
+            return generic_mapping;
+        }
+
+        if let Some(impl_did) = self.find_impl_of_trait_method_call(def_id, call_substs) {
+            let trait_did = self.tcx.trait_of_item(def_id).unwrap();
+
+            let trait_ref = ty::TraitRef::from_method(self.tcx, trait_did, call_substs);
+            let trait_binder = ty::Binder::bind_with_vars(trait_ref, ty::List::empty());
+            let param_env = self.tcx.param_env(impl_did);
+            let obligation = traits::codegen_fulfill_obligation(self.tcx,(param_env, trait_binder));
+
+            if let Ok(rustc_middle::traits::ImplSource::UserDefined(ud)) = obligation {
+                let own_substs_impl = ty::List::identity_for_item(self.tcx, impl_did);
+                let obligation_substs = ud.substs;
+
+                for (impl_arg, call_arg) in own_substs_impl.iter().zip(obligation_substs) {
+                    if let (
+                        ty::subst::GenericArgKind::Type(call_ty),
+                        ty::subst::GenericArgKind::Type(impl_ty),
+                    ) = (call_arg.unpack(), impl_arg.unpack())
+                    {
+                        if call_ty == impl_ty { // TODO: Nope
+                            continue;
+                        }
+                        if let ty::TyKind::Param(_) = impl_ty.kind() { // only insert if impl_ty is a generic param
+                            generic_mapping.insert(impl_ty, call_ty);
+                        }
+                    }
+                }
+            }
+        }
+
+        generic_mapping
     }
 }

--- a/prusti-interface/src/environment/traits/mod.rs
+++ b/prusti-interface/src/environment/traits/mod.rs
@@ -2,3 +2,4 @@ mod rustc_codegen;
 mod rustc_instance;
 
 pub(super) use rustc_instance::resolve_instance;
+pub(super) use rustc_codegen::codegen_fulfill_obligation;

--- a/prusti-interface/src/environment/tymap.rs
+++ b/prusti-interface/src/environment/tymap.rs
@@ -1,0 +1,127 @@
+use super::{traits, Environment};
+use crate::data::ProcedureDefId;
+use log::{trace, warn};
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_middle::{ty, ty::subst::SubstsRef};
+
+type Key<'tcx> = ty::Ty<'tcx>;
+type Value<'tcx> = ty::Ty<'tcx>;
+
+#[derive(Default, Clone, Debug)]
+pub struct SubstMap<'tcx> {
+    map: FxHashMap<Key<'tcx>, Value<'tcx>>,
+}
+
+impl<'tcx> SubstMap<'tcx> {
+    /// Builds a SubstMap from a call to a function.
+    /// The built tymap considers whether the called function resolves to a trait implementation
+    /// and adds the necessary substitutions.
+    pub fn build<'a>(
+        env: &'a Environment<'tcx>,
+        def_id: ProcedureDefId,
+        call_substs: SubstsRef<'tcx>,
+    ) -> Self {
+        trace!(
+            "Building tymap for {:?} with substs {:?}",
+            def_id,
+            call_substs
+        );
+
+        let mut tymap = Self::default();
+
+        // Add generic information from the call to this method
+        let own_substs = ty::List::identity_for_item(env.tcx(), def_id);
+        own_substs
+            .iter()
+            .zip(call_substs)
+            .for_each(|(generic_arg, call_arg)| tymap.insert_arg(generic_arg, call_arg));
+
+        // In case this is a trait method implementation, we also extend
+        // tymap with information from the implementation itself
+        let maybe_impl_did = if call_substs.is_empty() {
+            None
+        } else {
+            env.find_impl_of_trait_method_call(def_id, call_substs)
+        };
+
+        if let Some(impl_did) = maybe_impl_did {
+            let impl_own_substs = ty::List::identity_for_item(env.tcx(), impl_did);
+            let trait_did = env.tcx().trait_of_item(def_id).unwrap();
+            let trait_ref = ty::TraitRef::from_method(env.tcx(), trait_did, call_substs);
+            let trait_binder = ty::Binder::dummy(trait_ref);
+            let param_env = env.tcx().param_env(impl_did);
+            let obligation =
+                traits::codegen_fulfill_obligation(env.tcx(), (param_env, trait_binder));
+            let obligation_substs =
+                if let Ok(rustc_middle::traits::ImplSource::UserDefined(ud)) = obligation {
+                    trace!(
+                        "Additional substs declared on trait method impl: {:?}",
+                        ud.substs
+                    );
+                    ud.substs
+                } else {
+                    call_substs
+                };
+
+            impl_own_substs
+                .iter()
+                .zip(obligation_substs)
+                .for_each(|(impl_arg, obligation_arg)| tymap.insert_arg(impl_arg, obligation_arg));
+        }
+
+        trace!("\t-> {:?}", tymap);
+        tymap
+    }
+
+    pub fn get(&self, ty: &Key<'tcx>) -> Option<&Value<'tcx>> {
+        self.map.get(ty)
+    }
+
+    pub fn insert_ty(&mut self, k: Key<'tcx>, v: Value<'tcx>) -> Option<Value<'tcx>> {
+        self.map.insert(k, v)
+    }
+
+    pub fn insert_arg(&mut self, k: ty::subst::GenericArg<'tcx>, v: ty::subst::GenericArg<'tcx>) {
+        if let (ty::subst::GenericArgKind::Type(ty1), ty::subst::GenericArgKind::Type(ty2)) =
+            (k.unpack(), v.unpack())
+        {
+            if ty1 != ty2 {
+                self.insert_ty(ty1, ty2);
+            }
+        }
+    }
+
+    pub fn extend(&mut self, other: SubstMap<'tcx>) {
+        self.map.extend(other.map);
+    }
+
+    /// Transitively resolves a type.
+    /// In case there are cyclic dependencies, returns the last visited type.
+    pub fn resolve(&self, ty: &Key<'tcx>) -> Option<&Value<'tcx>> {
+        trace!("Resolving type {:?} with tymap {:?}", ty, self);
+        let mut result = self.map.get(ty);
+
+        // Handle cyclic dependencies with a set of already visited types
+        let mut visited: FxHashSet<Key<'tcx>> = FxHashSet::default();
+        while result.is_some() && self.map.contains_key(result.unwrap()) {
+            visited.insert(result.unwrap());
+
+            result = self.map.get(result.unwrap());
+
+            if let Some(result) = result {
+                if visited.contains(result) {
+                    warn!("Type {:?} has cyclic dependency", ty);
+                    return Some(result);
+                }
+                visited.insert(result);
+            }
+        }
+
+        trace!("\t-> {:?}", result);
+        result
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Key<'tcx>, &Value<'tcx>)> {
+        self.map.iter()
+    }
+}

--- a/prusti-tests/tests/verify_overflow/pass/trait-contracts-refinement/generics/trait-impl-for-generic-type-with-generic-trait.rs
+++ b/prusti-tests/tests/verify_overflow/pass/trait-contracts-refinement/generics/trait-impl-for-generic-type-with-generic-trait.rs
@@ -1,0 +1,37 @@
+use prusti_contracts::*;
+
+trait Trait<X> {
+    #[pure]
+    fn foo(&self) -> i32;
+}
+
+struct Foo<U, V>(std::marker::PhantomData<U>, std::marker::PhantomData<V>);
+impl<U, V, W> Trait<W> for Foo<U, V> {
+    #[pure]
+    fn foo(&self) -> i32 {
+        42
+    }
+}
+
+// Assuming function is called with T0,T1,T2, encoder should be smart enough to map
+// A->U->T0, B->U->T1, C->X->T2
+#[requires(Trait::<C>::foo(arg) == 42)]
+fn verify_generic_precondition_1<A,B,C>(arg: &Foo<A,B>) {
+}
+
+// Generics in function have same name as generics in trait impl
+#[requires(Trait::<W>::foo(arg) == 42)]
+fn verify_generic_precondition_2<U,V,W>(arg: &Foo<U,V>) {
+}
+
+fn main() {
+    let f = Foo::<u32, i32>(std::marker::PhantomData, std::marker::PhantomData);
+    assert!(Trait::<usize>::foo(&f) == 42);
+    verify_generic_precondition_1::<u32, i32, usize>(&f);
+    verify_generic_precondition_2::<u32, i32, usize>(&f);
+
+    let f = Foo::<i32, u32>(std::marker::PhantomData,std::marker::PhantomData);
+    assert!(Trait::<usize>::foo(&f) == 42);
+    verify_generic_precondition_1::<i32, u32, usize>(&f);
+    verify_generic_precondition_2::<i32, u32, usize>(&f);
+}

--- a/prusti-tests/tests/verify_overflow/pass/trait-contracts-refinement/generics/trait-impl-for-generic-type.rs
+++ b/prusti-tests/tests/verify_overflow/pass/trait-contracts-refinement/generics/trait-impl-for-generic-type.rs
@@ -14,16 +14,18 @@ impl<T> Trait for Foo<T> {
 }
 
 fn verify_instantiations() {
-    let f = Foo::<u32>(std::marker::PhantomData);
-    assert!(f.foo() == 42);
-
-    let f = Foo::<u32>(std::marker::PhantomData);
-    assert!(f.foo() == 42);
 }
 
 #[requires(arg.foo() == 42)]
-fn verify_in_precondition<T>(arg: Foo<T>) {
+fn verify_in_precondition<T>(arg: &Foo<T>) {
 }
 
 fn main() {
+    let f = Foo::<u32>(std::marker::PhantomData);
+    assert!(f.foo() == 42);
+    verify_in_precondition(&f);
+
+    let f = Foo::<u32>(std::marker::PhantomData);
+    assert!(f.foo() == 42);
+    verify_in_precondition(&f);
 }

--- a/prusti-tests/tests/verify_overflow/pass/trait-contracts-refinement/generics/trait-impl-for-generic-type.rs
+++ b/prusti-tests/tests/verify_overflow/pass/trait-contracts-refinement/generics/trait-impl-for-generic-type.rs
@@ -1,0 +1,29 @@
+use prusti_contracts::*;
+
+trait Trait {
+    #[pure]
+    fn foo(&self) -> i32;
+}
+
+struct Foo<T>(std::marker::PhantomData<T>);
+impl<T> Trait for Foo<T> {
+    #[pure]
+    fn foo(&self) -> i32 {
+        42
+    }
+}
+
+fn verify_instantiations() {
+    let f = Foo::<u32>(std::marker::PhantomData);
+    assert!(f.foo() == 42);
+
+    let f = Foo::<u32>(std::marker::PhantomData);
+    assert!(f.foo() == 42);
+}
+
+#[requires(arg.foo() == 42)]
+fn verify_in_precondition<T>(arg: Foo<T>) {
+}
+
+fn main() {
+}

--- a/prusti-tests/tests/verify_overflow/pass/trait-contracts-refinement/generics/trait-impl-for-generic-type.rs
+++ b/prusti-tests/tests/verify_overflow/pass/trait-contracts-refinement/generics/trait-impl-for-generic-type.rs
@@ -13,9 +13,6 @@ impl<T> Trait for Foo<T> {
     }
 }
 
-fn verify_instantiations() {
-}
-
 #[requires(arg.foo() == 42)]
 fn verify_in_precondition<T>(arg: &Foo<T>) {
 }
@@ -25,7 +22,7 @@ fn main() {
     assert!(f.foo() == 42);
     verify_in_precondition(&f);
 
-    let f = Foo::<u32>(std::marker::PhantomData);
+    let f = Foo::<i32>(std::marker::PhantomData);
     assert!(f.foo() == 42);
     verify_in_precondition(&f);
 }

--- a/prusti-viper/src/encoder/borrows.rs
+++ b/prusti-viper/src/encoder/borrows.rs
@@ -20,7 +20,7 @@ use prusti_interface::specs::typed;
 use log::{trace};
 use crate::encoder::errors::EncodingError;
 use crate::encoder::errors::EncodingResult;
-
+use prusti_interface::environment::tymap::SubstMap;
 
 
 #[derive(Clone, Debug)]
@@ -420,7 +420,7 @@ pub fn compute_procedure_contract<'p, 'a, 'tcx>(
     proc_def_id: ProcedureDefId,
     env: &Environment<'tcx>,
     specification: typed::SpecificationSet,
-    maybe_tymap: Option<&FxHashMap<ty::Ty<'tcx>, ty::Ty<'tcx>>>,
+    maybe_tymap: Option<&SubstMap<'tcx>>,
 ) -> EncodingResult<ProcedureContractMirDef<'tcx>>
 where
     'a: 'p,
@@ -462,7 +462,7 @@ where
 
     for (local, arg_ty) in args_ty {
         fake_mir_args.push(local);
-        fake_mir_args_ty.push(if let Some(replaced_arg_ty) = maybe_tymap.and_then(|tymap| tymap.get(arg_ty)) {
+        fake_mir_args_ty.push(if let Some(replaced_arg_ty) = maybe_tymap.and_then(|tymap| tymap.get(&arg_ty)) {
             replaced_arg_ty
         } else {
             arg_ty

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -27,7 +27,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::mir;
 use rustc_middle::ty;
 use std::cell::{Cell, RefCell, RefMut, Ref};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use std::io::Write;
 use std::rc::Rc;
 use crate::encoder::stub_procedure_encoder::StubProcedureEncoder;
@@ -57,6 +57,7 @@ use super::mir::{
     }
 };
 use super::high::types::{HighTypeEncoderState, HighTypeEncoderInterface};
+pub use prusti_interface::environment::tymap::SubstMap;
 
 pub struct Encoder<'v, 'tcx: 'v> {
     env: &'v Environment<'tcx>,
@@ -100,7 +101,6 @@ pub struct Encoder<'v, 'tcx: 'v> {
 }
 
 pub type EncodingTask<'tcx> = (ProcedureDefId, Vec<(ty::Ty<'tcx>, ty::Ty<'tcx>)>);
-pub type SubstMap<'tcx> = FxHashMap<ty::Ty<'tcx>, ty::Ty<'tcx>>;
 
 // If the field name is an identifier, removing the leading prefix r#
 pub fn encode_field_name(field_name: &str) -> String {
@@ -608,7 +608,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
 
         if !self.spec_functions.borrow().contains_key(&def_id) {
             let procedure = self.env.get_procedure(def_id);
-            let tymap = FxHashMap::default(); // TODO: This is probably wrong.
+            let tymap = SubstMap::default(); // TODO: This is probably wrong.
             let substs = ty::List::empty(); // TODO: This is probably wrong.
             let spec_func_encoder = SpecFunctionEncoder::new(self, &procedure, &tymap, &substs);
             let result = spec_func_encoder.encode()?.into_iter().map(|function| {
@@ -799,7 +799,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
 
                 // TODO: Make sure that this encoded function does not end up in
                 // the Viper file because that would be unsound.
-                if let Err(error) = self.encode_pure_function_def(proc_def_id, &FxHashMap::default(), &ty::List::empty()) {
+                if let Err(error) = self.encode_pure_function_def(proc_def_id, &SubstMap::default(), &ty::List::empty()) {
                     self.register_encoding_error(error);
                     debug!("Error encoding function: {:?}", proc_def_id);
                     // Skip encoding the function as a method.
@@ -832,24 +832,14 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         use rustc_middle::ty::fold::{TypeFolder, TypeFoldable};
         struct Resolver<'a, 'tcx> {
             tcx: ty::TyCtxt<'tcx>,
-            tymap: &'a FxHashMap<ty::Ty<'tcx>, ty::Ty<'tcx>>,
+            tymap: &'a SubstMap<'tcx>,
         }
         impl<'a, 'tcx> TypeFolder<'tcx> for Resolver<'a, 'tcx> {
             fn tcx(&self) -> ty::TyCtxt<'tcx> {
                 self.tcx
             }
             fn fold_ty(&mut self, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
-                let mut rep = self.tymap.get(&ty).unwrap_or(&ty);
-
-                // TODO hansenj: Is this working?
-                let mut visited: FxHashSet<ty::Ty<'tcx>> = FxHashSet::default(); // Break cycles
-                visited.insert(rep);
-                while self.tymap.contains_key(rep) {
-                    rep = self.tymap.get(rep).unwrap();
-                    if visited.contains(rep) { break; }
-                    visited.insert(rep);
-                }
-
+                let rep = self.tymap.resolve(&ty).unwrap_or(&ty);
                 rep.super_fold_with(self)
             }
         }

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -94,7 +94,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             // substitute to the same type as Self
             if let (Some(wrapper_self), Some(target_self)) = (wrapper_self, target_self) {
                 if let Some(self_subst) = tymap.get(&target_self.expect_ty()).cloned() {
-                    tymap.insert(wrapper_self.expect_ty(), self_subst);
+                    tymap.insert_ty(wrapper_self.expect_ty(), self_subst);
                 }
             }
         }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2038,7 +2038,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         &self.encoder.env().tcx().def_path_str(def_id);
                         // &self.encoder.env().tcx().absolute_item_path_str(def_id);
 
-                    let tymap = self.build_tymap_for_function_call(def_id, substs);
+                    // FIXME: this is a hack to support generics. See issue #187.
+                    let tymap = SubstMap::build(self.encoder.env(), def_id, substs);
 
                     match full_func_proc_name {
                         "std::rt::begin_panic"
@@ -2349,26 +2350,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(result)
     }
 
-    // FIXME: this is a hack to support generics. See issue #187.
-    // TODO hansenj: Might wanna move this
-    fn build_tymap_for_function_call(&self, def_id: ProcedureDefId, call_substs: SubstsRef<'tcx>) -> FxHashMap<ty::Ty<'tcx>, ty::Ty<'tcx>> {
-        let env = self.encoder.env();
-        let mut tymap = FxHashMap::default();
-        let own_substs = ty::List::identity_for_item(env.tcx(), def_id);
-        for (kind1, kind2) in own_substs.iter().zip(call_substs.iter()) {
-            if let (
-                ty::subst::GenericArgKind::Type(ty1),
-                ty::subst::GenericArgKind::Type(ty2),
-            ) = (kind1.unpack(), kind2.unpack())
-            {
-                tymap.insert(ty1, ty2);
-            }
-        }
-
-        tymap.extend(self.encoder.env().map_generics_to_substs(def_id, call_substs).into_iter());
-        tymap
-    }
-
     fn encode_slice_len_call(
         &mut self,
         destination: &Option<(mir::Place<'tcx>, BasicBlockIndex)>,
@@ -2464,7 +2445,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let base_seq_expr = self.encoder.encode_value_expr(base_seq, base_seq_ty)?;
 
         let j = vir_local!{ j: Int };
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let rhs_lookup_j = match base_seq_ty {
             a if a.peel_refs().is_array() => {
                 let enc_array_types = self.encoder.encode_array_types(a.peel_refs())?;
@@ -2548,7 +2529,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
 
         let slice_types_lhs = self.encoder.encode_slice_types(lhs_slice_ty)?;
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let elem_snap_ty = self.encoder.encode_snapshot_type(slice_types_lhs.elem_ty_rs, &tymap)?;
 
         // length
@@ -3498,7 +3479,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             .encode_prusti_local(self.procedure_contract().returned_value).into();
 
         // FIXME: ??? new tymap?
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let substs = ty::List::empty();
         debug!("procedure_contract: {:?}", self.procedure_contract());
 
@@ -3598,7 +3579,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         start_cfg_block: CfgBlockIndex,
         weakening_spec: Option<vir::Expr>,
     ) -> SpannedEncodingResult<()> {
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let substs = ty::List::empty();
         self.cfg_method
             .add_stmt(start_cfg_block, vir::Stmt::comment("Preconditions:"));
@@ -4077,7 +4058,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
         debug!("encode_package_end_of_method '{:?}'", location);
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let substs = ty::List::empty();
         let mut stmts = Vec::new();
         let span = self.mir.source_info(location).span;
@@ -4206,7 +4187,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         return_cfg_block: CfgBlockIndex,
         strengthening_spec: Option<vir::Expr>,
     ) -> SpannedEncodingResult<()> {
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let substs = ty::List::empty();
         // This clone is only due to borrow checker restrictions
         let contract = self.procedure_contract().clone();
@@ -4791,7 +4772,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             loop_head,
             spec_blocks
         );
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let substs = ty::List::empty();
 
         // `body_invariant!(..)` is desugared to a closure with special attributes,
@@ -5105,7 +5086,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         //   inhale lookup_pure(array, index) == encoded_rhs
         //   // now we have all the contents as before, just one item updated
 
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
 
         let (encoded_array, mut stmts) = self.postprocess_place_encoding(
             base,
@@ -5137,7 +5118,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let i_lt_len = vir_expr!{ [ i_var ] < [ vir::Expr::from(array_types.array_len) ] };
         let i_ne_idx = vir_expr!{ [ i_var ] != [ old(idx_val_int.clone()) ] };
         let idx_conditions = vir_expr!{ [zero_le_i] && ([i_lt_len] && [i_ne_idx]) };
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let lookup_ret_ty = self.encoder.encode_snapshot_type(array_types.elem_ty_rs, &tymap).with_span(span)?;
         let lookup_array_i = array_types.encode_lookup_pure_call(self.encoder, encoded_array.clone(), i_var, lookup_ret_ty.clone());
         let lookup_same_as_old = vir_expr!{ [lookup_array_i] == [old(lookup_array_i.clone())] };
@@ -5587,7 +5568,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                             self.proc_def_id,
                         );
                     }
-                    let substs = FxHashMap::default();
+                    let substs = SubstMap::default();
                     let encoded_rhs = self.encoder.encode_discriminant_func_app(
                         encoded_src,
                         adt_def,
@@ -5699,7 +5680,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             operand,
             dst_ty
         );
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let span = self.mir_encoder.get_span_of_location(location);
         let encoded_val = self.mir_encoder.encode_cast_expr(operand, dst_ty, span, &tymap)?;
         self.encode_copy_value_assign(encoded_lhs, encoded_val, ty, location)
@@ -5768,7 +5749,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             expr: vir_expr!{ [slice_len_call] == [vir::Expr::from(array_types.array_len)] }
         }));
 
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let elem_snap_ty = self.encoder.encode_snapshot_type(array_types.elem_ty_rs, &tymap).with_span(span)?;
 
         let i: Expr = vir_local! { i: Int }.into();
@@ -5886,7 +5867,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             .with_span(span)?;
         let len: usize = self.encoder.const_eval_intlike(&times.val).with_span(span)?
             .to_u64().unwrap().try_into().unwrap();
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let lookup_ret_ty = self.encoder.encode_snapshot_type(array_types.elem_ty_rs, &tymap)
             .with_span(span)?;
 
@@ -6138,7 +6119,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             "[enter] encode_assign_aggregate({:?}, {:?})",
             aggregate, operands
         );
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let span = self.mir_encoder.get_span_of_location(location);
         let mut stmts = self.encode_havoc_and_initialization(dst);
         // Initialize values
@@ -6342,7 +6323,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let lookup_res: vir::Expr = self.cfg_method.add_fresh_local_var(array_types.elem_pred_type.clone()).into();
         let val_field = self.encoder.encode_value_field(array_types.elem_ty_rs)?;
         let lookup_res_val_field = lookup_res.clone().field(val_field);
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let lookup_ret_ty = self.encoder.encode_snapshot_type(array_types.elem_ty_rs, &tymap)?;
 
         let (encoded_base_expr, mut stmts) = self.postprocess_place_encoding(base, ArrayAccessKind::Shared)?;
@@ -6376,7 +6357,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         _loan: Option<Borrow>,
         location: mir::Location,
     ) -> EncodingResult<(vir::Expr, Vec<vir::Stmt>)> {
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let array_types = self.encoder.encode_array_types(array_ty)?;
 
         let res: vir::Expr = self.cfg_method.add_fresh_local_var(array_types.elem_pred_type.clone()).into();
@@ -6412,7 +6393,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let old_lhs = |e| { vir::Expr::labelled_old("lhs", e) };
 
         // value of res
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let lookup_ret_ty = self.encoder.encode_snapshot_type(array_types.elem_ty_rs, &tymap)?;
         let lookup_pure_call = array_types.encode_lookup_pure_call(
             self.encoder,
@@ -6504,7 +6485,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 let res = vir::Expr::local(self.cfg_method.add_fresh_local_var(slice_types.elem_pred_type.clone()));
                 let val_field = self.encoder.encode_value_field(slice_types.elem_ty_rs)?;
                 let res_val_field = res.clone().field(val_field);
-                let tymap = FxHashMap::default();
+                let tymap = SubstMap::default();
                 let elem_snap_ty = self.encoder.encode_snapshot_type(slice_types.elem_ty_rs, &tymap)?;
 
                 let (encoded_base_expr, mut stmts) = self.postprocess_place_encoding(*base, array_encode_kind)?;

--- a/prusti-viper/src/encoder/purifier.rs
+++ b/prusti-viper/src/encoder/purifier.rs
@@ -64,7 +64,7 @@ pub fn purify_method(
         candidates
     );
 
-    let tymap = FxHashMap::default();
+    let tymap = SubstMap::default();
     let mut purifier = Purifier::new(encoder, candidates, tymap);
 
     for block in &mut method.basic_blocks {

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -141,7 +141,7 @@ impl SnapshotEncoder {
         method: vir::CfgMethod,
     ) -> EncodingResult<vir::CfgMethod> {
         debug!("[snap] method: {:?}", method.name());
-        let tymap = FxHashMap::default();
+        let tymap = SubstMap::default();
         let mut patcher = SnapshotPatcher {
             snapshot_encoder: self,
             encoder,


### PR DESCRIPTION
This PR aims to provide better support for generics with trait implementations.
Currently, when Prusti encodes a trait method and the corresponding implementation has generics like in this example:

```rust
trait Trait {
    #[pure]
    fn foo(&self) -> i32;
}

struct Foo<T>(std::marker::PhantomData<T>);
impl<T> Trait for Foo<T> {
    #[pure]
    fn foo(&self) -> i32 {
        42
    }
}

fn main() {
    let f = Foo::<u32>(std::marker::PhantomData);
    assert!(f.foo() == 42);
    let f = Foo::<i32>(std::marker::PhantomData);
    assert!(f.foo() == 42);
}
```
we get a wrong encoding because the generic parameter `T` is not instantiated with the callsite arguments `u32` and `i32`, which leads to a type error in Viper.
In this PR, I adjusted tymap to also contain information from the trait implementation block.