### PR TITLE
Add lifetime encoding at end of block

### DIFF
--- a/prusti-interface/src/environment/mir_dump/lifetimes.rs
+++ b/prusti-interface/src/environment/mir_dump/lifetimes.rs
@@ -68,16 +68,18 @@ impl Lifetimes {
             })
             .collect()
     }
-    pub fn edge_count(&self) -> u32 {
-        self.facts
-            .input_facts
-            .take()
-            .unwrap()
-            .cfg_edge
-            .len()
-            .try_into()
-            .unwrap()
+    pub fn lifetime_count(&self) -> u32 {
+        let original_lifetimes_count: u32 = self.get_original_lifetimes().len().try_into().unwrap();
+        let borrowck_in_facts = self.borrowck_in_facts();
+        let subset_lifetimes: BTreeSet<Region> = borrowck_in_facts
+            .subset_base
+            .iter()
+            .flat_map(|&(r1, r2, _)| [r1, r2])
+            .collect();
+        let subset_lifetimes_count: u32 = subset_lifetimes.len().try_into().unwrap();
+        original_lifetimes_count + subset_lifetimes_count
     }
+
     fn borrowck_in_facts(&self) -> Ref<AllInputFacts> {
         Ref::map(self.facts.input_facts.borrow(), |facts| {
             facts.as_ref().unwrap()

--- a/prusti-viper/src/encoder/errors/error_manager.rs
+++ b/prusti-viper/src/encoder/errors/error_manager.rs
@@ -125,7 +125,9 @@ pub enum ErrorCtxt {
     /// Failed to call a procedure.
     ProcedureCall,
     /// Failed to encode lifetimes
-    LifetimeEncoding
+    LifetimeEncoding,
+    /// Failed to encode LifetimeTake
+    LifetimeTake,
 }
 
 /// The error manager

--- a/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
@@ -85,6 +85,9 @@ impl CollectPermissionChanges for vir_high::Statement {
             vir_high::Statement::GhostAssignment(statement) => {
                 statement.collect(encoder, consumed_permissions, produced_permissions)
             }
+            vir_high::Statement::LifetimeTake(statement) => {
+                statement.collect(encoder, consumed_permissions, produced_permissions)
+            }
         }
     }
 }
@@ -487,6 +490,17 @@ impl CollectPermissionChanges for vir_high::EndLft {
 }
 
 impl CollectPermissionChanges for vir_high::GhostAssignment {
+    fn collect<'v, 'tcx>(
+        &self,
+        _encoder: &mut Encoder<'v, 'tcx>,
+        _consumed_permissions: &mut Vec<Permission>,
+        _produced_permissions: &mut Vec<Permission>,
+    ) -> SpannedEncodingResult<()> {
+        Ok(())
+    }
+}
+
+impl CollectPermissionChanges for vir_high::LifetimeTake {
     fn collect<'v, 'tcx>(
         &self,
         _encoder: &mut Encoder<'v, 'tcx>,

--- a/prusti-viper/src/encoder/high/to_middle/statement.rs
+++ b/prusti-viper/src/encoder/high/to_middle/statement.rs
@@ -61,4 +61,13 @@ impl<'v, 'tcx> ToMiddleStatementLowerer for crate::encoder::Encoder<'v, 'tcx> {
     ) -> Result<vir_mid::VariableDecl, <Self as ToMiddleStatementLowerer>::Error> {
         variable_decl.to_middle_expression(self)
     }
+
+    fn to_middle_statement_lifetime_const(
+        &self,
+        lifetime_const: vir_high::ty::LifetimeConst,
+    ) -> Result<vir_mid::ty::LifetimeConst, <Self as ToMiddleStatementLowerer>::Error> {
+        Ok(vir_mid::ty::LifetimeConst {
+            name: lifetime_const.name,
+        })
+    }
 }

--- a/prusti-viper/src/encoder/middle/core_proof/into_low/cfg.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/into_low/cfg.rs
@@ -391,6 +391,9 @@ impl IntoLow for vir_mid::Statement {
                 )];
                 Ok(statements)
             }
+            Self::LifetimeTake(_statement) => {
+                unimplemented!();
+            }
         }
     }
 }

