### PR TITLE
Lifetime Encoding for Mutable Reference Assignments

### DIFF
--- a/prusti-interface/src/environment/mir_dump/graphviz/mod.rs
+++ b/prusti-interface/src/environment/mir_dump/graphviz/mod.rs
@@ -1,6 +1,9 @@
-mod to_text;
+pub mod to_text;
 
 pub(super) use self::to_text::{
-    loan_containment_to_text, loan_to_text, loans_to_text, to_sorted_text, ToText,
+    loan_containment_to_text, loan_to_text, loans_to_text, to_sorted_text,
 };
+
+pub use self::to_text::{opaque_lifetime_string, ToText};
+
 pub(super) use vir::common::graphviz::{Graph, NodeBuilder};

--- a/prusti-interface/src/environment/mir_dump/graphviz/to_text.rs
+++ b/prusti-interface/src/environment/mir_dump/graphviz/to_text.rs
@@ -1,13 +1,17 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-pub(in super::super::super) trait ToText {
+pub trait ToText {
     fn to_text(&self) -> String;
 }
 
-pub(in super::super::super) fn to_sorted_text<S: ToText>(texts: &[S]) -> Vec<String> {
+pub(in super::super) fn to_sorted_text<S: ToText>(texts: &[S]) -> Vec<String> {
     let mut strings: Vec<_> = texts.iter().map(ToText::to_text).collect();
     strings.sort();
     strings
+}
+
+pub fn opaque_lifetime_string(index: usize) -> String {
+    format!("bw{}", index)
 }
 
 fn escape_html<S: ToString>(s: S) -> String {
@@ -40,7 +44,7 @@ impl ToText for rustc_middle::mir::Local {
 
 impl ToText for rustc_middle::ty::RegionVid {
     fn to_text(&self) -> String {
-        format!("'{}", self.index())
+        format!("lft{}", self.index())
     }
 }
 
@@ -92,7 +96,7 @@ pub(in super::super) fn loans_to_text(
     strings.join(", ")
 }
 
-pub(super) fn loan_set_to_text(
+pub(in super::super) fn loan_set_to_text(
     loans: &BTreeSet<crate::environment::borrowck::facts::Loan>,
 ) -> String {
     let strings: Vec<_> = loans.iter().map(loan_to_text).collect();
@@ -139,5 +143,30 @@ impl<'tcx> ToText for rustc_middle::mir::Terminator<'tcx> {
 impl<'tcx> ToText for rustc_middle::ty::Ty<'tcx> {
     fn to_text(&self) -> String {
         escape_html(format!("{:?}", self))
+    }
+}
+
+impl<'tcx> ToText for rustc_middle::ty::Region<'tcx> {
+    fn to_text(&self) -> String {
+        match self.kind() {
+            rustc_middle::ty::ReEarlyBound(_) => {
+                unimplemented!("ReEarlyBound: {}", format!("{}", self));
+            }
+            rustc_middle::ty::ReLateBound(debruijn, bound_reg) => {
+                format!("lft_late_{}_{}", debruijn.index(), bound_reg.var.index())
+            }
+            rustc_middle::ty::ReFree(_) => {
+                unimplemented!("ReFree: {}", format!("{}", self));
+            }
+            rustc_middle::ty::ReStatic => String::from("lft_static"),
+            rustc_middle::ty::ReVar(region_vid) => format!("lft_{}", region_vid.index()),
+            rustc_middle::ty::RePlaceholder(_) => {
+                unimplemented!("RePlaceholder: {}", format!("{}", self));
+            }
+            rustc_middle::ty::ReEmpty(_) => {
+                unimplemented!("ReEmpty: {}", format!("{}", self));
+            }
+            rustc_middle::ty::ReErased => String::from("lft_erased"),
+        }
     }
 }

--- a/prusti-interface/src/environment/mir_dump/mod.rs
+++ b/prusti-interface/src/environment/mir_dump/mod.rs
@@ -2,7 +2,7 @@ use super::Environment;
 
 use rustc_span::def_id::DefId;
 
-mod graphviz;
+pub mod graphviz;
 pub mod lifetimes;
 mod mir;
 

--- a/prusti-interface/src/lifetimes/lifetime_formatter.rs
+++ b/prusti-interface/src/lifetimes/lifetime_formatter.rs
@@ -1,0 +1,40 @@
+use rustc_middle::ty;
+
+pub fn opaque_lifetime_string(index: usize) -> String {
+    format!("bw{}", index)
+}
+
+pub trait LifetimeString {
+    fn lifetime_string(&self) -> String;
+}
+
+impl LifetimeString for ty::RegionVid {
+    fn lifetime_string(&self) -> String {
+        opaque_lifetime_string(self.index())
+    }
+}
+
+impl<'tcx> LifetimeString for ty::Region<'tcx> {
+    fn lifetime_string(&self) -> String {
+        match self.kind() {
+            ty::ReEarlyBound(_) => {
+                unimplemented!("ReEarlyBound: {}", format!("{}", self));
+            },
+            ty::ReLateBound(debruijn, bound_reg) => {
+                format!("lft_late_{}_{}", debruijn.index(), bound_reg.var.index())
+            },
+            ty::ReFree(_) => {
+                unimplemented!("ReFree: {}", format!("{}", self));
+            },
+            ty::ReStatic=> String::from("lft_static"),
+            ty::ReVar(region_vid) => format!("lft_{}", region_vid.index()),
+            ty::RePlaceholder(_) => {
+                unimplemented!("RePlaceholder: {}", format!("{}", self));
+            },
+            ty::ReEmpty(_) => {
+                unimplemented!("ReEmpty: {}", format!("{}", self));
+            },
+            ty::ReErased => String::from("lft_erased"),
+        }
+    }
+}

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -732,29 +732,6 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         self.intern_viper_identifier(full_name, short_name)
     }
 
-    pub fn encode_lifetime_name(&self, region: &ty::Region) -> String {
-        match region.kind() {
-            ty::ReEarlyBound(_) => {
-                unimplemented!("ReEarlyBound: {}", format!("{}", region));
-            },
-            ty::ReLateBound(debruijn, bound_reg) => {
-                format!("lft_late_{}_{}", debruijn.index(), bound_reg.var.index())
-            },
-            ty::ReFree(_) => {
-                unimplemented!("ReFree: {}", format!("{}", region));
-            },
-            ty::ReStatic=> String::from("lft_static"),
-            ty::ReVar(region_vid) => format!("lft_{}", region_vid.index()),
-            ty::RePlaceholder(_) => {
-                unimplemented!("RePlaceholder: {}", format!("{}", region));
-            },
-            ty::ReEmpty(_) => {
-                unimplemented!("ReEmpty: {}", format!("{}", region));
-            },
-            ty::ReErased => String::from("lft_erased"),
-        }
-    }
-
     pub fn encode_invariant_func_app(
         &self,
         ty: ty::Ty<'tcx>,

--- a/prusti-viper/src/encoder/errors/error_manager.rs
+++ b/prusti-viper/src/encoder/errors/error_manager.rs
@@ -124,6 +124,8 @@ pub enum ErrorCtxt {
     UnfoldUnionVariant,
     /// Failed to call a procedure.
     ProcedureCall,
+    /// Failed to encode lifetimes
+    LifetimeEncoding
 }
 
 /// The error manager

--- a/prusti-viper/src/encoder/high/lower/ty.rs
+++ b/prusti-viper/src/encoder/high/lower/ty.rs
@@ -33,6 +33,7 @@ impl IntoPolymorphic<vir_poly::Type> for vir_high::Type {
             vir_high::Type::FunctionDef(ty) => vir_poly::Type::TypedRef(ty.lower(encoder)),
             vir_high::Type::Projection(ty) => vir_poly::Type::TypedRef(ty.lower(encoder)),
             vir_high::Type::Unsupported(ty) => vir_poly::Type::TypedRef(ty.lower(encoder)),
+            vir_high::Type::Lifetime => unreachable!("Lifetimes ignored"),
         })
     }
 }
@@ -54,7 +55,9 @@ impl IntoPolymorphic<vir_poly::TypeVar> for vir_high::ty::TypeVar {
         vir_poly::TypeVar {
             label: match self {
                 vir_high::ty::TypeVar::GenericType(generic_type) => generic_type.get_identifier(),
-                vir_high::ty::TypeVar::Lifetime(lifetime) => lifetime.get_identifier(),
+                vir_high::ty::TypeVar::LifetimeConst(lifetime_const) => {
+                    lifetime_const.get_identifier()
+                }
             },
         }
     }

--- a/prusti-viper/src/encoder/high/procedures/inference/ensurer.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/ensurer.rs
@@ -226,8 +226,13 @@ fn ensure_permission_in_state(
     } else if permission_kind == PermissionKind::MemoryBlock
         && can_place_be_ensured_in(context, &place, PermissionKind::Owned, predicate_state)?
     {
-        // We have Owned and we need MemoryBlock. Fully unfold.
-        for place in predicate_state.collect_owned_with_prefix(&place)? {
+        let places = predicate_state.collect_owned_with_prefix(&place)?;
+        if places.is_empty() {
+            // We have Owned and we need MemoryBlock. Fully unfold.
+            // PROBLEM: we don't have a place here for a deref and it will recursively call itself without doing anything
+            unimplemented!("Deref not yet supported");
+        }
+        for place in places {
             predicate_state.remove(PermissionKind::Owned, &place)?;
             predicate_state.insert(PermissionKind::MemoryBlock, place.clone())?;
             actions.push(Action::owned_into_memory_block(place));

--- a/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
@@ -63,6 +63,15 @@ impl CollectPermissionChanges for vir_high::Statement {
             vir_high::Statement::LeakAll(statement) => {
                 statement.collect(consumed_permissions, produced_permissions)
             }
+            vir_high::Statement::NewLft(statement) => {
+                statement.collect(consumed_permissions, produced_permissions)
+            }
+            vir_high::Statement::EndLft(statement) => {
+                statement.collect(consumed_permissions, produced_permissions)
+            }
+            vir_high::Statement::GhostAssignment(statement) => {
+                statement.collect(consumed_permissions, produced_permissions)
+            }
         }
     }
 }
@@ -221,6 +230,7 @@ impl CollectPermissionChanges for vir_high::Rvalue {
         produced_permissions: &mut Vec<Permission>,
     ) -> SpannedEncodingResult<()> {
         match self {
+            Self::Ref(rvalue) => rvalue.collect(consumed_permissions, produced_permissions),
             Self::AddressOf(rvalue) => rvalue.collect(consumed_permissions, produced_permissions),
             Self::UnaryOp(rvalue) => rvalue.collect(consumed_permissions, produced_permissions),
             Self::BinaryOp(rvalue) => rvalue.collect(consumed_permissions, produced_permissions),
@@ -229,6 +239,18 @@ impl CollectPermissionChanges for vir_high::Rvalue {
             }
             Self::Aggregate(rvalue) => rvalue.collect(consumed_permissions, produced_permissions),
         }
+    }
+}
+
+impl CollectPermissionChanges for vir_high::ast::rvalue::Ref {
+    fn collect(
+        &self,
+        consumed_permissions: &mut Vec<Permission>,
+        produced_permissions: &mut Vec<Permission>,
+    ) -> SpannedEncodingResult<()> {
+        consumed_permissions.push(Permission::Owned(self.place.clone()));
+        produced_permissions.push(Permission::Owned(self.place.clone()));
+        Ok(())
     }
 }
 
@@ -334,6 +356,36 @@ impl CollectPermissionChanges for vir_high::ast::rvalue::Operand {
 }
 
 impl CollectPermissionChanges for vir_high::LeakAll {
+    fn collect(
+        &self,
+        _consumed_permissions: &mut Vec<Permission>,
+        _produced_permissions: &mut Vec<Permission>,
+    ) -> SpannedEncodingResult<()> {
+        Ok(())
+    }
+}
+
+impl CollectPermissionChanges for vir_high::NewLft {
+    fn collect(
+        &self,
+        _consumed_permissions: &mut Vec<Permission>,
+        _produced_permissions: &mut Vec<Permission>,
+    ) -> SpannedEncodingResult<()> {
+        Ok(())
+    }
+}
+
+impl CollectPermissionChanges for vir_high::EndLft {
+    fn collect(
+        &self,
+        _consumed_permissions: &mut Vec<Permission>,
+        _produced_permissions: &mut Vec<Permission>,
+    ) -> SpannedEncodingResult<()> {
+        Ok(())
+    }
+}
+
+impl CollectPermissionChanges for vir_high::GhostAssignment {
     fn collect(
         &self,
         _consumed_permissions: &mut Vec<Permission>,

--- a/prusti-viper/src/encoder/high/procedures/inference/visitor/context.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/visitor/context.rs
@@ -68,7 +68,11 @@ impl<'p, 'v, 'tcx> super::super::ensurer::Context for Visitor<'p, 'v, 'tcx> {
                 ]
             }
             vir_high::TypeDecl::Array(_) => unimplemented!("ty: {}", ty),
-            vir_high::TypeDecl::Reference(_) => unimplemented!("ty: {}", ty),
+            vir_high::TypeDecl::Reference(_) => {
+                // TODO: implement context visitor for Reference
+                // required e.g. for returning a reference?
+                unimplemented!("ty: {}", ty)
+            }
             vir_high::TypeDecl::Never => unimplemented!("ty: {}", ty),
             vir_high::TypeDecl::Closure(_) => unimplemented!("ty: {}", ty),
             vir_high::TypeDecl::Unsupported(_) => unimplemented!("ty: {}", ty),

--- a/prusti-viper/src/encoder/high/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/high/pure_functions/interface.rs
@@ -93,7 +93,7 @@ impl<'v, 'tcx: 'v> HighPureFunctionEncoderInterface<'tcx>
         // FIXME: Should use encode_builtin_function_use.
         let name = "subslice";
         let element_type = extract_container_element_type(&container)?;
-        let pure_lifetime = vir_high::ty::Lifetime {
+        let pure_lifetime = vir_high::ty::LifetimeConst {
             name: String::from("pure_erased"),
         };
         let return_type =

--- a/prusti-viper/src/encoder/high/to_middle/statement.rs
+++ b/prusti-viper/src/encoder/high/to_middle/statement.rs
@@ -54,4 +54,11 @@ impl<'v, 'tcx> ToMiddleStatementLowerer for crate::encoder::Encoder<'v, 'tcx> {
     ) -> Result<vir_mid::Operand, Self::Error> {
         operand.to_middle_rvalue(self)
     }
+
+    fn to_middle_statement_variable_decl(
+        &self,
+        variable_decl: vir_high::VariableDecl,
+    ) -> Result<vir_mid::VariableDecl, <Self as ToMiddleStatementLowerer>::Error> {
+        variable_decl.to_middle_expression(self)
+    }
 }

--- a/prusti-viper/src/encoder/high/types/fields.rs
+++ b/prusti-viper/src/encoder/high/types/fields.rs
@@ -52,7 +52,11 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
             )));
         }
 
-        vir::Type::MBool | vir::Type::MInt | vir::Type::MFloat32 | vir::Type::MFloat64 => {
+        vir::Type::MBool
+        | vir::Type::MInt
+        | vir::Type::MFloat32
+        | vir::Type::MFloat64
+        | vir::Type::Lifetime => {
             unreachable!()
         }
     };

--- a/prusti-viper/src/encoder/middle/core_proof/compute_address/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/compute_address/interface.rs
@@ -204,7 +204,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ComputeAddressInterface for Lowerer<'p, 'v, 'tcx> {
                     }
                 }
                 // vir_mid::TypeDecl::Array(Array) => {},
