### PR TITLE
[Merged by Bors] - Avoid some more warnings about extra braces/parens

### DIFF
--- a/prusti-specs/src/lib.rs
+++ b/prusti-specs/src/lib.rs
@@ -270,7 +270,7 @@ pub fn body_invariant(tokens: TokenStream) -> TokenStream {
     let invariant = handle_result!(rewriter.process_loop_invariant(spec_id, tokens));
     let callsite_span = Span::call_site();
     quote_spanned! {callsite_span=>
-        #[allow(unused_must_use, unused_variables)]
+        #[allow(unused_must_use, unused_variables, unused_braces, unused_parens)]
         if false {
             #invariant
         }
@@ -352,19 +352,19 @@ pub fn closure(tokens: TokenStream, drop_spec: bool) -> TokenStream {
 
     quote_spanned! {callsite_span=>
         {
-            #[allow(unused_variables)]
+            #[allow(unused_variables, unused_braces, unused_parens)]
             #[prusti::closure]
             #cl_annotations #attrs_ts
             let _prusti_closure =
                 #asyncness #movability #capture
                 #or1_token #inputs #or2_token #output
                 {
-                    #[allow(unused_must_use)]
+                    #[allow(unused_must_use, unused_braces, unused_parens)]
                     if false {
                         #spec_toks_pre
                     }
                     let result = #body ;
-                    #[allow(unused_must_use)]
+                    #[allow(unused_must_use, unused_braces, unused_parens)]
                     if false {
                         #spec_toks_post
                     }

--- a/prusti-tests/tests/parse/ui/true.stdout
+++ b/prusti-tests/tests/parse/ui/true.stdout
@@ -37,7 +37,8 @@ fn test2() {}
 fn test3() {
     for _ in 0..2 {
 
-        #[allow(unused_must_use, unused_variables)]
+        #[allow(unused_must_use, unused_variables, unused_braces,
+        unused_parens)]
         if false {
                 {
 
@@ -67,7 +68,8 @@ fn prusti_post_item_test4_$(NUM_UUID)(result: ())
 fn test4() {
     for _ in 0..2 {
 
-        #[allow(unused_must_use, unused_variables)]
+        #[allow(unused_must_use, unused_variables, unused_braces,
+        unused_parens)]
         if false {
                 {
 

--- a/prusti-tests/tests/verify/ui/collect.stdout
+++ b/prusti-tests/tests/verify/ui/collect.stdout
@@ -38,7 +38,8 @@ fn test3() {
     let mut curr = 0;
     while curr < 2 {
 
-        #[allow(unused_must_use, unused_variables)]
+        #[allow(unused_must_use, unused_variables, unused_braces,
+        unused_parens)]
         if false {
                 {
 
@@ -70,7 +71,8 @@ fn test4() {
     let mut curr = 0;
     while curr < 2 {
 
-        #[allow(unused_must_use, unused_variables)]
+        #[allow(unused_must_use, unused_variables, unused_braces,
+        unused_parens)]
         if false {
                 {
 


### PR DESCRIPTION
We insert them in generated code, to be sure not to miss any precedence,
but since it's generated code disable warnings there.