### PR TITLE
Backlog fixes

### DIFF
--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -525,7 +525,8 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
     pub fn encode_spec_funcs(&self, def_id: ProcedureDefId)
         -> SpannedEncodingResult<Vec<vir::FunctionIdentifier>>
     {
-        if !self.env().tcx().is_mir_available(def_id) || self.env().tcx().is_constructor(def_id) {
+        if !self.env().tcx().is_mir_available(def_id) || self.env().tcx().is_constructor(def_id)
+            || !def_id.is_local() {
             return Ok(vec![]);
         }
 

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -2988,7 +2988,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         destination: mir::Place<'tcx>,
         target: Option<BasicBlockIndex>,
         called_def_id: ProcedureDefId,
-        substs: ty::subst::SubstsRef<'tcx>,
+        mut substs: ty::subst::SubstsRef<'tcx>,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
         let full_func_proc_name = &self
             .encoder
@@ -2997,6 +2997,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             .def_path_str(called_def_id);
             // .absolute_item_path_str(called_def_id);
         debug!("Encoding non-pure function call '{}' with args {:?} and substs {:?}", full_func_proc_name, mir_args, substs);
+
+        // Spans for fake exprs that cannot be encoded in viper
+        let mut fake_expr_spans: FxHashMap<Local, Span> = FxHashMap::default();
 
         // First we construct the "operands" vector. This construction differs
         // for closure calls, where we need to unpack a tuple into the actual
@@ -3032,6 +3035,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             if let ty::TyKind::Tuple(arg_types) = arg_tuple_ty.kind() {
                 for (field_num, arg_ty) in arg_types.into_iter().enumerate() {
                     let arg = self.locals.get_fresh(arg_ty);
+                    fake_expr_spans.insert(arg, call_site_span);
                     let value_field = self
                         .encoder
                         .encode_raw_ref_field(format!("tuple_{}", field_num), arg_ty)
@@ -3046,6 +3050,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             } else {
                 unimplemented!();
             }
+
+            // TODO: weird fix for closure call substitutions, we need to
+            // prepend the identity substs of the containing method ...
+            substs = self.encoder.env().tcx().mk_substs(self.substs.iter().chain(substs));
         } else {
             for (arg, encoded_operand) in mir_args.iter().zip(encoded_operands.iter_mut()) {
                 let arg_ty = self.mir_encoder.get_operand_ty(arg);
@@ -3070,9 +3078,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         // This data structure maps the newly created local variables to the expression that was
         // originally passed as an argument.
         let mut fake_exprs: FxHashMap<vir::Expr, vir::Expr> = FxHashMap::default();
-
-        // Spans for fake exprs that cannot be encoded in viper
-        let mut fake_expr_spans: FxHashMap<Local, Span> = FxHashMap::default();
 
         let mut arguments = vec![];
 

--- a/test-crates/cargo-locks/022_cfg-if.Cargo.lock
+++ b/test-crates/cargo-locks/022_cfg-if.Cargo.lock
@@ -1,4 +1,4 @@
 [[package]]
 name = "cfg-if"
-version = "0.1.6"
+version = "1.0.0"
 

--- a/test-crates/crates.csv
+++ b/test-crates/crates.csv
@@ -21,7 +21,7 @@ time,0.1.40,NoCrash
 utf8-ranges,1.0.1,Skip
 byteorder,1.2.6,NoCrash
 serde_json,1.0.32,Skip
-cfg-if,0.1.6,Skip
+cfg-if,1.0.0,NoErrors
 url,1.7.1,Skip
 num_cpus,1.8.0,NoCrash
 gcc,0.3.55,Skip


### PR DESCRIPTION
In `test-crates/crates.csv`, replace one `Skip` with `NoCrash` or one `NoCrash` with `NoErrors`. Optionally, also update a crate version. This should be enough to make the `test-crates` test fail because of panics or internal errors. To test a single crate you can use `./target/release/test-crates <FILTER>`, which checks only the crates whose name contains `<FILTER>`.

The purpose of this PR is to fix at least one bug (e.g. convert a panic to an internal error or an internal error to a readable "unsupported" error message).

@Aurel300 could you take care of this?