### PR TITLE
Add Lifetime Encoding for Function Calls

### DIFF
--- a/prusti-interface/src/environment/mir_dump/lifetimes.rs
+++ b/prusti-interface/src/environment/mir_dump/lifetimes.rs
@@ -68,18 +68,44 @@ impl Lifetimes {
             })
             .collect()
     }
-    pub fn lifetime_count(&self) -> u32 {
-        let original_lifetimes_count: u32 = self.get_original_lifetimes().len().try_into().unwrap();
+    pub fn lifetime_count(&self) -> usize {
+        let original_lifetimes_count = self.get_original_lifetimes().len();
         let borrowck_in_facts = self.borrowck_in_facts();
         let subset_lifetimes: BTreeSet<Region> = borrowck_in_facts
             .subset_base
             .iter()
             .flat_map(|&(r1, r2, _)| [r1, r2])
             .collect();
-        let subset_lifetimes_count: u32 = subset_lifetimes.len().try_into().unwrap();
-        original_lifetimes_count + subset_lifetimes_count
+        let opaque_lifetimes_count = self
+            .get_opaque_lifetimes_with_inclusions_names()
+            .keys()
+            .count();
+        let subset_lifetimes_count = subset_lifetimes.len();
+        original_lifetimes_count + subset_lifetimes_count + opaque_lifetimes_count
     }
-
+    pub fn get_opaque_lifetimes_with_inclusions_names(&self) -> BTreeMap<String, BTreeSet<String>> {
+        let opaque_lifetimes = self.get_opaque_lifetimes_with_inclusions();
+        let mut result = BTreeMap::new();
+        for lifetime_with_inclusions in opaque_lifetimes {
+            result.insert(
+                lifetime_with_inclusions.lifetime.to_text(),
+                lifetime_with_inclusions
+                    .included_in
+                    .iter()
+                    .map(|x| x.to_text())
+                    .collect(),
+            );
+        }
+        result
+    }
+    pub fn get_subset_base_at_start(&self, location: mir::Location) -> Vec<(Region, Region)> {
+        let rich_location = RichLocation::Start(location);
+        self.get_subset_base(rich_location)
+    }
+    pub fn get_subset_base_at_mid(&self, location: mir::Location) -> Vec<(Region, Region)> {
+        let rich_location = RichLocation::Mid(location);
+        self.get_subset_base(rich_location)
+    }
     fn borrowck_in_facts(&self) -> Ref<AllInputFacts> {
         Ref::map(self.facts.input_facts.borrow(), |facts| {
             facts.as_ref().unwrap()

--- a/prusti-interface/src/environment/mir_dump/lifetimes.rs
+++ b/prusti-interface/src/environment/mir_dump/lifetimes.rs
@@ -1,3 +1,5 @@
+// FIXME: Delete this file.
+
 use crate::environment::{
     borrowck::facts::{AllInputFacts, AllOutputFacts, BorrowckFacts, Loan, PointIndex, Region},
     mir_dump::graphviz::{loan_to_text, opaque_lifetime_string, to_sorted_text, ToText},

--- a/prusti-interface/src/environment/mir_dump/mir.rs
+++ b/prusti-interface/src/environment/mir_dump/mir.rs
@@ -91,13 +91,13 @@ fn visit_basic_block(
         visit_statement(
             &mut node_builder,
             location,
-            &statements[location.statement_index],
+            statements[location.statement_index].to_text(),
             lifetimes,
         );
         location.statement_index += 1;
     }
     if let Some(terminator) = terminator {
-        node_builder.add_row_single(terminator.to_text());
+        visit_statement(&mut node_builder, location, terminator.to_text(), lifetimes);
     }
     node_builder.build();
     if let Some(terminator) = terminator {
@@ -108,7 +108,7 @@ fn visit_basic_block(
 fn visit_statement(
     node_builder: &mut NodeBuilder,
     location: mir::Location,
-    statement: &mir::Statement<'_>,
+    statement_text: String,
     lifetimes: &Lifetimes,
 ) {
     let subset_base_start = lifetimes.get_subset_base(RichLocation::Start(location));
@@ -127,7 +127,7 @@ fn visit_statement(
 
     let mut row_builder_start = node_builder.create_row();
     row_builder_start.set("location", location.to_text());
-    row_builder_start.set("statement", statement.to_text());
+    row_builder_start.set("statement", statement_text);
     row_builder_start.set("subset_base", subset_base_start.to_text());
     row_builder_start.set("subset", subset_start.to_text());
     row_builder_start.set("origin_live_on_entry", origin_live_on_entry_start.to_text());

--- a/prusti-viper/src/encoder/errors/error_manager.rs
+++ b/prusti-viper/src/encoder/errors/error_manager.rs
@@ -136,6 +136,10 @@ pub enum ErrorCtxt {
     LifetimeTake,
     /// Failed to encode LifetimeReturn
     LifetimeReturn,
+    /// An error when inhaling lifetimes
+    LifetimeInhale,
+    /// An error when exhaling lifetimes
+    LifetimeExhale,
     /// Failed to encode OpenMutRef
     OpenMutRef,
     /// Failed to encode OpenFracRef

--- a/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
@@ -151,6 +151,7 @@ fn extract_managed_predicate_place(
             Ok(Some(Permission::Owned(predicate.place.clone())))
         }
         vir_high::Predicate::MemoryBlockStackDrop(_)
+        | vir_high::Predicate::LifetimeToken(_)
         | vir_high::Predicate::MemoryBlockHeap(_)
         | vir_high::Predicate::MemoryBlockHeapDrop(_) => {
             // Unmanaged predicates.

--- a/prusti-viper/src/encoder/high/to_middle/predicate.rs
+++ b/prusti-viper/src/encoder/high/to_middle/predicate.rs
@@ -20,4 +20,13 @@ impl<'v, 'tcx> ToMiddlePredicateLowerer for crate::encoder::Encoder<'v, 'tcx> {
     ) -> SpannedEncodingResult<vir_mid::Expression> {
         expression.to_middle_expression(self)
     }
+
+    fn to_middle_predicate_lifetime_const(
+        &self,
+        lifetime_const: vir_high::ty::LifetimeConst,
+    ) -> SpannedEncodingResult<vir_mid::ty::LifetimeConst> {
+        Ok(vir_mid::ty::LifetimeConst {
+            name: lifetime_const.name,
+        })
+    }
 }

--- a/prusti-viper/src/encoder/middle/core_proof/into_low/cfg.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/into_low/cfg.rs
@@ -460,14 +460,15 @@ impl IntoLow for vir_mid::Statement {
                             lifetime.to_procedure_snapshot(lowerer)?,
                         ));
                     }
-                    arguments.push(vir_low::Expression::fractional_permission(
-                        statement.rd_perm,
-                    ));
+                    let perm_amount = statement
+                        .lifetime_token_permission
+                        .to_procedure_snapshot(lowerer)?;
+                    arguments.push(perm_amount);
                     let target = vec![vir_low::Expression::local_no_pos(
                         statement.target.to_procedure_snapshot(lowerer)?,
                     )];
                     Ok(vec![Statement::method_call(
-                        String::from("lft_tok_sep_take"),
+                        format!("lft_tok_sep_take${}", statement.value.len()),
                         arguments,
                         target,
                         statement.position,
@@ -486,11 +487,12 @@ impl IntoLow for vir_mid::Statement {
                             lifetime.to_procedure_snapshot(lowerer)?,
                         ));
                     }
-                    arguments.push(vir_low::Expression::fractional_permission(
-                        statement.rd_perm,
-                    ));
+                    let perm_amount = statement
+                        .lifetime_token_permission
+                        .to_procedure_snapshot(lowerer)?;
+                    arguments.push(perm_amount);
                     Ok(vec![Statement::method_call(
-                        String::from("lft_tok_sep_take"),
+                        format!("lft_tok_sep_return${}", statement.value.len()),
                         arguments,
                         vec![],
                         statement.position,
@@ -504,8 +506,9 @@ impl IntoLow for vir_mid::Statement {
                 let ty = place.get_type();
                 lowerer.encode_frac_bor_atomic_acc_method(ty)?;
                 let lifetime = lowerer.encode_lifetime_const_into_variable(statement.lifetime)?;
-                let perm_amount =
-                    vir_low::Expression::fractional_permission(statement.token_permission_amount);
+                let perm_amount = statement
+                    .lifetime_token_permission
+                    .to_procedure_snapshot(lowerer)?;
                 let reference_place = lowerer.encode_expression_as_place(place)?;
                 let reference_value = place.to_procedure_snapshot(lowerer)?;
                 let targets = vec![statement
@@ -528,8 +531,9 @@ impl IntoLow for vir_mid::Statement {
                 let place = statement.place.get_parent_ref().unwrap();
                 let ty = place.get_type();
                 let lifetime = lowerer.encode_lifetime_const_into_variable(statement.lifetime)?;
-                let perm_amount =
-                    vir_low::Expression::fractional_permission(statement.token_permission_amount);
+                let perm_amount = statement
+                    .lifetime_token_permission
+                    .to_procedure_snapshot(lowerer)?;
                 let reference_place = lowerer.encode_expression_as_place(place)?;
                 let deref_place =
                     lowerer.reference_deref_place(reference_place, statement.position)?;
@@ -558,8 +562,9 @@ impl IntoLow for vir_mid::Statement {
                 let ty = place.get_type();
                 lowerer.encode_open_close_mut_ref_methods(ty)?;
                 let lifetime = lowerer.encode_lifetime_const_into_variable(statement.lifetime)?;
-                let perm_amount =
-                    vir_low::Expression::fractional_permission(statement.token_permission_amount);
+                let perm_amount = statement
+                    .lifetime_token_permission
+                    .to_procedure_snapshot(lowerer)?;
                 let reference_place = lowerer.encode_expression_as_place(place)?;
                 let reference_value = place.to_procedure_snapshot(lowerer)?;
                 let statements = vec![stmtp! { statement.position =>
@@ -577,8 +582,9 @@ impl IntoLow for vir_mid::Statement {
                 let ty = place.get_type();
                 lowerer.encode_open_close_mut_ref_methods(ty)?;
                 let lifetime = lowerer.encode_lifetime_const_into_variable(statement.lifetime)?;
-                let perm_amount =
-                    vir_low::Expression::fractional_permission(statement.token_permission_amount);
+                let perm_amount = statement
+                    .lifetime_token_permission
+                    .to_procedure_snapshot(lowerer)?;
                 let reference_place = lowerer.encode_expression_as_place(place)?;
                 let reference_value = place.to_procedure_snapshot(lowerer)?;
                 let deref_place =
@@ -620,6 +626,13 @@ impl IntoLow for vir_mid::Predicate {
         use vir_low::macros::*;
         use vir_mid::Predicate;
         let result = match self {
+            Predicate::LifetimeToken(predicate) => {
+                lowerer.encode_lifetime_token_predicate()?;
+                let lifetime = lowerer.encode_lifetime_const_into_variable(predicate.lifetime)?;
+                let permission = predicate.permission.to_procedure_snapshot(lowerer)?;
+                expr! { acc(LifetimeToken([lifetime.into()]), [permission])}
+                    .set_default_position(predicate.position)
+            }
             Predicate::MemoryBlockStack(predicate) => {
                 lowerer.encode_memory_block_predicate()?;
                 let place = lowerer.encode_expression_as_place_address(&predicate.place)?;

--- a/prusti-viper/src/encoder/middle/core_proof/lifetimes/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lifetimes/interface.rs
@@ -125,7 +125,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> LifetimesInterface for Lowerer<'p, 'v, 'tcx> {
             self.lifetimes_state
                 .encoded_lifetime_intersect
                 .insert(lft_count);
-
+            self.encode_lifetime_included()?;
+            self.encode_lifetime_included_intersect_axiom(lft_count)?;
             let return_type = self.domain_type("Lifetime")?;
             let arguments = self.create_lifetime_expressions(lft_count).unwrap();
             self.create_domain_func_app(

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/values/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/values/interface.rs
@@ -216,6 +216,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValuesInterface for Lowerer<'p, 'v, 'tcx> {
         right: vir_low::Expression,
         position: vir_mid::Position,
     ) -> SpannedEncodingResult<vir_low::Expression> {
+        // TODO: Add MPerm special cases here.
         if ty == &vir_mid::Type::MBool {
             Ok(vir_low::Expression::binary_op(
                 op.to_snapshot(self)?,

--- a/prusti-viper/src/encoder/mir/procedures/encoder/scc.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/scc.rs
@@ -1,0 +1,127 @@
+// source: https://rosettacode.org/wiki/Tarjan#Rust
+// license: GNU Free Documentation License 1.2
+// TODO: use rust's scc? https://doc.rust-lang.org/beta/nightly-rustc/rustc_data_structures/graph/scc/index.html
+
+use std::collections::{BTreeMap, BTreeSet};
+
+// Using a naked BTreeMap would not be very nice, so let's make a simple graph representation
+#[derive(Clone, Debug)]
+pub struct Graph {
+    neighbors: BTreeMap<usize, BTreeSet<usize>>,
+}
+
+impl Graph {
+    pub fn new(size: usize) -> Self {
+        Self {
+            neighbors: (0..size).fold(BTreeMap::new(), |mut acc, x| {
+                acc.insert(x, BTreeSet::new());
+                acc
+            }),
+        }
+    }
+
+    pub fn edges<'a>(&'a self, vertex: usize) -> impl Iterator<Item = usize> + '_ {
+        self.neighbors[&vertex].iter().cloned()
+    }
+
+    pub fn add_edge(&mut self, from: usize, to: usize) {
+        assert!(to < self.len());
+        self.neighbors.get_mut(&from).unwrap().insert(to);
+    }
+
+    pub fn len(&self) -> usize {
+        self.neighbors.len()
+    }
+}
+
+#[derive(Clone)]
+struct VertexState {
+    index: usize,
+    low_link: usize,
+    on_stack: bool,
+}
+
+// The easy way not to fight with Rust's borrow checker is moving the state in
+// a structure and simply invoke methods on that structure.
+
+pub struct Tarjan<'a> {
+    graph: &'a Graph,
+    index: usize,
+    stack: Vec<usize>,
+    state: Vec<VertexState>,
+    components: Vec<BTreeSet<usize>>,
+}
+
+impl<'a> Tarjan<'a> {
+    // Having index: Option<usize> would look nicer, but requires just
+    // some unwraps and Vec has actual len limit isize::MAX anyway, so
+    // we can reserve this large value as the invalid one.
+    const INVALID_INDEX: usize = usize::MAX;
+
+    pub fn walk(graph: &'a Graph) -> Vec<BTreeSet<usize>> {
+        Self {
+            graph,
+            index: 0,
+            stack: Vec::new(),
+            state: vec![
+                VertexState {
+                    index: Self::INVALID_INDEX,
+                    low_link: Self::INVALID_INDEX,
+                    on_stack: false
+                };
+                graph.len()
+            ],
+            components: Vec::new(),
+        }
+        .visit_all()
+    }
+
+    fn visit_all(mut self) -> Vec<BTreeSet<usize>> {
+        for vertex in 0..self.graph.len() {
+            if self.state[vertex].index == Self::INVALID_INDEX {
+                self.visit(vertex);
+            }
+        }
+
+        self.components
+    }
+
+    fn visit(&mut self, v: usize) {
+        let v_ref = &mut self.state[v];
+        v_ref.index = self.index;
+        v_ref.low_link = self.index;
+        self.index += 1;
+        self.stack.push(v);
+        v_ref.on_stack = true;
+
+        for w in self.graph.edges(v) {
+            let w_ref = &self.state[w];
+            if w_ref.index == Self::INVALID_INDEX {
+                self.visit(w);
+                let w_low_link = self.state[w].low_link;
+                let v_ref = &mut self.state[v];
+                v_ref.low_link = v_ref.low_link.min(w_low_link);
+            } else if w_ref.on_stack {
+                let w_index = self.state[w].index;
+                let v_ref = &mut self.state[v];
+                v_ref.low_link = v_ref.low_link.min(w_index);
+            }
+        }
+
+        let v_ref = &self.state[v];
+        if v_ref.low_link == v_ref.index {
+            let mut component = BTreeSet::new();
+
+            loop {
+                let w = self.stack.pop().unwrap();
+                self.state[w].on_stack = false;
+                component.insert(w);
+                if w == v {
+                    break;
+                }
+            }
+
+            self.components.push(component);
+        }
+    }
+}

--- a/vir/defs/high/ast/expression.rs
+++ b/vir/defs/high/ast/expression.rs
@@ -230,6 +230,8 @@ pub struct FuncApp {
 
 #[derive(Copy)]
 pub enum BuiltinFunc {
+    LifetimeIncluded,
+    LifetimeIntersect,
     EmptyMap,
     UpdateMap,
     LookupMap,

--- a/vir/defs/high/ast/predicate.rs
+++ b/vir/defs/high/ast/predicate.rs
@@ -1,5 +1,5 @@
 pub(crate) use super::super::{
-    ast::{expression::Expression, position::Position},
+    ast::{expression::Expression, position::Position, ty::LifetimeConst},
     operations_internal::ty::Typed,
 };
 
@@ -7,11 +7,19 @@ pub(crate) use super::super::{
 #[derive_visitors]
 #[derive(derive_more::From, derive_more::IsVariant)]
 pub enum Predicate {
+    LifetimeToken(LifetimeToken),
     MemoryBlockStack(MemoryBlockStack),
     MemoryBlockStackDrop(MemoryBlockStackDrop),
     MemoryBlockHeap(MemoryBlockHeap),
     MemoryBlockHeapDrop(MemoryBlockHeapDrop),
     OwnedNonAliased(OwnedNonAliased),
+}
+
+#[display(fmt = "acc(LifetimeToken({}), {})", lifetime, permission)]
+pub struct LifetimeToken {
+    pub lifetime: LifetimeConst,
+    pub permission: Expression,
+    pub position: Position,
 }
 
 /// A memory block on the stack allocated with `StorageLive`.

--- a/vir/defs/high/ast/rvalue.rs
+++ b/vir/defs/high/ast/rvalue.rs
@@ -31,7 +31,7 @@ pub struct Ref {
     pub place: Expression,
     pub lifetime: LifetimeConst,
     pub is_mut: bool,
-    pub rd_perm: u32,
+    pub lifetime_token_permission: Expression,
     pub target: Expression,
 }
 

--- a/vir/defs/high/ast/statement.rs
+++ b/vir/defs/high/ast/statement.rs
@@ -249,12 +249,12 @@ pub struct Dead {
     fmt = "{} := lifetime_take({}, {})",
     target,
     "display::cjoin(value)",
-    rd_perm
+    lifetime_token_permission
 )]
 pub struct LifetimeTake {
     pub target: VariableDecl,
     pub value: Vec<VariableDecl>,
-    pub rd_perm: u32,
+    pub lifetime_token_permission: Expression,
     pub position: Position,
 }
 
@@ -262,24 +262,24 @@ pub struct LifetimeTake {
     fmt = "lifetime_return({}, {}, {})",
     target,
     "display::cjoin(value)",
-    rd_perm
+    lifetime_token_permission
 )]
 pub struct LifetimeReturn {
     pub target: VariableDecl,
     pub value: Vec<VariableDecl>,
-    pub rd_perm: u32,
+    pub lifetime_token_permission: Expression,
     pub position: Position,
 }
 
 #[display(
     fmt = "open_mut_ref({}, rd({}), {})",
     lifetime,
-    token_permission_amount,
+    lifetime_token_permission,
     place
 )]
 pub struct OpenMutRef {
     pub lifetime: LifetimeConst,
-    pub token_permission_amount: u32,
+    pub lifetime_token_permission: Expression,
     pub place: Expression,
     pub position: Position,
 }
@@ -288,7 +288,7 @@ pub struct OpenMutRef {
     fmt = "{} := open_frac_ref({}, rd({}), {})",
     predicate_permission_amount,
     lifetime,
-    token_permission_amount,
+    lifetime_token_permission,
     place
 )]
 pub struct OpenFracRef {
@@ -296,7 +296,7 @@ pub struct OpenFracRef {
     /// The permission amount that we get for accessing `Owned`.
     pub predicate_permission_amount: VariableDecl,
     /// The permission amount taken from the token.
-    pub token_permission_amount: u32,
+    pub lifetime_token_permission: Expression,
     pub place: Expression,
     pub position: Position,
 }
@@ -304,12 +304,12 @@ pub struct OpenFracRef {
 #[display(
     fmt = "close_mut_ref({}, rd({}), {})",
     lifetime,
-    token_permission_amount,
+    lifetime_token_permission,
     place
 )]
 pub struct CloseMutRef {
     pub lifetime: LifetimeConst,
-    pub token_permission_amount: u32,
+    pub lifetime_token_permission: Expression,
     pub place: Expression,
     pub position: Position,
 }
@@ -317,14 +317,14 @@ pub struct CloseMutRef {
 #[display(
     fmt = "close_frac_ref({}, rd({}), {}, {})",
     lifetime,
-    token_permission_amount,
+    lifetime_token_permission,
     place,
     predicate_permission_amount
 )]
 pub struct CloseFracRef {
     pub lifetime: LifetimeConst,
     /// The permission amount taken from the token.
-    pub token_permission_amount: u32,
+    pub lifetime_token_permission: Expression,
     pub place: Expression,
     /// The permission amount that we get for accessing `Owned`.
     pub predicate_permission_amount: VariableDecl,

--- a/vir/defs/high/mod.rs
+++ b/vir/defs/high/mod.rs
@@ -13,7 +13,8 @@ pub use self::{
         function::FunctionDecl,
         position::Position,
         predicate::{
-            MemoryBlockHeap, MemoryBlockHeapDrop, MemoryBlockStack, MemoryBlockStackDrop, Predicate,
+            LifetimeToken, MemoryBlockHeap, MemoryBlockHeapDrop, MemoryBlockStack,
+            MemoryBlockStackDrop, Predicate,
         },
         rvalue::{Operand, OperandKind, Rvalue},
         statement::{

--- a/vir/defs/high/operations_internal/expression.rs
+++ b/vir/defs/high/operations_internal/expression.rs
@@ -429,4 +429,10 @@ impl Expression {
         let position = self.position();
         self.variant(variant_name, ty, position)
     }
+    pub fn none_permission() -> Self {
+        Self::constant_no_pos(ConstantValue::Int(0), Type::MPerm)
+    }
+    pub fn full_permission() -> Self {
+        Self::constant_no_pos(ConstantValue::Int(1), Type::MPerm)
+    }
 }

--- a/vir/defs/high/operations_internal/identifier/predicate.rs
+++ b/vir/defs/high/operations_internal/identifier/predicate.rs
@@ -10,12 +10,19 @@ use crate::common::identifier::WithIdentifier;
 impl WithIdentifier for Predicate {
     fn get_identifier(&self) -> String {
         match self {
+            Self::LifetimeToken(predicate) => predicate.get_identifier(),
             Self::MemoryBlockStack(predicate) => predicate.get_identifier(),
             Self::MemoryBlockStackDrop(predicate) => predicate.get_identifier(),
             Self::MemoryBlockHeap(predicate) => predicate.get_identifier(),
             Self::MemoryBlockHeapDrop(predicate) => predicate.get_identifier(),
             Self::OwnedNonAliased(predicate) => predicate.get_identifier(),
         }
+    }
+}
+
+impl WithIdentifier for predicate::LifetimeToken {
+    fn get_identifier(&self) -> String {
+        "LifetimeToken".to_string()
     }
 }
 

--- a/vir/defs/high/operations_internal/predicate.rs
+++ b/vir/defs/high/operations_internal/predicate.rs
@@ -11,6 +11,9 @@ use super::super::{
 impl Predicate {
     pub fn parameter_types(&self) -> Vec<Type> {
         match self {
+            Self::LifetimeToken(_predicate) => {
+                vec![]
+            }
             Self::MemoryBlockStack(predicate) => {
                 vec![
                     predicate.place.get_type().clone(),

--- a/vir/defs/middle/ast/statement.rs
+++ b/vir/defs/middle/ast/statement.rs
@@ -245,12 +245,12 @@ pub struct Dead {
     fmt = "{} := lifetime_take({}, {})",
     target,
     "display::cjoin(value)",
-    rd_perm
+    lifetime_token_permission
 )]
 pub struct LifetimeTake {
     pub target: VariableDecl,
     pub value: Vec<VariableDecl>,
-    pub rd_perm: u32,
+    pub lifetime_token_permission: Expression,
     pub position: Position,
 }
 
@@ -258,24 +258,24 @@ pub struct LifetimeTake {
     fmt = "lifetime_return({}, {}, {})",
     target,
     "display::cjoin(value)",
-    rd_perm
+    lifetime_token_permission
 )]
 pub struct LifetimeReturn {
     pub target: VariableDecl,
     pub value: Vec<VariableDecl>,
-    pub rd_perm: u32,
+    pub lifetime_token_permission: Expression,
     pub position: Position,
 }
 
 #[display(
     fmt = "open_mut_ref({}, rd({}), {})",
     lifetime,
-    token_permission_amount,
+    lifetime_token_permission,
     place
 )]
 pub struct OpenMutRef {
     pub lifetime: LifetimeConst,
-    pub token_permission_amount: u32,
+    pub lifetime_token_permission: Expression,
     pub place: Expression,
     pub position: Position,
 }
@@ -284,7 +284,7 @@ pub struct OpenMutRef {
     fmt = "{} := open_frac_ref({}, rd({}), {})",
     predicate_permission_amount,
     lifetime,
-    token_permission_amount,
+    lifetime_token_permission,
     place
 )]
 pub struct OpenFracRef {
@@ -292,7 +292,7 @@ pub struct OpenFracRef {
     /// The permission amount that we get for accessing `Owned`.
     pub predicate_permission_amount: VariableDecl,
     /// The permission amount taken from the token.
-    pub token_permission_amount: u32,
+    pub lifetime_token_permission: Expression,
     pub place: Expression,
     pub position: Position,
 }
@@ -300,12 +300,12 @@ pub struct OpenFracRef {
 #[display(
     fmt = "close_mut_ref({}, rd({}), {})",
     lifetime,
-    token_permission_amount,
+    lifetime_token_permission,
     place
 )]
 pub struct CloseMutRef {
     pub lifetime: LifetimeConst,
-    pub token_permission_amount: u32,
+    pub lifetime_token_permission: Expression,
     pub place: Expression,
     pub position: Position,
 }
@@ -313,14 +313,14 @@ pub struct CloseMutRef {
 #[display(
     fmt = "close_frac_ref({}, rd({}), {}, {})",
     lifetime,
-    token_permission_amount,
+    lifetime_token_permission,
     place,
     predicate_permission_amount
 )]
 pub struct CloseFracRef {
     pub lifetime: LifetimeConst,
     /// The permission amount taken from the token.
-    pub token_permission_amount: u32,
+    pub lifetime_token_permission: Expression,
     pub place: Expression,
     /// The permission amount that we get for accessing `Owned`.
     pub predicate_permission_amount: VariableDecl,

--- a/vir/src/high/builders/procedure.rs
+++ b/vir/src/high/builders/procedure.rs
@@ -38,19 +38,24 @@ pub enum SuccessorBuilder {
 }
 
 impl ProcedureBuilder {
+    #![allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
         allocate_parameters: Vec<vir_high::Statement>,
         allocate_returns: Vec<vir_high::Statement>,
         assume_preconditions: Vec<vir_high::Statement>,
+        assume_lifetime_preconditions: Vec<vir_high::Statement>,
         deallocate_parameters: Vec<vir_high::Statement>,
         deallocate_returns: Vec<vir_high::Statement>,
         assert_postconditions: Vec<vir_high::Statement>,
+        assert_lifetime_postconditions: Vec<vir_high::Statement>,
     ) -> Self {
         let mut pre_statements = allocate_parameters;
         pre_statements.extend(assume_preconditions);
+        pre_statements.extend(assume_lifetime_preconditions);
         pre_statements.extend(allocate_returns);
         let mut post_statements = assert_postconditions;
+        post_statements.extend(assert_lifetime_postconditions);
         post_statements.extend(deallocate_parameters);
         post_statements.extend(deallocate_returns);
         Self {


### PR DESCRIPTION
 On caller side:
 - [x] Assert Lifetime preconditions
 - [x] Exhale Lifetimes access (function lifetime,  argument lifetimes, static lifetime)
 - [x] Inhale Lifetimes again after function call
 
On called side:
  - [x] Inhale Lifetime access
  - [x] Inhale Lifetime preconditions