--- a/prusti-viper/src/encoder/mir/procedures/encoder.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder.rs
@@ -61,6 +61,7 @@ pub(super) fn encode_procedure<'v, 'tcx: 'v>(
     };
     let mir = procedure.get_mir();
     let locals_without_explicit_allocation: BTreeSet<_> = mir.vars_and_temps_iter().collect();
+    let rd_perm = lifetimes.lifetime_count();
     let mut procedure_encoder = ProcedureEncoder {
         encoder,
         def_id,
@@ -70,6 +71,7 @@ pub(super) fn encode_procedure<'v, 'tcx: 'v>(
         check_panics: config::check_panics(),
         locals_without_explicit_allocation,
         fresh_id_generator: 0,
+        rd_perm,
     };
     procedure_encoder.encode()
 }
@@ -86,6 +88,7 @@ struct ProcedureEncoder<'p, 'v: 'p, 'tcx: 'v> {
     /// the entire body of the function.
     locals_without_explicit_allocation: BTreeSet<mir::Local>,
     fresh_id_generator: usize,
+    rd_perm: u32,
 }
 
 impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
@@ -357,11 +360,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(())
     }
 
-    fn read_permission_amount(&mut self) -> u32 {
-        // TODO: count lifetimes, not cfg_edges
-        self.lifetimes.edge_count()
-    }
-
     fn encode_basic_block(
         &mut self,
         procedure_builder: &mut ProcedureBuilder,
@@ -409,11 +407,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         original_lifetimes: &mut BTreeSet<String>,
         derived_lifetimes: &mut BTreeMap<String, BTreeSet<String>>,
     ) -> SpannedEncodingResult<()> {
-        let (new_lifetimes, ended_lifetimes, new_derived_lifetimes) =
+        let (new_lifetimes, ended_lifetimes, introduced_derived_lifetimes) =
             self.update_lifetimes(original_lifetimes, derived_lifetimes, location);
         self.encode_end_lft(block_builder, location, ended_lifetimes)?;
         self.encode_new_lft(block_builder, location, new_lifetimes)?;
-        self.encode_lft_assignment(block_builder, location, new_derived_lifetimes)?;
+        self.encode_lft_assignments(block_builder, location, introduced_derived_lifetimes)?;
         Ok(())
     }
 
@@ -451,28 +449,67 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(())
     }
 
