### PR TITLE
[Merged by Bors] - Automatically assign backlog tasks

### DIFF
--- a/.github/workflows/backlog.yml
+++ b/.github/workflows/backlog.yml
@@ -1,0 +1,41 @@
+name: Backlog fixes
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At 07:00 UTC on day-of-month 1 and 15. Use https://crontab.guru/ to edit this.
+    - cron:  '0 7 1,15 * *'
+
+jobs:
+  # Update the version of rustc, open a PR and assign a developer.
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Choose developer
+        run: |
+          declare -a DEVELOPERS=(Aurel300 fpoli JonasAlaif vakaras)
+          UPDATE_NUMBER=$(( 10#$(date +%m) * 2 + (10#$(date +%d) / 15) - 2 ))
+          DEVELOPER="${DEVELOPERS[ $UPDATE_NUMBER % ${#DEVELOPERS[@]} ]}"
+          DATE="$(date +%Y-%m-%d)"
+          echo "The assigned developer on $DATE is $DEVELOPER"
+          echo "DEVELOPER=$DEVELOPER" >> $GITHUB_ENV
+          echo "DATE=$DATE" >> $GITHUB_ENV
+
+      - name: Open a pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          # Use viper-admin's token to workaround a restriction of GitHub.
+          # See: https://github.com/peter-evans/create-pull-request/issues/48
+          token: ${{ secrets.VIPER_ADMIN_TOKEN }}
+          commit-message: Backlog fixes
+          title: Backlog fixes
+          branch: auto-backlog-${{ env.DATE }}
+          delete-branch: true
+          assignees: ${{ env.DEVELOPER }}
+          body: |
+            1. In `test-crates/crates.csv`, replace one `Skip` with `NoCrash` or one `NoCrash` with `NoErrors`.
+            2. Test the corresponding crate (`./target/release/test-crates <name_of_the_crate>`).
+            3. If the test succeeds, go back to step 1 and repeat.
+            4. If the test fails, fix at least one bug (e.g. convert a panic to an internal error or an internal error to a readable "unsupported" error message).
+
+            @${{ env.DEVELOPER }} could you take care of this?

--- a/.github/workflows/backlog.yml
+++ b/.github/workflows/backlog.yml
@@ -7,7 +7,6 @@ on:
     - cron:  '0 7 1,15 * *'
 
 jobs:
-  # Update the version of rustc, open a PR and assign a developer.
   update:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/backlog.yml
+++ b/.github/workflows/backlog.yml
@@ -37,5 +37,6 @@ jobs:
             2. Test the corresponding crate (`./target/release/test-crates <name_of_the_crate>`).
             3. If the test succeeds, go back to step 1 and repeat.
             4. If the test fails, fix at least one bug (e.g. convert a panic to an internal error or an internal error to a readable "unsupported" error message).
+            5. At this point, if your fix alone is not enough to make all the tests pass, it's fine to revert your latest change of step 1.
 
             @${{ env.DEVELOPER }} could you take care of this?

--- a/.github/workflows/backlog.yml
+++ b/.github/workflows/backlog.yml
@@ -33,7 +33,7 @@ jobs:
           delete-branch: true
           assignees: ${{ env.DEVELOPER }}
           body: |
-            1. In `test-crates/crates.csv`, replace one `Skip` with `NoCrash` or one `NoCrash` with `NoErrors`.
+            1. In `test-crates/crates.csv`, replace one `Skip` with `NoCrash` or one `NoCrash` with `NoErrors`. Optionally, also update the version of the crate.
             2. Test the corresponding crate (`./target/release/test-crates <name_of_the_crate>`).
             3. If the test succeeds, go back to step 1 and repeat.
             4. If the test fails, fix at least one bug (e.g. convert a panic to an internal error or an internal error to a readable "unsupported" error message).


### PR DESCRIPTION
With this PR, a github action will open a PR every 2 weeks asking one of us to fix a panic/error in the test-crates job. Any comments?