### PR TITLE
Update dependencies (rustc nightly-2022-04-01, viper v-2022-03-26-0733)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -456,9 +456,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbfe11fe19ff083c48923cf179540e8cd0535903dc35e178a1fdeeb59aef51f"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
@@ -1335,9 +1335,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"
@@ -1387,9 +1387,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1474,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
@@ -1527,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1813,9 +1813,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -1993,9 +1993,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -2087,7 +2087,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -2135,21 +2135,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -2332,7 +2333,7 @@ dependencies = [
  "flate2",
  "fs2",
  "futures-util",
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "git2",
  "http",
  "lazy_static",
@@ -2431,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "serde"
@@ -2543,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "socket2"
@@ -2572,9 +2573,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd69e719f31e88618baa1eaa6ee2de5c9a1c004f1e9ecdb58e8352a13f20a01"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2770,7 +2771,7 @@ dependencies = [
  "bytes 1.1.0",
  "libc",
  "memchr",
- "mio 0.8.1",
+ "mio 0.8.2",
  "num_cpus",
  "once_cell",
  "pin-project-lite 0.2.8",
@@ -2868,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
 ]
@@ -2893,13 +2894,14 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
-version = "1.0.56"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d60539445867cdd9680b2bfe2d0428f1814b7d5c9652f09d8d3eae9d19308db"
+checksum = "606ab3fe0065741fdbb51f64bcb6ba76f13fad49f1723030041826c631782764"
 dependencies = [
  "glob",
  "once_cell",
  "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
  "toml",
@@ -3034,7 +3036,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "serde",
 ]
 

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -180,7 +180,7 @@ impl<'tcx> Environment<'tcx> {
 
     /// Returns true if an error has been emitted
     pub fn has_errors(&self) -> bool {
-        self.tcx.sess.has_errors()
+        self.tcx.sess.has_errors().is_some()
     }
 
     /// Get ids of Rust procedures that are annotated with a Prusti specification

--- a/prusti-interface/src/environment/traits/rustc_codegen.rs
+++ b/prusti-interface/src/environment/traits/rustc_codegen.rs
@@ -1,13 +1,14 @@
 // This file was taken from the compiler:
-// https://github.com/rust-lang/rust/blob/86f5e177bca8121e1edc9864023a8ea61acf9034/compiler/rustc_trait_selection/src/traits/codegen.rs
+// https://raw.githubusercontent.com/rust-lang/rust/949b98cab8a186b98bf87e64374b8d0848c55271/compiler/rustc_trait_selection/src/traits/codegen.rs
 // This file is licensed under Apache 2.0
-// (https://github.com/rust-lang/rust/blob/86f5e177bca8121e1edc9864023a8ea61acf9034/LICENSE-APACHE)
+// (https://github.com/rust-lang/rust/blob/949b98cab8a186b98bf87e64374b8d0848c55271/LICENSE-APACHE)
 // and MIT
-// (https://github.com/rust-lang/rust/blob/86f5e177bca8121e1edc9864023a8ea61acf9034/LICENSE-MIT).
+// (https://github.com/rust-lang/rust/blob/949b98cab8a186b98bf87e64374b8d0848c55271/LICENSE-MIT).
 
 // Changes:
 // + Fix compilation errors.
 // + Remove all diagnostics (this is the main motivation for duplication).
+// + `ErrorGuaranteed` changed to `()` (private constructor).
 
 
 // This file contains various trait resolution methods used by codegen.
@@ -21,7 +22,6 @@ use rustc_trait_selection::traits::{
     FulfillmentContext, ImplSource, Obligation, ObligationCause, SelectionContext, TraitEngine,
     Unimplemented,
 };
-use rustc_errors::ErrorGuaranteed;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::{self, TyCtxt};
 
@@ -35,7 +35,7 @@ use rustc_middle::ty::{self, TyCtxt};
 pub fn codegen_fulfill_obligation<'tcx>(
     tcx: TyCtxt<'tcx>,
     (param_env, trait_ref): (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>),
-) -> Result<ImplSource<'tcx, ()>, ErrorGuaranteed> {
+) -> Result<&'tcx ImplSource<'tcx, ()>, ()> {
     // Remove any references to regions; this helps improve caching.
     let trait_ref = tcx.erase_regions(trait_ref);
     // We expect the input to be fully normalized.
@@ -64,7 +64,7 @@ pub fn codegen_fulfill_obligation<'tcx>(
                 // // leading to an ambiguous result. So report this as an
                 // // overflow bug, since I believe this is the only case
                 // // where ambiguity can result.
-                // infcx.tcx.sess.delay_span_bug(
+                // let reported = infcx.tcx.sess.delay_span_bug(
                 //     rustc_span::DUMMY_SP,
                 //     &format!(
                 //         "encountered ambiguity selecting `{:?}` during codegen, presuming due to \
@@ -72,21 +72,21 @@ pub fn codegen_fulfill_obligation<'tcx>(
                 //         trait_ref
                 //     ),
                 // );
-                return Err(ErrorGuaranteed);
+                return Err(());
             }
             Err(Unimplemented) => {
                 // // This can trigger when we probe for the source of a `'static` lifetime requirement
                 // // on a trait object: `impl Foo for dyn Trait {}` has an implicit `'static` bound.
                 // // This can also trigger when we have a global bound that is not actually satisfied,
                 // // but was included during typeck due to the trivial_bounds feature.
-                // infcx.tcx.sess.delay_span_bug(
+                // let guar = infcx.tcx.sess.delay_span_bug(
                 //     rustc_span::DUMMY_SP,
                 //     &format!(
                 //         "Encountered error `Unimplemented` selecting `{:?}` during codegen",
                 //         trait_ref
                 //     ),
                 // );
-                return Err(ErrorGuaranteed);
+                return Err(());
             }
             Err(e) => {
                 panic!("Encountered error `{:?}` selecting `{:?}` during codegen", e, trait_ref)
@@ -105,8 +105,12 @@ pub fn codegen_fulfill_obligation<'tcx>(
         });
         let impl_source = drain_fulfillment_cx_or_panic(&infcx, &mut fulfill_cx, impl_source);
 