-                // vir_mid::TypeDecl::Reference(Reference) => {},
+                vir_mid::TypeDecl::Reference(_reference) => {
+                    // Do nothing
+                }
                 // vir_mid::TypeDecl::Never => {},
                 // vir_mid::TypeDecl::Closure(Closure) => {},
                 // vir_mid::TypeDecl::Unsupported(Unsupported) => {},

--- a/prusti-viper/src/encoder/middle/core_proof/predicates_owned/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/predicates_owned/interface.rs
@@ -216,7 +216,16 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 }
             }
             // vir_mid::TypeDecl::Array(Array) => {},
-            // vir_mid::TypeDecl::Reference(Reference) => {},
+            vir_mid::TypeDecl::Reference(_) => {
+                predicate! {
+                    OwnedNonAliased<ty>(place: Place, root_address: Address, snapshot: {snapshot_type})
+                    {(
+                        ([validity]) &&
+                        (acc(MemoryBlock([compute_address], [size_of]))) &&
+                        (([bytes]) == (Snap<ty>::to_bytes(snapshot)))
+                    )}
+                }
+            }
             // vir_mid::TypeDecl::Never => {},
             // vir_mid::TypeDecl::Closure(Closure) => {},
             // vir_mid::TypeDecl::Unsupported(Unsupported) => {},

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/values/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/values/interface.rs
@@ -174,6 +174,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValuesInterface for Lowerer<'p, 'v, 'tcx> {
             vir_mid::Type::Bool => vir_low::Type::Bool,
             vir_mid::Type::Int(_) => vir_low::Type::Int,
             vir_mid::Type::Pointer(_) => self.address_type()?,
