### PR TITLE
Update dependencies (rustc nightly-2022-05-15, viper v.22.04.17-release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
  "tracing",
 ]
 
@@ -1052,7 +1052,7 @@ checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -1099,7 +1099,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1183,9 +1183,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jni"
@@ -1262,9 +1262,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
@@ -1584,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "pathdiff"
@@ -1713,11 +1713,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2151,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "a024a432ae760ab3bff924ad91ce1cfa52cb57ed16e1ef32d0d249cfee1a6c13"
 dependencies = [
  "log",
  "ring",
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "safemem"
@@ -2308,7 +2308,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -2320,7 +2320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -2406,13 +2406,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2629,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2643,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2791,6 +2791,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "unicode-normalization"
@@ -2983,7 +2989,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower-service",
  "tracing",
 ]

--- a/analysis/src/bin/analysis-driver.rs
+++ b/analysis/src/bin/analysis-driver.rs
@@ -36,7 +36,7 @@ struct OurCompilerCalls {
     args: Vec<String>,
 }
 
-fn get_attributes<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: DefId) -> &[rustc_ast::ast::Attribute] {
+fn get_attributes(tcx: ty::TyCtxt<'_>, def_id: DefId) -> &[rustc_ast::ast::Attribute] {
     if let Some(local_def_id) = def_id.as_local() {
         tcx.hir()
             .attrs(tcx.hir().local_def_id_to_hir_id(local_def_id))

--- a/analysis/src/bin/analysis-driver.rs
+++ b/analysis/src/bin/analysis-driver.rs
@@ -36,32 +36,43 @@ struct OurCompilerCalls {
     args: Vec<String>,
 }
 
+fn get_attributes<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: DefId) -> &[rustc_ast::ast::Attribute] {
+    if let Some(local_def_id) = def_id.as_local() {
+        tcx.hir()
+            .attrs(tcx.hir().local_def_id_to_hir_id(local_def_id))
+    } else {
+        tcx.item_attrs(def_id)
+    }
+}
+
 fn get_attribute<'tcx>(
     tcx: ty::TyCtxt<'tcx>,
     def_id: DefId,
     segment1: &str,
     segment2: &str,
 ) -> Option<&'tcx Attribute> {
-    tcx.get_attrs(def_id).iter().find(|attr| match &attr.kind {
-        ast::AttrKind::Normal(
-            ast::AttrItem {
-                path:
-                    ast::Path {
-                        span: _,
-                        segments,
-                        tokens: _,
-                    },
-                args: ast::MacArgs::Empty,
-                tokens: _,
-            },
-            _,
-        ) => {
-            segments.len() == 2
-                && segments[0].ident.as_str() == segment1
-                && segments[1].ident.as_str() == segment2
-        }
-        _ => false,
-    })
+    get_attributes(tcx, def_id)
+        .iter()
+        .find(|attr| match &attr.kind {
+            ast::AttrKind::Normal(
+                ast::AttrItem {
+                    path:
+                        ast::Path {
+                            span: _,
+                            segments,
+                            tokens: _,
+                        },
+                    args: ast::MacArgs::Empty,
+                    tokens: _,
+                },
+                _,
+            ) => {
+                segments.len() == 2
+                    && segments[0].ident.as_str() == segment1
+                    && segments[1].ident.as_str() == segment2
+            }
+            _ => false,
+        })
 }
 
 mod mir_storage {

--- a/prusti-common/src/vir/fixes/ghost_vars.rs
+++ b/prusti-common/src/vir/fixes/ghost_vars.rs
@@ -46,9 +46,8 @@ struct GhostVarFixer {
 
 impl GhostVarFixer {
     fn fix_name(&self, mut local_var: ast::LocalVar) -> ast::LocalVar {
-        local_var
-            .name
-            .push_str(&format!("$p{}", self.package_stmt_count));
+        use std::fmt::Write;
+        write!(local_var.name, "$p{}", self.package_stmt_count).unwrap();
         local_var
     }
 }

--- a/prusti-interface/src/environment/collect_prusti_spec_visitor.rs
+++ b/prusti-interface/src/environment/collect_prusti_spec_visitor.rs
@@ -37,7 +37,7 @@ impl<'a, 'tcx> CollectPrustiSpecVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx> ItemLikeVisitor<'tcx> for CollectPrustiSpecVisitor<'a, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
-        let attrs = self.tcx.get_attrs(item.def_id.to_def_id());
+        let attrs = self.env.get_local_attributes(item.def_id);
         if has_spec_only_attr(attrs) || has_extern_spec_attr(attrs) {
             return;
         }
@@ -50,7 +50,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for CollectPrustiSpecVisitor<'a, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, trait_item: &hir::TraitItem) {
-        let attrs = self.tcx.get_attrs(trait_item.def_id.to_def_id());
+        let attrs = self.env.get_local_attributes(trait_item.def_id);
         if has_spec_only_attr(attrs) || has_extern_spec_attr(attrs) {
             return;
         }
@@ -73,7 +73,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for CollectPrustiSpecVisitor<'a, 'tcx> {
     }
 
     fn visit_impl_item(&mut self, impl_item: &hir::ImplItem) {
-        let attrs = self.tcx.get_attrs(impl_item.def_id.to_def_id());
+        let attrs = self.env.get_local_attributes(impl_item.def_id);
         if has_spec_only_attr(attrs) || has_extern_spec_attr(attrs) {
             return;
         }

--- a/prusti-interface/src/environment/mir_sets/local_set.rs
+++ b/prusti-interface/src/environment/mir_sets/local_set.rs
@@ -33,7 +33,7 @@ impl LocalSet {
     }
 }
 
-impl<'tcx> From<FxHashSet<mir::Local>> for LocalSet {
+impl From<FxHashSet<mir::Local>> for LocalSet {
     fn from(locals: FxHashSet<mir::Local>) -> Self {
         Self { locals }
     }

--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -195,7 +195,7 @@ fn build_reachable_basic_blocks(mir: &Mir, real_edges: &RealEdges) -> HashSet<Ba
 }
 
 fn is_spec_closure(def_id: def_id::DefId, tcx: &TyCtxt) -> bool {
-    crate::utils::has_spec_only_attr(tcx.get_attrs(def_id))
+    crate::utils::has_spec_only_attr(crate::utils::get_attributes(*tcx, def_id))
 }
 
 pub fn is_marked_specification_block(bb_data: &BasicBlockData, tcx: &TyCtxt) -> bool {
@@ -212,7 +212,7 @@ pub fn is_marked_specification_block(bb_data: &BasicBlockData, tcx: &TyCtxt) -> 
 pub fn get_loop_invariant<'tcx>(bb_data: &BasicBlockData<'tcx>, tcx: TyCtxt<'tcx>) -> Option<(ProcedureDefId, rustc_middle::ty::subst::SubstsRef<'tcx>)> {
     for stmt in &bb_data.statements {
         if let StatementKind::Assign(box (_, Rvalue::Aggregate(box AggregateKind::Closure(def_id, substs), _))) = &stmt.kind {
-            if is_spec_closure(*def_id, &tcx) && crate::utils::has_prusti_attr(tcx.get_attrs(*def_id), "loop_body_invariant_spec") {
+            if is_spec_closure(*def_id, &tcx) && crate::utils::has_prusti_attr(crate::utils::get_attributes(tcx, *def_id), "loop_body_invariant_spec") {
                 return Some((*def_id, substs))
             }
         }

--- a/prusti-interface/src/specs/checker/predicate_checks.rs
+++ b/prusti-interface/src/specs/checker/predicate_checks.rs
@@ -115,7 +115,7 @@ impl<'tcx> intravisit::Visitor<'tcx> for CollectPredicatesVisitor<'tcx> {
 
     fn visit_trait_item(&mut self, ti: &'tcx hir::TraitItem<'tcx>) {
         let def_id = ti.def_id.to_def_id();
-        let attrs = self.tcx.get_attrs(def_id);
+        let attrs = crate::utils::get_local_attributes(self.tcx, ti.def_id);
 
         if has_abstract_predicate_attr(attrs) {
             let span = self.tcx.def_span(def_id);

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -238,7 +238,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for SpecCollector<'a, 'tcx> {
         let id = ti.hir_id();
         let local_id = self.tcx.hir().local_def_id(id);
         let def_id = local_id.to_def_id();
-        let attrs = self.tcx.get_attrs(ti.def_id.to_def_id());
+        let attrs = self.env.get_local_attributes(ti.def_id);
 
         // Collect procedure specifications
         if let Some(procedure_spec_ref) = get_procedure_spec_ids(def_id, attrs) {

--- a/prusti-interface/src/specs/typed.rs
+++ b/prusti-interface/src/specs/typed.rs
@@ -258,7 +258,7 @@ impl SpecGraph<ProcedureSpecification> {
         spec: LocalDefId,
         env: &Environment<'tcx>,
     ) -> Option<SpecConstraintKind> {
-        let attrs = env.tcx().get_attrs(spec.to_def_id());
+        let attrs = env.get_local_attributes(spec);
         if has_trait_bounds_ghost_constraint(attrs) {
             return Some(SpecConstraintKind::ResolveGenericParamTraitBounds);
         }

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -9,11 +9,11 @@
 use log::trace;
 use rustc_ast::ast;
 use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::{
     mir,
     ty::{self, TyCtxt},
 };
-
 use prusti_utils::force_matches;
 
 /// Check if the place `potential_prefix` is a prefix of `place`. For example:
@@ -271,6 +271,18 @@ impl<'tcx> VecPlace<'tcx> {
     }
 }
 
+pub fn get_local_attributes<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: LocalDefId) -> &[rustc_ast::ast::Attribute] {
+    tcx.hir().attrs(tcx.hir().local_def_id_to_hir_id(def_id))
+}
+
+pub fn get_attributes<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: DefId) -> &[rustc_ast::ast::Attribute] {
+    if let Some(local_def_id) = def_id.as_local() {
+        get_local_attributes(tcx, local_def_id)
+    } else {
+        tcx.item_attrs(def_id)
+    }
+}
+
 /// Check if `prusti::<name>` is among the attributes.
 /// Any arguments of the attribute are ignored.
 pub fn has_prusti_attr(attrs: &[ast::Attribute], name: &str) -> bool {
@@ -338,7 +350,7 @@ pub fn read_prusti_attrs(attr_name: &str, attrs: &[ast::Attribute]) -> Vec<Strin
                         segments,
                         tokens: _,
                     },
-                args: ast::MacArgs::Eq(_, token),
+                args: ast::MacArgs::Eq(_, ast::MacArgsEq::Hir(ast::Lit {token, ..})),
                 tokens: _,
             },
             _,
@@ -351,12 +363,8 @@ pub fn read_prusti_attrs(attr_name: &str, attrs: &[ast::Attribute]) -> Vec<Strin
             {
                 continue;
             }
-            use rustc_ast::token::{Lit, Token, TokenKind};
-            fn extract_string(token: &Token) -> String {
-                force_matches!(&token.kind, TokenKind::Literal(Lit { symbol, .. }) => {
-                        symbol.as_str().replace("\\\"", "\"")
-                    }
-                )
+            fn extract_string(token: &rustc_ast::token::Lit) -> String {
+                token.symbol.as_str().replace("\\\"", "\"")
             }
             strings.push(extract_string(token));
         };

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -271,11 +271,11 @@ impl<'tcx> VecPlace<'tcx> {
     }
 }
 
-pub fn get_local_attributes<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: LocalDefId) -> &[rustc_ast::ast::Attribute] {
+pub fn get_local_attributes(tcx: ty::TyCtxt<'_>, def_id: LocalDefId) -> &[rustc_ast::ast::Attribute] {
     tcx.hir().attrs(tcx.hir().local_def_id_to_hir_id(def_id))
 }
 
-pub fn get_attributes<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: DefId) -> &[rustc_ast::ast::Attribute] {
+pub fn get_attributes(tcx: ty::TyCtxt<'_>, def_id: DefId) -> &[rustc_ast::ast::Attribute] {
     if let Some(local_def_id) = def_id.as_local() {
         get_local_attributes(tcx, local_def_id)
     } else {

--- a/prusti-viper/src/encoder/mir/contracts/interface.rs
+++ b/prusti-viper/src/encoder/mir/contracts/interface.rs
@@ -136,11 +136,8 @@ fn get_procedure_contract<'p, 'v: 'p, 'tcx: 'v>(
     if !tcx.is_closure(proc_def_id) {
         // FIXME: "skip_binder" is most likely wrong
         // FIXME: Replace with FakeMirEncoder.
-        let fn_sig: FnSig = env
-            .tcx()
-            .fn_sig(proc_def_id)
-            .skip_binder()
-            .subst(env.tcx(), substs);
+        let fn_sig: FnSig =
+            ty::EarlyBinder(env.tcx().fn_sig(proc_def_id).skip_binder()).subst(env.tcx(), substs);
         if fn_sig.c_variadic {
             return Err(EncodingError::unsupported(
                 "variadic functions are not supported",

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -426,7 +426,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
             // compose substitutions
             // TODO(tymap): do we need this?
             use crate::rustc_middle::ty::subst::Subst;
-            let substs = call_substs.subst(self.encoder.env().tcx(), self.substs);
+            let substs = ty::EarlyBinder(*call_substs).subst(self.encoder.env().tcx(), self.substs);
 
             let state = if let Some((lhs_place, target_block)) = destination {
                 let encoded_lhs = self.encode_place(*lhs_place).with_span(span)?;

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -102,10 +102,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
 
         // TODO: move this to a signatures module
         use crate::rustc_middle::ty::subst::Subst;
-        let sig = encoder
-            .env()
-            .tcx()
-            .fn_sig(proc_def_id)
+        let sig = ty::EarlyBinder(encoder.env().tcx().fn_sig(proc_def_id))
             .subst(encoder.env().tcx(), substs);
         let sig = encoder
             .env()

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -172,10 +172,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
 
         // TODO: move this to a signatures module
         use crate::rustc_middle::ty::subst::Subst;
-        let sig = encoder
-            .env()
-            .tcx()
-            .fn_sig(proc_def_id)
+        let sig = ty::EarlyBinder(encoder.env().tcx().fn_sig(proc_def_id))
             .subst(encoder.env().tcx(), substs);
         let sig = encoder
             .env()

--- a/prusti-viper/src/encoder/mir/specifications/constraints.rs
+++ b/prusti-viper/src/encoder/mir/specifications/constraints.rs
@@ -187,7 +187,7 @@ pub mod trait_bounds {
         let maybe_trait_method = env.find_trait_method_substs(context.proc_def_id, context.substs);
         let param_env = if let Some((_, trait_substs)) = maybe_trait_method {
             trace!("Applying trait substs {:?}", trait_substs);
-            param_env.subst(env.tcx(), trait_substs)
+            ty::EarlyBinder(param_env).subst(env.tcx(), trait_substs)
         } else {
             param_env
         };
@@ -201,7 +201,7 @@ pub mod trait_bounds {
             param_env
         } else {
             trace!("Applying call substs {:?}", context.substs);
-            param_env.subst(env.tcx(), context.substs)
+            ty::EarlyBinder(param_env).subst(env.tcx(), context.substs)
         };
 
         trace!(
@@ -231,7 +231,7 @@ pub mod trait_bounds {
         for spec_id in pres.iter().chain(posts.iter()) {
             let param_env = env.tcx().param_env(spec_id.to_def_id());
             let spec_span = env.tcx().def_span(spec_id.to_def_id());
-            let attrs = env.tcx().get_attrs(spec_id.to_def_id());
+            let attrs = env.get_local_attributes(*spec_id);
             if has_trait_bounds_ghost_constraint(attrs) {
                 param_envs
                     .entry(param_env)

--- a/prusti-viper/src/encoder/mir/specifications/interface.rs
+++ b/prusti-viper/src/encoder/mir/specifications/interface.rs
@@ -209,7 +209,7 @@ impl<'v, 'tcx: 'v> SpecificationsInterface<'tcx> for super::super::super::Encode
     }
 
     fn is_spec_closure(&self, def_id: DefId) -> bool {
-        has_spec_only_attr(self.env().tcx().get_attrs(def_id))
+        has_spec_only_attr(self.env().get_attributes(def_id))
     }
 
     fn get_spec_span(&self, def_id: DefId) -> Span {

--- a/prusti-viper/src/lib.rs
+++ b/prusti-viper/src/lib.rs
@@ -7,7 +7,6 @@
 #![feature(rustc_private)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
-#![feature(bool_to_option)]
 #![feature(try_blocks)]
 #![feature(never_type)]
 #![feature(btree_drain_filter)]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-05-01"
+channel = "nightly-2022-05-16"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-std", "rustfmt" ]
 profile = "minimal"


### PR DESCRIPTION
* [x] Update Viper version to `v.22.04.17-release`.
* [x] Update rustc version to `nightly-2022-05-15`.
* [x] Manualy update outdated dependencies (see the list below).
* [x] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ cargo outdated --root-deps-only --workspace

info: syncing channel updates for 'nightly-2022-05-15-x86_64-unknown-linux-gnu'
info: latest update on 2022-05-15, rust version 1.62.0-nightly (70b3681bf 2022-05-14)
info: downloading component 'cargo'
info: downloading component 'llvm-tools-preview'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustc-dev'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'llvm-tools-preview'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustc-dev'
info: installing component 'rustfmt'
    Updating git repository `https://github.com/rust-lang/cargo.git`
analysis
================
Name        Project  Compat  Latest   Kind    Platform
----        -------  ------  ------   ----    --------
log         0.4.16   ---     0.4.17   Normal  ---
serde       1.0.136  ---     1.0.137  Normal  ---
serde_json  1.0.79   ---     1.0.81   Normal  ---
syn         1.0.91   ---     1.0.94   Normal  ---

prusti
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.16   ---     0.4.17  Normal  ---

prusti-common
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
log    0.4.16   ---     0.4.17   Normal  ---
serde  1.0.136  ---     1.0.137  Normal  ---
uuid   0.8.2    ---     1.0.0    Normal  ---

viper
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
log    0.4.16   ---     0.4.17   Normal  ---
serde  1.0.136  ---     1.0.137  Normal  ---
uuid   0.8.2    ---     1.0.0    Normal  ---

viper-sys
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.16   ---     0.4.17  Normal  ---

jni-gen
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
log   0.4.16   ---     0.4.17  Normal  ---

vir
================
Name         Project  Compat  Latest   Kind    Platform
----         -------  ------  ------   ----    --------
log          0.4.16   ---     0.4.17   Normal  ---
proc-macro2  1.0.37   ---     1.0.38   Normal  ---
serde        1.0.136  ---     1.0.137  Normal  ---
syn          1.0.91   ---     1.0.94   Normal  ---
thiserror    1.0.30   ---     1.0.31   Normal  ---
uuid         0.8.2    ---     1.0.0    Normal  ---

vir-gen
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.37   ---     1.0.38  Normal  ---
syn          1.0.91   ---     1.0.94  Normal  ---

prusti-contracts
================
Name      Project  Compat  Latest  Kind         Platform
----      -------  ------  ------  ----         --------
trybuild  1.0.59   ---     1.0.61  Development  ---

prusti-contracts-internal
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.37   ---     1.0.38  Normal  ---

prusti-specs
================
Name         Project  Compat  Latest   Kind    Platform
----         -------  ------  ------   ----    --------
proc-macro2  1.0.37   ---     1.0.38   Normal  ---
serde        1.0.136  ---     1.0.137  Normal  ---
serde_json   1.0.79   ---     1.0.81   Normal  ---
syn          1.0.91   ---     1.0.94   Normal  ---
uuid         0.8.2    ---     1.0.0    Normal  ---

prusti-interface
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
log    0.4.16   ---     0.4.17   Normal  ---
serde  1.0.136  ---     1.0.137  Normal  ---

prusti-viper
================
Name        Project  Compat  Latest   Kind    Platform
----        -------  ------  ------   ----    --------
backtrace   0.3.64   ---     0.3.65   Normal  ---
log         0.4.16   ---     0.4.17   Normal  ---
num-traits  0.2.14   ---     0.2.15   Normal  ---
serde       1.0.136  ---     1.0.137  Normal  ---

prusti-server
================
Name     Project  Compat  Latest   Kind    Platform
----     -------  ------  ------   ----    --------
clap     3.1.8    ---     3.1.18   Normal  ---
log      0.4.16   ---     0.4.17   Normal  ---
reqwest  0.10.10  ---     0.11.10  Normal  ---
serde    1.0.136  ---     1.0.137  Normal  ---
tokio    0.2.25   ---     1.18.2   Normal  ---
warp     0.2.5    ---     0.3.2    Normal  ---

prusti-launch
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
ctrlc  3.2.1    ---     3.2.2    Normal  ---
nix    0.23.1   ---     0.24.1   Normal  cfg(unix)
serde  1.0.136  ---     1.0.137  Normal  ---

test-crates
================
Name   Project  Compat  Latest   Kind    Platform
----   -------  ------  ------   ----    --------
clap   3.1.8    ---     3.1.18   Normal  ---
log    0.4.16   ---     0.4.17   Normal  ---
serde  1.0.136  ---     1.0.137  Normal  ---
```
</details>

@vakaras could you take care of this?