+        // Opaque types may have gotten their hidden types constrained, but we can ignore them safely
+        // as they will get constrained elsewhere, too.
+        let _opaque_types = infcx.inner.borrow_mut().opaque_type_storage.take_opaque_types();
+
         debug!("Cache miss: {:?} => {:?}", trait_ref, impl_source);
-        Ok(impl_source)
+        Ok(&*tcx.arena.alloc(impl_source))
     })
 }
 

--- a/prusti-interface/src/environment/traits/rustc_instance.rs
+++ b/prusti-interface/src/environment/traits/rustc_instance.rs
@@ -1,17 +1,17 @@
 // This file was taken from the compiler:
-// https://raw.githubusercontent.com/rust-lang/rust/7be8693984d32d2f65ce9ded4f65b6b7340bddce/compiler/rustc_ty_utils/src/instance.rs
+// https://raw.githubusercontent.com/rust-lang/rust/949b98cab8a186b98bf87e64374b8d0848c55271/compiler/rustc_ty_utils/src/instance.rs
 // This file is licensed under Apache 2.0
-// (https://github.com/rust-lang/rust/blob/86f5e177bca8121e1edc9864023a8ea61acf9034/LICENSE-APACHE)
+// (https://github.com/rust-lang/rust/blob/949b98cab8a186b98bf87e64374b8d0848c55271/LICENSE-APACHE)
 // and MIT
-// (https://github.com/rust-lang/rust/blob/86f5e177bca8121e1edc9864023a8ea61acf9034/LICENSE-MIT).
+// (https://github.com/rust-lang/rust/blob/949b98cab8a186b98bf87e64374b8d0848c55271/LICENSE-MIT).
 //
 // Changes:
 // + Fix compilation errors.
 // + Use our copy of `codegen_fulfill_obligation` that does not record delayed
 //   span bugs, which is the main motivation for duplication.
+// + `ErrorGuaranteed` changed to `()` (private constructor).
 
-use rustc_errors::ErrorGuaranteed;
-use rustc_hir::def_id::{DefId};
+use rustc_hir::def_id::DefId;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{self, Binder, Instance, Ty, TyCtxt, TypeFoldable, TypeVisitor};
@@ -125,11 +125,12 @@ impl<'tcx> TypeVisitor<'tcx> for BoundVarsCollector<'tcx> {
 pub fn resolve_instance<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: ty::ParamEnvAnd<'tcx, (DefId, SubstsRef<'tcx>)>,
-) -> Result<Option<Instance<'tcx>>, ErrorGuaranteed> {
+) -> Result<Option<Instance<'tcx>>, ()> {
     let (param_env, (did, substs)) = key.into_parts();
     if let Some(did) = did.as_local() {
         if let Some(param_did) = tcx.opt_const_param_of(did) {
-            return tcx.resolve_instance_of_const_arg(param_env.and((did, param_did, substs)));
+            return tcx.resolve_instance_of_const_arg(param_env.and((did, param_did, substs)))
+                .map_err(|_| ());
         }
     }
 
@@ -139,7 +140,7 @@ pub fn resolve_instance<'tcx>(
 fn inner_resolve_instance<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: ty::ParamEnvAnd<'tcx, (ty::WithOptConstParam<DefId>, SubstsRef<'tcx>)>,
-) -> Result<Option<Instance<'tcx>>, ErrorGuaranteed> {
+) -> Result<Option<Instance<'tcx>>, ()> {
     let (param_env, (def, substs)) = key.into_parts();
 
     let result = if let Some(trait_def_id) = tcx.trait_of_item(def.did) {
@@ -199,7 +200,7 @@ fn resolve_associated_item<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
     trait_id: DefId,
     rcvr_substs: SubstsRef<'tcx>,
-) -> Result<Option<Instance<'tcx>>, ErrorGuaranteed> {
+) -> Result<Option<Instance<'tcx>>, ()> {
     debug!(?trait_item_id, ?param_env, ?trait_id, ?rcvr_substs, "resolve_associated_item");
 
     let trait_ref = ty::TraitRef::from_method(tcx, trait_id, rcvr_substs);
