### PR TITLE
Small fixes to the dev and user guides

### DIFF
--- a/docs/dev-guide/src/encoding/types-snap.md
+++ b/docs/dev-guide/src/encoding/types-snap.md
@@ -41,7 +41,7 @@ domain Snap$SomeStruct { // (1)
   axiom Snap$SomeStruct$injectivity {
     forall
       a1: Int, b1: Int, a2: Int, b2: Int :: { cons$SomeStruct(a1, b1), cons$SomeStruct(a2, b2) }
-      cons$SomeStruct(a1, b1) == cons$SomeStruct(a2, b2) ==> a1 == b1 && a2 == b2
+      cons$SomeStruct(a1, b1) == cons$SomeStruct(a2, b2) ==> a1 == a2 && b1 == b2
   }
 
 }

--- a/docs/user-guide/src/basic.md
+++ b/docs/user-guide/src/basic.md
@@ -68,7 +68,7 @@ After that, we used `#[ensures(...)]` to attach two [postconditions](verify/prep
 The syntax of specifications is a superset of Rust expressions, where `result` is a keyword referring to the function's return value. 
 
 Again, verifying the above code with Prusti should succeed. 
-Notice that Prusti assumes by default that integer types are unbounded; it thus ignores [overflow and underflow checks](verify/overflow.md) unless corresponding options are provided.
+Notice that Prusti assumes by default that integer types are bounded; it thus performs [overflow and underflow checks](verify/overflow.md) unless corresponding options are provided.
 
 Next, we add a second function `max3` which returns the maximum of three instead of two integers; we reuse the already verified function `max` in the new function's specification to show that this function is implemented correctly.
 

--- a/docs/user-guide/src/verify/panic.md
+++ b/docs/user-guide/src/verify/panic.md
@@ -34,5 +34,5 @@ pub fn main() {
 ```
 
 Since Prusti is conservative, if it reports no verification errors then the program is provably correct *with regard to the checked properties.*
-The last part is important because [overflow checks](overflow.html) are *not* enabled by default. 
+The last part is important because checks such as [overflow checks](overflow.html) may be disabled. 
 Furthermore, Prusti may verify a program although some (or even all) of its executions do not terminate because it verifies partial correctness properties.


### PR DESCRIPTION
- Fixes a typo in the snapshot encoding example where the two structs should have equal components
- Updates wording that mentions overflow checks are off by default #622