+    fn encode_lft_intersection(
+        &mut self,
+        lifetimes: BTreeSet<String>,
+    ) -> SpannedEncodingResult<vir_high::Expression> {
+        let mut iter = lifetimes.into_iter();
+        let mut intersection = self.encode_lft_variable(iter.next().unwrap())?.into();
+        for name in iter {
+            intersection = vir_high::Expression::binary_op_no_pos(
+                vir_high::BinaryOpKind::LifetimeIntersection,
+                intersection,
+                self.encode_lft_variable(name)?.into(),
+            );
+        }
+        Ok(intersection)
+    }
+
+    fn encode_lifetime_take(
+        &mut self,
+        block_builder: &mut BasicBlockBuilder,
+        location: mir::Location,
+        lifetime: String,
+        constraints: BTreeSet<String>,
+    ) -> SpannedEncodingResult<()> {
+        let encoded_target = self.encode_lft_variable(lifetime)?;
+        let lifetimes: Vec<vir_high::ty::LifetimeConst> = constraints
+            .into_iter()
+            .map(|name| vir_high::ty::LifetimeConst { name })
+            .collect();
+        block_builder.add_statement(self.set_statement_error(
+            location,
+            ErrorCtxt::LifetimeEncoding,
+            vir_high::Statement::lifetime_take_no_pos(encoded_target, lifetimes, self.rd_perm),
+        )?);
+        Ok(())
+    }
+
     fn encode_lft_assignment(
+        &mut self,
+        block_builder: &mut BasicBlockBuilder,
+        location: mir::Location,
+        lifetime: String,
+        constraints: BTreeSet<String>,
+    ) -> SpannedEncodingResult<()> {
+        let encoded_target = self.encode_lft_variable(lifetime)?;
+        let intersection = self.encode_lft_intersection(constraints)?;
+        block_builder.add_statement(self.set_statement_error(
+            location,
+            ErrorCtxt::LifetimeEncoding,
+            vir_high::Statement::ghost_assignment_no_pos(encoded_target, intersection),
+        )?);
+        Ok(())
+    }
+
+    fn encode_lft_assignments(
         &mut self,
         block_builder: &mut BasicBlockBuilder,
         location: mir::Location,
         lifetimes: BTreeMap<String, BTreeSet<String>>,
     ) -> SpannedEncodingResult<()> {
         for (lifetime, constraints) in lifetimes {
-            let encoded_target = self.encode_lft_variable(lifetime)?;
-            let mut iter = constraints.into_iter();
-            let mut intersection = self.encode_lft_variable(iter.next().unwrap())?.into();
-            for name in iter {
-                intersection = vir_high::Expression::binary_op_no_pos(
-                    vir_high::BinaryOpKind::LifetimeIntersection,
-                    intersection,
-                    self.encode_lft_variable(name)?.into(),
-                );
-            }
-            block_builder.add_statement(self.set_statement_error(
-                location,
-                ErrorCtxt::LifetimeEncoding,
-                vir_high::Statement::ghost_assignment_no_pos(encoded_target, intersection),
-            )?);
+            self.encode_lft_assignment(block_builder, location, lifetime, constraints)?;
         }
         Ok(())
     }
@@ -612,13 +649,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     }
                 );
                 let encoded_place = self.encoder.encode_place_high(self.mir, *place)?;
-                let rd_perm = self.read_permission_amount();
                 let region_name = region.to_text();
                 let encoded_rvalue = vir_high::Rvalue::ref_(
                     encoded_place,
                     vir_high::ty::LifetimeConst::new(region_name),
                     is_mut,
-                    rd_perm,
+                    self.rd_perm,
                     encoded_target.clone(),
                 );
                 let assign_statement = vir_high::Statement::assign(
@@ -864,6 +900,85 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(kind)
     }
 