@@ -224,7 +225,7 @@ fn resolve_associated_item<'tcx>(
             let trait_def_id = tcx.trait_id_of_impl(impl_data.impl_def_id).unwrap();
             let trait_def = tcx.trait_def(trait_def_id);
             let leaf_def = trait_def
-                .ancestors(tcx, impl_data.impl_def_id)?
+                .ancestors(tcx, impl_data.impl_def_id).map_err(|_| ())?
                 .leaf_def(tcx, trait_item_id)
                 .unwrap_or_else(|| {
                     panic!("{:?} not found in {:?}", trait_item_id, impl_data.impl_def_id);
@@ -304,7 +305,7 @@ fn resolve_associated_item<'tcx>(
                     let span = tcx.def_span(leaf_def.item.def_id);
                     tcx.sess.delay_span_bug(span, &msg);
 
-                    return Err(ErrorGuaranteed);
+                    return Err(());
                 }
             }
 
@@ -374,6 +375,6 @@ fn resolve_associated_item<'tcx>(
         | traits::ImplSource::DiscriminantKind(..)
         | traits::ImplSource::Pointee(..)
         | traits::ImplSource::TraitUpcasting(_)
-        | traits::ImplSource::ConstDrop(_) => None,
+        | traits::ImplSource::ConstDestruct(_) => None,
     })
 }

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -82,8 +82,8 @@ fn report_prusti_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
 
     // a .span_bug or .bug call has already printed what it wants to print.
     if !info.payload().is::<rustc_errors::ExplicitBug>() {
-        let d = rustc_errors::Diagnostic::new(rustc_errors::Level::Bug, "unexpected panic");
-        handler.emit_diagnostic(&d);
+        let mut d = rustc_errors::Diagnostic::new(rustc_errors::Level::Bug, "unexpected panic");
+        handler.emit_diagnostic(&mut d);
     }
 
     let version_info = get_prusti_version_info();

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-03-15"
+channel = "nightly-2022-04-01"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-std", "rustfmt" ]
 profile = "minimal"


### PR DESCRIPTION
* [ ] Update Viper version to `v-2022-03-26-0733`.
* [x] Update rustc version to `nightly-2022-04-01`.
* [x] Manualy update outdated dependencies (see the list below).
* [x] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ cargo outdated --root-deps-only --workspace

info: syncing channel updates for 'nightly-2022-04-01-x86_64-unknown-linux-gnu'
info: latest update on 2022-04-01, rust version 1.61.0-nightly (0677edc86 2022-03-31)
info: downloading component 'cargo'
info: downloading component 'llvm-tools-preview'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustc-dev'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'llvm-tools-preview'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustc-dev'
info: installing component 'rustfmt'
    Updating git repository `https://github.com/rust-lang/cargo.git`
analysis
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.14   ---     0.4.16  Normal  ---
syn   1.0.88   ---     1.0.90  Normal  ---

prusti
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.14   ---     0.4.16  Normal  ---

prusti-common
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.14   ---     0.4.16  Normal  ---

viper
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.14   ---     0.4.16  Normal  ---

viper-sys
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.14   ---     0.4.16  Normal  ---

jni-gen
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.14   ---     0.4.16  Normal  ---

vir
================
Name   Project  Compat  Latest  Kind    Platform
----   -------  ------  ------  ----    --------
log    0.4.14   ---     0.4.16  Normal  ---
quote  1.0.15   ---     1.0.17  Normal  ---
syn    1.0.88   ---     1.0.90  Normal  ---

vir-gen
================
Name   Project  Compat  Latest  Kind    Platform
----   -------  ------  ------  ----    --------
quote  1.0.15   ---     1.0.17  Normal  ---
syn    1.0.88   ---     1.0.90  Normal  ---

prusti-contracts
================
Name      Project  Compat  Latest  Kind         Platform
----      -------  ------  ------  ----         --------
trybuild  1.0.56   ---     1.0.58  Development  ---

prusti-specs
================
Name   Project  Compat  Latest  Kind    Platform
----   -------  ------  ------  ----    --------
quote  1.0.15   ---     1.0.17  Normal  ---
syn    1.0.88   ---     1.0.90  Normal  ---

prusti-interface
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.14   ---     0.4.16  Normal  ---

prusti-viper
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.14   ---     0.4.16  Normal  ---

prusti-server
================
Name     Project  Compat  Latest   Kind    Platform
----     -------  ------  ------   ----    --------
clap     2.34.0   ---     3.1.7    Normal  ---
log      0.4.14   ---     0.4.16   Normal  ---
reqwest  0.10.10  ---     0.11.10  Normal  ---
tokio    0.2.25   ---     1.17.0   Normal  ---
warp     0.2.5    ---     0.3.2    Normal  ---

test-crates
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
clap  2.34.0   ---     3.1.7   Normal  ---
log   0.4.14   ---     0.4.16  Normal  ---
```
</details>

@Aurel300 could you take care of this?