+            vir_mid::Type::Reference(_) => self.address_type()?,
             x => unimplemented!("{:?}", x),
         };
         vir_low::operations::ty::Typed::set_type(&mut argument, low_type);

--- a/prusti-viper/src/encoder/middle/core_proof/types/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/types/interface.rs
@@ -152,6 +152,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 self.register_constant_constructor(&domain_name, address_type.clone())?;
                 self.encode_validity_axioms_primitive(&domain_name, address_type, true.into())?;
             }
+            vir_mid::TypeDecl::Reference(reference) => {
+                self.ensure_type_definition(&reference.target_type)?;
+                let address_type = self.address_type()?;
+                self.register_constant_constructor(&domain_name, address_type.clone())?;
+                self.encode_validity_axioms_primitive(&domain_name, address_type, true.into())?;
+            }
             _ => unimplemented!("type: {:?}", type_decl),
         };
         Ok(())

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -237,7 +237,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
                     .encoder
                     .encode_type_of_place_high(self.mir, *place)
                     .with_span(span)?;
-                let pure_lifetime = vir_high::ty::Lifetime {
+                let pure_lifetime = vir_high::ty::LifetimeConst {
                     name: String::from("pure_erased"),
                 };
                 let encoded_ref = vir_high::Expression::addr_of_no_pos(

--- a/prusti-viper/src/encoder/mir/types/encoder.rs
+++ b/prusti-viper/src/encoder/mir/types/encoder.rs
@@ -16,6 +16,7 @@ use crate::encoder::{
 use log::debug;
 use prusti_common::config;
 
+use prusti_interface::environment::mir_dump::graphviz::ToText;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty;
 use rustc_span::MultiSpan;
@@ -64,10 +65,6 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
         format!("fndef${}", self.encoder.encode_item_name(did))
     }
 
-    fn encode_lifetime_name(&self, region: &ty::Region) -> String {
-        self.encoder.encode_lifetime_name(region)
-    }
-
     fn compute_array_len(&self, size: ty::Const<'tcx>) -> u64 {
         self.encoder
             .const_eval_intlike(size.val())
@@ -106,8 +103,8 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
             }
 
             ty::TyKind::Ref(region, ty, _) => {
-                let lft_name = self.encode_lifetime_name(region);
-                let lifetime = vir::ty::Lifetime { name: lft_name };
+                let lft_name = region.to_text();
+                let lifetime = vir::ty::LifetimeConst { name: lft_name };
                 vir::Type::reference(self.encoder.encode_type_high(*ty)?, lifetime)
             }
 
@@ -310,8 +307,8 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
             }
             ty::TyKind::Ref(region, ty, _) => {
                 let target_type = self.encoder.encode_type_high(*ty)?;
-                let lft_name = self.encode_lifetime_name(region);
-                let lifetime = vir_crate::high::type_decl::Lifetime { name: lft_name };
+                let lft_name = region.to_text();
+                let lifetime = vir_crate::high::type_decl::LifetimeConst { name: lft_name };
                 vir::TypeDecl::reference(target_type, lifetime)
             }
             ty::TyKind::Tuple(elems) => vir::TypeDecl::tuple(

--- a/vir/defs/high/ast/rvalue.rs
+++ b/vir/defs/high/ast/rvalue.rs
@@ -12,7 +12,7 @@ use crate::common::display;
 pub enum Rvalue {
     // Use(Use),
     // Repeat(Repeat),
-    // Ref(Ref),
+    Ref(Ref),
     // ThreadLocalRef(ThreadLocalRef),
     AddressOf(AddressOf),
     // Len(Len),
@@ -24,6 +24,15 @@ pub enum Rvalue {
     Discriminant(Discriminant),
     Aggregate(Aggregate),
     // ShallowInitBox(ShallowInitBox),
+}
+
+#[display(fmt = "ref {}", place)]
+pub struct Ref {
+    pub place: Expression,
+    pub lifetime_name: String,
+    pub is_mut: bool,
+    pub rd_perm: u32,
+    pub target: Expression,
 }
 
 #[display(fmt = "&raw({})", place)]

--- a/vir/defs/high/ast/statement.rs
+++ b/vir/defs/high/ast/statement.rs
@@ -7,6 +7,7 @@ pub(crate) use super::{
     variable::VariableDecl,
 };
 use crate::common::display;
+use std::collections::BTreeSet;
 
 #[derive_helpers]
 #[derive_visitors]
@@ -25,6 +26,9 @@ pub enum Statement {
     WriteAddress(WriteAddress),
     Assign(Assign),
     LeakAll(LeakAll),
+    NewLft(NewLft),
+    EndLft(EndLft),
+    GhostAssignment(GhostAssignment),
 }
 
 #[display(fmt = "// {}", comment)]
@@ -157,3 +161,22 @@ pub struct Assign {
 /// Tells fold-unfold to leak all predicates. This marks the end of the
 /// unwinding path.
 pub struct LeakAll {}
+
+#[display(fmt = "{} = newlft()", target)]
+pub struct NewLft {
+    pub target: VariableDecl,
+    pub position: Position,
+}
+
+#[display(fmt = "endlft({})", lifetime)]
+pub struct EndLft {
+    pub lifetime: VariableDecl,
+    pub position: Position,
+}
+
+#[display(fmt = "ghost-assign {} := {:?}", target, value)]
+pub struct GhostAssignment {
+    pub target: VariableDecl,
+    pub value: Vec<String>,
+    pub position: Position,
+}

--- a/vir/defs/high/ast/ty.rs
+++ b/vir/defs/high/ast/ty.rs
@@ -11,6 +11,7 @@ pub enum Type {
     /// Mathematical floats that corresponds to Viper's Float.
     MFloat32,
     MFloat64,
+    Lifetime,
     /// Rust's Bool allocated on the Viper heap.
     Bool,
     /// Rust's Int allocated on the Viper heap.
@@ -59,8 +60,16 @@ pub enum Float {
 }
 
 #[display(fmt = "{}", name)]
-pub struct Lifetime {
+pub struct LifetimeConst {
     pub name: String,
+}
+
+#[display(fmt = "NoNameLifetime")]
+pub struct Lifetime {}
+impl Default for Lifetime {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[display(fmt = "{}", name)]
@@ -71,7 +80,7 @@ pub struct GenericType {
 #[derive_helpers]
 #[derive(derive_more::Unwrap)]
 pub enum TypeVar {
-    Lifetime(Lifetime),
+    LifetimeConst(LifetimeConst),
     GenericType(GenericType),
 }
 
@@ -130,7 +139,7 @@ pub struct Slice {
 #[display(fmt = "&{}", target_type)]
 pub struct Reference {
     pub target_type: Box<Type>,
-    pub lifetime: Lifetime,
+    pub lifetime_const: LifetimeConst,
 }
 
 #[display(fmt = "*{}", target_type)]

--- a/vir/defs/high/ast/type_decl.rs
+++ b/vir/defs/high/ast/type_decl.rs
@@ -47,7 +47,7 @@ pub struct Float {
 }
 
 #[display(fmt = "{}", name)]
-pub struct Lifetime {
+pub struct LifetimeConst {
     pub name: String,
 }
 
@@ -59,7 +59,7 @@ pub struct GenericType {
 #[derive_helpers]
 #[derive(derive_more::Unwrap)]
 pub enum TypeVar {
-    Lifetime(Lifetime),
+    Lifetime(LifetimeConst),
     GenericType(GenericType),
 }
 
@@ -109,7 +109,7 @@ pub struct Array {
 #[display(fmt = "&{}", target_type)]
 pub struct Reference {
     pub target_type: Type,
-    pub lifetime: Lifetime,
+    pub lifetime: LifetimeConst,
 }
 
 #[display(fmt = "*{}", target_type)]

--- a/vir/defs/high/mod.rs
+++ b/vir/defs/high/mod.rs
@@ -17,8 +17,8 @@ pub use self::{
         },
         rvalue::{Operand, OperandKind, Rvalue},
         statement::{
-            Assert, Assign, Assume, Comment, Consume, CopyPlace, Exhale, Inhale, LeakAll,
-            MovePlace, Statement, WriteAddress, WritePlace,
+            Assert, Assign, Assume, Comment, Consume, CopyPlace, EndLft, Exhale, GhostAssignment,
+            Inhale, LeakAll, MovePlace, NewLft, Statement, WriteAddress, WritePlace,
         },
         ty::{self, Type},
         type_decl::{self, TypeDecl},

--- a/vir/defs/high/operations_internal/expression.rs
+++ b/vir/defs/high/operations_internal/expression.rs
@@ -8,7 +8,7 @@ use super::{
             *,
         },
         position::Position,
-        ty::{visitors::TypeFolder, Lifetime, Type},
+        ty::{visitors::TypeFolder, LifetimeConst, Type},
     },
     ty::Typed,
 };
@@ -57,6 +57,7 @@ impl Expression {
             Expression::Local(_) => None,
             Expression::Variant(Variant { box ref base, .. })
             | Expression::Field(Field { box ref base, .. })
+            | Expression::Deref(Deref { box ref base, .. })
             | Expression::AddrOf(AddrOf { box ref base, .. }) => Some(base),
             Expression::LabelledOld(_) => None,
             expr => unreachable!("{}", expr),
@@ -104,8 +105,8 @@ impl Expression {
             }
         }
         impl TypeFolder for DefaultLifetimeEraser {
-            fn fold_lifetime(&mut self, _lifetime: Lifetime) -> Lifetime {
-                Lifetime {
+            fn fold_lifetime_const(&mut self, _lifetime: LifetimeConst) -> LifetimeConst {
+                LifetimeConst {
                     name: String::from("pure_erased"),
                 }
             }

--- a/vir/defs/high/operations_internal/identifier/rvalue.rs
+++ b/vir/defs/high/operations_internal/identifier/rvalue.rs
@@ -9,7 +9,14 @@ impl WithIdentifier for Rvalue {
             Self::UnaryOp(value) => value.get_identifier(),
             Self::Aggregate(value) => value.get_identifier(),
             Self::Discriminant(value) => value.get_identifier(),
+            Self::Ref(value) => value.get_identifier(),
         }
+    }
+}
+
+impl WithIdentifier for Ref {
+    fn get_identifier(&self) -> String {
+        format!("ref_${}", self.place.get_type().get_identifier())
     }
 }
 

--- a/vir/defs/high/operations_internal/identifier/ty.rs
+++ b/vir/defs/high/operations_internal/identifier/ty.rs
@@ -27,6 +27,7 @@ impl WithIdentifier for ty::Type {
             ty::Type::FunctionDef(ty) => ty.get_identifier(),
             ty::Type::Projection(ty) => ty.get_identifier(),
             ty::Type::Unsupported(ty) => ty.get_identifier(),
+            ty::Type::Lifetime => "Lifetime".to_string(),
         }
     }
 }
@@ -46,13 +47,13 @@ impl WithIdentifier for ty::Float {
 impl WithIdentifier for ty::TypeVar {
     fn get_identifier(&self) -> String {
         match self {
-            ty::TypeVar::Lifetime(type_var) => type_var.get_identifier(),
+            ty::TypeVar::LifetimeConst(type_var) => type_var.get_identifier(),
             ty::TypeVar::GenericType(type_var) => type_var.get_identifier(),
         }
     }
 }
 
-impl WithIdentifier for ty::Lifetime {
+impl WithIdentifier for ty::LifetimeConst {
     fn get_identifier(&self) -> String {
         self.name.clone()
     }

--- a/vir/defs/high/operations_internal/position/statement.rs
+++ b/vir/defs/high/operations_internal/position/statement.rs
@@ -16,6 +16,9 @@ impl Positioned for Statement {
             Self::Assign(statement) => statement.position(),
             Self::Consume(statement) => statement.position(),
             Self::LeakAll(statement) => statement.position(),
+            Self::NewLft(statement) => statement.position(),
+            Self::EndLft(statement) => statement.position(),
+            Self::GhostAssignment(statement) => statement.position(),
         }
     }
 }
@@ -89,5 +92,23 @@ impl Positioned for Consume {
 impl Positioned for LeakAll {
     fn position(&self) -> Position {
         Default::default()
+    }
+}
+
+impl Positioned for NewLft {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for EndLft {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for GhostAssignment {
+    fn position(&self) -> Position {
+        self.position
     }
 }

--- a/vir/defs/high/operations_internal/ty.rs
+++ b/vir/defs/high/operations_internal/ty.rs
@@ -75,7 +75,7 @@ impl Type {
     }
     pub fn erase_lifetime(&mut self) {
         if let Type::Reference(reference) = self {
-            reference.lifetime = Lifetime {
+            reference.lifetime_const = LifetimeConst {
                 name: String::from("pure_erased"),
             };
         }

--- a/vir/defs/middle/ast/statement.rs
+++ b/vir/defs/middle/ast/statement.rs
@@ -28,6 +28,9 @@ pub enum Statement {
     WritePlace(WritePlace),
     WriteAddress(WriteAddress),
     Assign(Assign),
+    NewLft(NewLft),
+    EndLft(EndLft),
+    GhostAssignment(GhostAssignment),
 }
 
 #[display(fmt = "// {}", comment)]
@@ -171,5 +174,25 @@ pub struct WriteAddress {
 pub struct Assign {
     pub target: Expression,
     pub value: Rvalue,
+    pub position: Position,
+}
+
+#[display(fmt = "{} = newlft()", target)]
+pub struct NewLft {
+    pub target: VariableDecl,
+    pub position: Position,
+}
+
+#[display(fmt = "endlft({})", lifetime)]
+pub struct EndLft {
+    pub lifetime: VariableDecl,
+    pub position: Position,
+}
+
+#[display(fmt = "ghost-assign {} := {:?}", target, value)]
+pub struct GhostAssignment {
+    pub target: VariableDecl,
+    // TODO: why can't I use a BTreeSet here?
+    pub value: Vec<String>,
     pub position: Position,
 }

--- a/vir/defs/middle/operations_internal/position/statement.rs
+++ b/vir/defs/middle/operations_internal/position/statement.rs
@@ -20,6 +20,9 @@ impl Positioned for Statement {
             Self::WriteAddress(statement) => statement.position(),
             Self::Assign(statement) => statement.position(),
             Self::Consume(statement) => statement.position(),
+            Self::NewLft(statement) => statement.position(),
+            Self::EndLft(statement) => statement.position(),
+            Self::GhostAssignment(statement) => statement.position(),
         }
     }
 }
@@ -115,6 +118,24 @@ impl Positioned for Assign {
 }
 
 impl Positioned for Consume {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for NewLft {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for EndLft {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for GhostAssignment {
     fn position(&self) -> Position {
         self.position
     }


### PR DESCRIPTION
# Work

 - [x] Encode NewLft Statement
 - [x] Encode EndLft Statement
 - [x] Encode GhostAssignment Statement
 - [x] Extend ToText

# Example

rust:
```
fn x() {
    let x = 4;
    let y = &mut x;
}
```
viper:
```
_1.val := 4
...
bw0 := newlft()
lft3 := bw0
lft4 := bw0
_2.ref := _1
...
endlft(bw0)
```