### PR TITLE
[Merged by Bors] - Fix MIR availability error for bodyless trait methods

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/generic/traits-3.rs
+++ b/prusti-tests/tests/verify_overflow/pass/generic/traits-3.rs
@@ -1,0 +1,13 @@
+use prusti_contracts::*;
+
+trait Validity {
+    #[pure]
+    fn valid(&self) -> bool;
+}
+
+#[requires(a.valid())]
+fn test<T: Validity>(a: T) -> T {
+    a
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -277,7 +277,10 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
 
             let maybe_identifier: SpannedEncodingResult<vir_poly::FunctionIdentifier> = (|| {
                 let proc_kind = self.get_proc_kind(proc_def_id, Some(substs));
-                let mut function = if self.is_trusted(proc_def_id, Some(substs)) {
+                let is_bodyless = self.is_trusted(proc_def_id, Some(substs))
+                    || !self.env().tcx().is_mir_available(proc_def_id)
+                    || self.env().tcx().is_constructor(proc_def_id);
+                let mut function = if is_bodyless {
                     pure_function_encoder.encode_bodyless_function()?
                 } else {
                     match proc_kind {


### PR DESCRIPTION
Fix a panic trying to get the MIR body of a pure trait method with no body (see test).