### PR TITLE
Disable squash merge

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,2 @@
 status = ["test-crates", "clippy-check", "fmt-check", "purification-tests", "all-tests (ubuntu-latest)", "all-tests (windows-latest)", "all-tests (macos-latest)"]
 timeout_sec = 21600
-use_squash_merge = true


### PR DESCRIPTION
Disable the squash merge in bors, because it's annoying to see the merged PRs as "closed".