### PR TITLE
Add correct lifetime identifiers

### DIFF
--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -713,6 +713,29 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         self.intern_viper_identifier(full_name, short_name)
     }
 
+    pub fn encode_lifetime_name(&self, region: &ty::Region) -> String {
+        match region.kind() {
+            ty::ReEarlyBound(_) => {
+                unimplemented!("ReEarlyBound: {}", format!("{}", region));
+            },
+            ty::ReLateBound(_, _) => {
+                unimplemented!("ReLateBound: {}", format!("{}", region));
+            },
+            ty::ReFree(_) => {
+                unimplemented!("ReFree: {}", format!("{}", region));
+            },
+            ty::ReStatic=> String::from("lft_static"),
+            ty::ReVar(region_vid) => format!("lft_{}", region_vid.index()),
+            ty::RePlaceholder(_) => {
+                unimplemented!("RePlaceholder: {}", format!("{}", region));
+            },
+            ty::ReEmpty(_) => {
+                unimplemented!("ReEmpty: {}", format!("{}", region));
+            },
+            ty::ReErased => String::from("lft_erased"),
+        }
+    }
+
     pub fn encode_invariant_func_app(
         &self,
         ty: ty::Ty<'tcx>,

--- a/prusti-viper/src/encoder/high/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/high/pure_functions/interface.rs
@@ -92,12 +92,11 @@ impl<'v, 'tcx: 'v> HighPureFunctionEncoderInterface<'tcx>
         // FIXME: Should use encode_builtin_function_use.
         let name = "subslice";
         let element_type = extract_container_element_type(&container)?;
-        // TODO: add real lifetime here
-        let fake_lft = vir_high::ty::Lifetime {
-            name: "lft_fake".to_string(),
+        let pure_lifetime = vir_high::ty::Lifetime {
+            name: String::from("pure_erased"),
         };
         let return_type =
-            vir_high::Type::reference(vir_high::Type::slice(element_type.clone()), fake_lft);
+            vir_high::Type::reference(vir_high::Type::slice(element_type.clone()), pure_lifetime);
         Ok(vir_high::Expression::function_call(
             name,
             vec![element_type.clone()],

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -239,13 +239,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
                     .encoder
                     .encode_type_of_place_high(self.mir, *place)
                     .with_span(span)?;
-                // TODO: add real lifetime here?
-                let fake_lft = vir_high::ty::Lifetime {
-                    name: String::from("lft_fake"),
+                let pure_lifetime = vir_high::ty::Lifetime {
+                    name: String::from("pure_erased"),
                 };
                 let encoded_ref = vir_high::Expression::addr_of_no_pos(
                     encoded_place,
-                    vir_high::Type::reference(ty, fake_lft),
+                    vir_high::Type::reference(ty, pure_lifetime),
                 );
                 // Substitute the place
                 state.substitute_value(&encoded_lhs, encoded_ref);

--- a/prusti-viper/src/encoder/mir/pure/interpreter/state.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/state.rs
@@ -55,12 +55,14 @@ impl ExprBackwardInterpreterState {
         replacement: vir_high::Expression,
     ) {
         trace!("substitute_value {:?} --> {:?}", target, replacement);
-        let target = target.clone().substitute_types(&self.substs);
-        let replacement = replacement.substitute_types(&self.substs);
+        let mut target = target.clone().substitute_types(&self.substs);
+        let mut replacement = replacement.substitute_types(&self.substs);
 
         if let Some(curr_expr) = self.expr.as_mut() {
             // Replace two times to avoid cloning `expr`, which could be big.
             let expr = mem::replace(curr_expr, true.into());
+            target = target.erase_lifetime();
+            replacement = replacement.erase_lifetime();
             let mut new_expr = expr.replace_place(&target, &replacement); //.simplify_addr_of();
             mem::swap(curr_expr, &mut new_expr);
         }

--- a/vir/defs/high/operations_internal/ty.rs
+++ b/vir/defs/high/operations_internal/ty.rs
@@ -52,6 +52,13 @@ impl Type {
             false
         }
     }
+    pub fn erase_lifetime(&mut self) {
+        if let Type::Reference(reference) = self {
+            reference.lifetime = Lifetime {
+                name: String::from("pure_erased"),
+            };
+        }
+    }
 }
 
 impl AsRef<str> for VariantIndex {


### PR DESCRIPTION
# Changes
 - [x] Add constant lifetime for references in pure context
 - [x] Add real lifetimes for references created in mixed contexts (pure and impure)
 - [x] Replace real lifetimes with constant lifetimes (again) for pure contexts and make sure all cases are covered 
 - [x] Add function to create viper compatible variable names for Regions
