### PR TITLE
fix for #925

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-925.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-925.rs
@@ -1,0 +1,34 @@
+use prusti_contracts::*;
+
+fn main() {
+    let a = A::new(2, 3);
+    A::test(a, 4);
+}
+
+#[derive(Clone, Copy)]
+pub struct A {
+    foo: isize,
+    bar: usize,
+}
+
+impl A {
+    #[pure]
+    #[requires(num < isize::MAX as usize)]
+    pub fn new(num: usize, bar: usize) -> Self {
+        Self {
+            foo: num as isize + isize::MIN,
+            bar,
+        }
+    }
+
+    #[pure]
+    pub fn bar(&self) -> usize {
+        self.bar
+    }
+
+    #[pure]
+    #[requires(num < isize::MAX as usize)]
+    pub fn test(a: A, num: usize) -> A {
+        A::new(num, a.bar)
+    }
+}


### PR DESCRIPTION
This PR addresses issue #925 where a problem was uncovered with encoding the arguments of a pure function.

There was already an earlier attempt to fix this which already lives here:

https://github.com/viperproject/prusti-dev/blob/6a9291b92f1d742e36715a3fde15786abd950ea8/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs#L142-L167

However, it does not seem to catch all corner cases. I pretty much copied and pasted this code to `PureFunctionEncoder::encode_function_given_body` after the snapshot patching here:

https://github.com/viperproject/prusti-dev/blob/6a9291b92f1d742e36715a3fde15786abd950ea8/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs#L343-L350

Originally, I wanted to move the existing logic there instead of copying it, but it turns out that in order to patch the snapshots the arguments need to be "fixed", and in order to fix the arguments (again) the snapshots need to be patched :smile: 

The need for code duplication in this case and the presence of this circular code dependency, suggests there might exist a better way to address this. There is one other avenue I explored, although I couldn't piece it together, I'm including an explanation of it here, just in case:

To recap, the offending Viper code for #925 is:

```
function m_new__$TY$__(_1: Int, _2: Int): Snap$struct$m_A
  requires true
  requires _1 < builtin$cast$isize$usize__$TY$__(9223372036854775807)
  requires 0 <= _1
  requires _1 <= 18446744073709551615
  requires 0 <= _2
  requires _2 <= 18446744073709551615
  ensures true
  ensures [result == mirror_simple$m_new__$TY$__(_1, _2), true]
{
  (
    !(
      builtin$cast$usize$isize__$TY$__(_1) + -9223372036854775808 < -9223372036854775808
      || builtin$cast$usize$isize__$TY$__(_1) + -9223372036854775808 > 9223372036854775807
    )
      ? cons$0$__$TY$__Snap$struct$m_A$(
          builtin$cast$usize$isize__$TY$__(_1) + -9223372036854775808,
           _2.val_int // <-- the error comes from here
        )
      : builtin$unreach__$TY$__Snap$struct$m_A$()
  )
}
```

Here the second argument to the constructor of `A` is not properly encoded, it passes `_2.val_int` as a value instead of `_2`. The way the `PureFunctionBackwardInterpreter` walks the MIR to find this parameter, goes like this:

![mir](https://user-images.githubusercontent.com/81013316/160285335-de946a9d-eb1e-46de-83dc-0079de11d03c.png)

It starts at the end since it goes backwards, so the first time it encounters the second parameter is at MIR statement `_0 = A { foo: move _3, bar: move _7 }`. Next, it sees the assignment `_7 = _2;`. In theory, here the backwards interpreter can already recognize that `_2` is a (pure) function argument and that there will be no further statements encountered that would replace `_2`. At this point, it could already patch this assignment by wrapping `_2` in a field expression. This would happen here:

https://github.com/viperproject/prusti-dev/blob/e9edf18d1c6fa99cb4eaac1180d67e3837a661c1/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs#L798-L808

As long as `_2` is not wrapped in a field expression, the existing code in `PureFunctionEncoder::encode_function` is not able to fix this argument. The existing code replaces `target_place` which is assembled by calling `Encoder::encode_value_expr` (which in this case indirectly determines that the wrapping field is of type `vir::Type::Int` and has field name `val_int` and wraps it as such).

I was not able to properly puzzle this together in the code itself, but if it turns out that this is the preferred way to fix it, I could take another shot at it later this week :) Alternatively, an even better fix could also be deferred until a forward MIR interpreter is implemented (there was some talk of this not too long ago in #854, in order to bring down the memory consumption for encoding pure expressions with many branches).

I also included the example from #925 as a regression test.