### PR TITLE
some fixes and regression tests for #738 related to retaining domain axioms

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-738-2.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-738-2.rs
@@ -1,0 +1,11 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+#[pure]
+pub fn get(a: &usize) -> usize {
+    *a
+}
+fn foo(a: &usize) {
+    let v = get(a);
+}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-738-3.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-738-3.rs
@@ -1,0 +1,16 @@
+use prusti_contracts::*;
+
+#[requires(test(1).a == 1)]
+fn main() {}
+
+#[derive(Clone, Copy)]
+pub struct A {
+    a: usize
+}
+
+#[pure]
+#[requires(a <= isize::MAX as usize)]
+#[ensures(result.a <= isize::MAX as usize)]
+pub fn test(a: usize) -> A {
+    A { a: a as isize as usize as isize as usize }
+}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-738-4.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-738-4.rs
@@ -1,0 +1,28 @@
+use prusti_contracts::*;
+
+fn main() {
+    bar(1, 1);
+    bar(1, 2);
+    baz(1, 1);
+    baz(1, 2);
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct A {
+    a: usize
+}
+
+#[pure]
+pub fn foo(a: usize) -> A {
+    A { a }
+}
+
+/// Test surjectivity
+#[pure]
+#[requires(a == b ==> foo(a) == foo(b))]
+pub fn bar(a: usize, b: usize) {}
+
+/// Test injectivity
+#[pure]
+#[requires(foo(a) == foo(b) ==> a == b)]
+pub fn baz(a: usize, b: usize) {}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-738-5.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-738-5.rs
@@ -3,9 +3,9 @@ use prusti_contracts::*;
 fn main() {}
 
 #[pure]
-pub fn get(a: &usize) -> usize {
-    *a //~^ ERROR
+pub fn get(a: &&&usize) -> usize {
+    ***a
 }
-fn foo(a: &usize) {
+fn foo(a: &&&usize) {
     let v = get(a);
 }

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-738-2.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-738-2.rs
@@ -1,0 +1,11 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+#[pure]
+pub fn get(a: &usize) -> usize {
+    *a //~^ ERROR
+}
+fn foo(a: &usize) {
+    let v = get(a);
+}

--- a/prusti-viper/src/encoder/mir/types/encoder.rs
+++ b/prusti-viper/src/encoder/mir/types/encoder.rs
@@ -255,6 +255,7 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                 Some(bounds)
             }
             ty::TyKind::Char => Some((0.into(), std::char::MAX.into())),
+            ty::TyKind::Ref(_, ty, _) => Self::new(self.encoder, *ty).get_integer_bounds(),
             _ => None,
         }
     }


### PR DESCRIPTION
I found a few more cases where the definition collector is a little too strict when removing domain axioms (#738). I included some fixes and regression tests in this PR. A short summary of the changes:

I extended the logic that determines whether to retain the domain axioms to also include cases such as:

* Retain the injectivity axiom when the constructor is "used".
* Also retain the field axiom when the field access snap function is used.

On top of that, I had to change a bit of logic in `prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs` so that Prusti encoded the type bound preconditions before the other preconditions. Apparently the order in which these are defined matters for Viper (tested by regression test `issue-738-4.rs`).

(This PR does not fully fix the related issue #738)