### PR TITLE
Backlog fixes

### DIFF
--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -84,6 +84,15 @@ pub fn expand_struct_place<'tcx>(
                     places.push(tcx.mk_place_deref(*place));
                 }
             },
+            ty::Closure(_, substs) => {
+                for (index, subst_ty) in substs.as_closure().upvar_tys().enumerate() {
+                    if Some(index) != without_field {
+                        let field = mir::Field::from_usize(index);
+                        let field_place = tcx.mk_place_field(*place, field, subst_ty);
+                        places.push(field_place.into());
+                    }
+                }
+            }
             ref ty => {
                 unimplemented!("ty={:?}", ty);
             }

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -89,7 +89,7 @@ pub fn expand_struct_place<'tcx>(
                     if Some(index) != without_field {
                         let field = mir::Field::from_usize(index);
                         let field_place = tcx.mk_place_field(*place, field, subst_ty);
-                        places.push(field_place.into());
+                        places.push(field_place);
                     }
                 }
             }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -3597,7 +3597,21 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             ty::TyKind::Ref(_, ty, mutability) => {
                 // Use unfolded references.
                 let encoded_local = self.encode_prusti_local(local);
-                let span = override_span.unwrap_or_else(|| self.mir_encoder.get_local_span(local.into()));
+                let span = if let Some(fake_local_span) = override_span {
+                    fake_local_span
+                } else {
+                    if self.mir.local_decls.get(local.into()).is_none() {
+                        return Err(SpannedEncodingError::internal(
+                            format!(
+                                "In ProcedureEncoder::encode_local_variable_permission the local \
+                                {:?} is fake but override_span is None",
+                                local,
+                            ),
+                            self.mir.span
+                        ));
+                    }
+                    self.mir_encoder.get_local_span(local.into())
+                };
                 let field = self.encoder.encode_dereference_field(*ty)
                     .with_span(span)?;
                 let place = vir::Expr::from(encoded_local).field(field);

--- a/test-crates/crates.csv
+++ b/test-crates/crates.csv
@@ -2,7 +2,7 @@ name,version,test_kind
 libc,0.2.43,NoErrors
 bitflags,1.0.4,NoErrors
 log,0.4.5,NoCrash
-lazy_static,1.1.0,Skip
+lazy_static,1.1.0,NoCrash
 serde,1.0.80,Skip
 winapi,0.3.6,NoCrash
 regex,1.0.5,Skip


### PR DESCRIPTION
In `test-crates/crates.csv`, replace one `Skip` with `NoCrash` or one `NoCrash` with `NoErrors`. Optionally, also update a crate version. This should be enough to make the `test-crates` test fail because of panics or internal errors. To test a single crate you can use `./target/release/test-crates <FILTER>`, which checks only the crates whose name contains `<FILTER>`.

The purpose of this PR is to fix at least one bug (e.g. convert a panic to an internal error or an internal error to a readable "unsupported" error message).

@fpoli could you take care of this?