+    fn needed_derived_lifetimes_for_block(
+        &mut self,
+        bb: &mir::BasicBlock,
+    ) -> BTreeMap<String, BTreeSet<String>> {
+        let first_location = mir::Location {
+            block: *bb,
+            statement_index: 0,
+        };
+        self.lifetimes
+            .get_origin_contains_loan_at_mid(first_location)
+    }
+
+    fn needed_original_lifetimes_for_block(&mut self, bb: &mir::BasicBlock) -> BTreeSet<String> {
+        let first_location = mir::Location {
+            block: *bb,
+            statement_index: 0,
+        };
+        self.lifetimes.get_loan_live_at_start(first_location)
+    }
+
+    fn encode_merge_blocks_new_lft(
+        &mut self,
+        target: mir::BasicBlock,
+        location: mir::Location,
+        block_builder: &mut BasicBlockBuilder,
+    ) -> SpannedEncodingResult<()> {
+        let needed_original_lifetimes = self.needed_original_lifetimes_for_block(&target);
+        let current_original_lifetimes = self.lifetimes.get_loan_live_at_start(location);
+        let difference_original_lifetimes: BTreeSet<String> = needed_original_lifetimes
+            .difference(&current_original_lifetimes)
+            .cloned()
+            .collect();
+        self.encode_new_lft(block_builder, location, difference_original_lifetimes)?;
+        Ok(())
+    }
+
+    fn encode_merge_blocks_shorten_lifetime(
+        &mut self,
+        target: mir::BasicBlock,
+        location: mir::Location,
+        block_builder: &mut BasicBlockBuilder,
+    ) -> SpannedEncodingResult<()> {
+        let needed_derived_lifetimes = self.needed_derived_lifetimes_for_block(&target);
+        let current_derived_lifetimes = self.lifetimes.get_origin_contains_loan_at_mid(location);
+        for (derived_lifetime, needed_derived_from) in needed_derived_lifetimes {
+            if current_derived_lifetimes
+                .get(&derived_lifetime[..])
+                .is_some()
+            {
+                self.encode_lifetime_take(
+                    block_builder,
+                    location,
+                    derived_lifetime,
+                    needed_derived_from,
+                )?;
+            } else {
+                // TODO: check if/when this case happens
+                self.encode_lft_assignment(
+                    block_builder,
+                    location,
+                    derived_lifetime,
+                    needed_derived_from,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn encode_merge_blocks(
+        &mut self,
+        target: mir::BasicBlock,
+        location: mir::Location,
+        block_builder: &mut BasicBlockBuilder,
+    ) -> SpannedEncodingResult<()> {
+        self.encode_merge_blocks_new_lft(target, location, block_builder)?;
+        self.encode_merge_blocks_shorten_lifetime(target, location, block_builder)?;
+        Ok(())
+    }
+
     fn encode_terminator(
         &mut self,
         block_builder: &mut BasicBlockBuilder,
@@ -874,9 +989,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let span = self.encoder.get_span_of_location(self.mir, location);
         use rustc_middle::mir::TerminatorKind;
         let successor = match &terminator.kind {
-            TerminatorKind::Goto { target } => SuccessorBuilder::jump(vir_high::Successor::Goto(
-                self.encode_basic_block_label(*target),
-            )),
+            TerminatorKind::Goto { target } => {
+                self.encode_merge_blocks(*target, location, block_builder)?;
+                SuccessorBuilder::jump(vir_high::Successor::Goto(
+                    self.encode_basic_block_label(*target),
+                ))
+            }
             TerminatorKind::SwitchInt {
                 targets,
                 discr,

--- a/vir/defs/high/ast/statement.rs
+++ b/vir/defs/high/ast/statement.rs
@@ -3,7 +3,7 @@ pub(crate) use super::{
     position::Position,
     predicate::Predicate,
     rvalue::{Operand, Rvalue},
-    ty::Type,
+    ty::{LifetimeConst, Type},
     variable::VariableDecl,
 };
 use crate::common::display;
@@ -30,6 +30,7 @@ pub enum Statement {
     NewLft(NewLft),
     EndLft(EndLft),
     GhostAssignment(GhostAssignment),
+    LifetimeTake(LifetimeTake),
 }
 
 #[display(fmt = "// {}", comment)]
@@ -186,5 +187,13 @@ pub struct EndLft {
 pub struct GhostAssignment {
     pub target: VariableDecl,
     pub value: Expression,
+    pub position: Position,
+}
+
+#[display(fmt = "{} := shorten_lifetime({:?}, {})", target, value, rd_perm)]
+pub struct LifetimeTake {
+    pub target: VariableDecl,
+    pub value: Vec<LifetimeConst>,
+    pub rd_perm: u32,
     pub position: Position,
 }

--- a/vir/defs/high/mod.rs
+++ b/vir/defs/high/mod.rs
@@ -18,7 +18,8 @@ pub use self::{
         rvalue::{Operand, OperandKind, Rvalue},
         statement::{
             Assert, Assign, Assume, Comment, Consume, CopyPlace, EndLft, Exhale, GhostAssignment,
-            Inhale, LeakAll, MovePlace, NewLft, OldLabel, Statement, WriteAddress, WritePlace,
+            Inhale, LeakAll, LifetimeTake, MovePlace, NewLft, OldLabel, Statement, WriteAddress,
+            WritePlace,
         },
         ty::{self, Type},
         type_decl::{self, DiscriminantRange, DiscriminantValue, TypeDecl},

--- a/vir/defs/high/operations_internal/identifier/ty.rs
+++ b/vir/defs/high/operations_internal/identifier/ty.rs
@@ -128,7 +128,11 @@ impl WithIdentifier for ty::Slice {
 
 impl WithIdentifier for ty::Reference {
     fn get_identifier(&self) -> String {
-        format!("ref${}", self.target_type.get_identifier())
+        format!(
+            "ref${}${}",
+            self.lifetime.get_identifier(),
+            self.target_type.get_identifier(),
+        )
     }
 }
 

--- a/vir/defs/high/operations_internal/position/statement.rs
+++ b/vir/defs/high/operations_internal/position/statement.rs
@@ -20,6 +20,7 @@ impl Positioned for Statement {
             Self::NewLft(statement) => statement.position(),
             Self::EndLft(statement) => statement.position(),
             Self::GhostAssignment(statement) => statement.position(),
+            Self::LifetimeTake(statement) => statement.position(),
         }
     }
 }
@@ -115,6 +116,12 @@ impl Positioned for EndLft {
 }
 
 impl Positioned for GhostAssignment {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for LifetimeTake {
     fn position(&self) -> Position {
         self.position
     }

--- a/vir/defs/middle/ast/statement.rs
+++ b/vir/defs/middle/ast/statement.rs
@@ -33,6 +33,7 @@ pub enum Statement {
     NewLft(NewLft),
     EndLft(EndLft),
     GhostAssignment(GhostAssignment),
+    LifetimeTake(LifetimeTake),
 }
 
 #[display(fmt = "// {}", comment)]
@@ -216,5 +217,13 @@ pub struct EndLft {
 pub struct GhostAssignment {
     pub target: VariableDecl,
     pub value: Expression,
+    pub position: Position,
+}
+
+#[display(fmt = "{} := shorten_lifetime({:?}, {})", target, value, rd_perm)]
+pub struct LifetimeTake {
+    pub target: VariableDecl,
+    pub value: Vec<LifetimeConst>,
+    pub rd_perm: u32,
     pub position: Position,
 }

--- a/vir/defs/middle/operations_internal/position/statement.rs
+++ b/vir/defs/middle/operations_internal/position/statement.rs
@@ -25,6 +25,7 @@ impl Positioned for Statement {
             Self::NewLft(statement) => statement.position(),
             Self::EndLft(statement) => statement.position(),
             Self::GhostAssignment(statement) => statement.position(),
+            Self::LifetimeTake(statement) => statement.position(),
         }
     }
 }
@@ -150,6 +151,12 @@ impl Positioned for EndLft {
 }
 
 impl Positioned for GhostAssignment {
+    fn position(&self) -> Position {
+        self.position
+    }
+}
+
+impl Positioned for LifetimeTake {
     fn position(&self) -> Position {
         self.position
     }


### PR DESCRIPTION
# Work

 - [x] Count number of lifetimes for read permission amount
 - [x] Use NewLft statements for lifetimes needed by the target block of the goto-terminator
 - [x] Implement and use ShortenLifetime statement to shorten derived lifetimes as needed by the target block of the goto-terminator

# Example

Here the if-branch creates lifetimes `lft6 ⊆ bw0`, the else-branch creates `lft6 ⊆ bw1`. After the branch we require the lifetimes to be the same. This means that the if-branch also needs to create `bw1` and the else-branch also needs to create `bw0` and `lft6` must be shortened to  `lft6 ⊆ bw0 ∩ bw1`.

```
fn main(c: bool){
    let mut a: i32 = 4;
    let mut b: i32 = 5;
    let x;
    if c {
        x = &mut a;
    } else {
        x = &mut b;
    }
    *x = 6;
}
```