### PR TITLE
Fix a bug in the purification optimization

### DIFF
--- a/prusti-common/src/vir/optimizations/purification/mod.rs
+++ b/prusti-common/src/vir/optimizations/purification/mod.rs
@@ -17,6 +17,11 @@ pub fn purify_methods(
     methods
 }
 
+pub fn is_purifiable_type(ty: &Type) -> bool {
+    debug_assert!(crate::config::enable_purification_optimization());
+    SUPPORTED_TYPES.contains(&ty.name().as_str())
+}
+
 fn translate_type(typ: &Type) -> Type {
     match typ {
         Type::TypedRef(..) => match typ.name().as_str() {

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1703,7 +1703,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             )),
             std::cmp::Ordering::Equal => {
                 let borrow_info = &borrow_infos[0];
-    
+
                 // Get the magic wand info.
                 let (post_label, lhs, rhs) = self
                     .magic_wand_at_location
@@ -1715,14 +1715,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         (post_label, lhs, rhs)
                     })
                     .unwrap();
-    
+
                 // Obtain the LHS permission.
                 for (path, _) in &borrow_info.blocking_paths {
                     let (encoded_place, _, _) = self.encode_generic_place(
                         contract.def_id, Some(loan_location), path
                     ).with_span(span)?;
                     let encoded_place = replace_fake_exprs(encoded_place);
-    
+
                     // Move the permissions from the "in loans" ("reborrowing loans") to the current loan
                     if node.incoming_zombies {
                         for &in_loan in node.reborrowing_loans.iter() {
@@ -1745,7 +1745,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         ));
                     }
                 }
-    
+
                 let pos = self.register_error(
                     //self.mir.span,
                     // TODO change to where the loan expires?
@@ -5178,6 +5178,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                             kind: vir::AssignKind::Move,
                         }));
                         alloc_stmts
+                    }
+                    _ if config::enable_purification_optimization() &&
+                         prusti_common::vir::optimizations::purification::is_purifiable_type(lhs.get_type()) => {
+                        self.encode_copy2(src, lhs.clone(), ty, location)?
                     }
                     _ => {
                         // Just move.

--- a/x.py
+++ b/x.py
@@ -212,7 +212,14 @@ def get_env():
 
 
 def run_command(args, env=None, cwd=None, on_exit=None, report_time=False):
-    """Run a command with the given arguments."""
+    """Run a command with the given arguments.
+
+    +   ``env`` – an environment in which to run.
+    +   ``cwd`` – the path at which to run.
+    +   ``on_exit`` – function to be executed on exit.
+    +   ``report_time`` – whether to report how long it took to execute
+        the command.
+    """
     if env is None:
         env = get_env()
     start_time = datetime.datetime.now()


### PR DESCRIPTION
Fixes a bug in the purification optimization: if a purified type is moved, it is potentially not unfolded:
```
  // [mir] _49 = move _111
  _49 := _111
```
and optimization would incorrectly change it to:
```
  // [mir] _49 = move _111
  _49 := _111.val_int
```
which fails to do permission error because `_111` is not unfolded. This PR fixes the problem by forcing copy assignments for all purifiable types.