### PR TITLE
Fix for #1006 and other minor changes

### DIFF
--- a/prusti-common/src/config.rs
+++ b/prusti-common/src/config.rs
@@ -105,6 +105,7 @@ lazy_static! {
         settings.set_default("unsafe_core_proof", false).unwrap();
         settings.set_default("only_memory_safety", false).unwrap();
         settings.set_default("enable_type_invariants", false).unwrap();
+        settings.set_default("use_new_encoder", true).unwrap();
 
         settings.set_default("print_desugared_specs", false).unwrap();
         settings.set_default("print_typeckd_specs", false).unwrap();
@@ -551,6 +552,18 @@ pub fn unsafe_core_proof() -> bool {
 /// **Note:** This should be used only when `UNSAFE_CORE_PROOF` is enabled.
 pub fn only_memory_safety() -> bool {
     read_setting("only_memory_safety")
+}
+
+/// When enabled, Prusti uses the new VIR encoder.
+///
+/// This is a temporary configuration flag.
+/// The new VIR encoder is still a work in progress,
+/// once finished this will become the only encoder.
+///
+/// If you run into `todo!()` or `unreachable!()`,
+/// then setting this flag to `false` may help.
+pub fn use_new_encoder() -> bool {
+    read_setting("use_new_encoder")
 }
 
 /// The given basic blocks will be replaced with `assume false`.

--- a/prusti-server/src/process_verification.rs
+++ b/prusti-server/src/process_verification.rs
@@ -8,7 +8,7 @@ use crate::{VerificationRequest, ViperBackendConfig};
 use log::info;
 use prusti_common::{config, report::log::report, vir::ToViper, Stopwatch};
 use std::{fs::create_dir_all, path::PathBuf};
-use viper::{Cache, VerificationBackend, VerificationContext};
+use viper::{Cache, VerificationBackend, VerificationContext, VerificationResult};
 
 pub fn process_verification_request<'v, 't: 'v>(
     verification_context: &'v VerificationContext<'t>,
@@ -18,7 +18,11 @@ pub fn process_verification_request<'v, 't: 'v>(
     let ast_utils = verification_context.new_ast_utils();
 
     let hash = request.get_hash();
-    info!("Verification request hash: {}", hash);
+    info!(
+        "Verification request hash: {} - for program {}",
+        hash,
+        request.program.get_name()
+    );
 
     let build_or_dump_viper_program = || {
         let mut stopwatch = Stopwatch::start("prusti-server", "construction of JVM objects");
@@ -52,6 +56,13 @@ pub fn process_verification_request<'v, 't: 'v>(
     // Early return in case of cache hit
     if config::enable_cache() {
         if let Some(result) = cache.get(hash) {
+            if result != VerificationResult::Success {
+                info!(
+                    "cached result {:?} for program {}",
+                    &result,
+                    request.program.get_name()
+                );
+            }
             if config::dump_viper_program() {
                 ast_utils.with_local_frame(16, || {
                     let _ = build_or_dump_viper_program();
@@ -73,6 +84,13 @@ pub fn process_verification_request<'v, 't: 'v>(
         let result = verifier.verify(viper_program);
 
         if config::enable_cache() {
+            if result != VerificationResult::Success {
+                info!(
+                    "storing new cached result {:?} for program {}",
+                    &result,
+                    request.program.get_name()
+                );
+            }
             cache.insert(hash, result.clone());
         }
 

--- a/prusti-tests/tests/verify/pass/issues/issue-1006.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-1006.rs
@@ -1,0 +1,39 @@
+// ignore-test: new encoder seems to break on this test
+use prusti_contracts::*;
+
+fn main() {}
+
+#[derive(Copy, Clone)]
+pub struct A {
+    inner: usize,
+}
+
+impl A {
+    #[pure]
+    pub const fn get(&self) -> usize {
+        self.inner
+    }
+}
+
+pub struct B {
+    a: A,
+}
+
+impl B {
+    #[pure]
+    #[trusted]
+    pub fn foo(&self, a: usize, b: usize) -> &[u8] {
+        unimplemented!()
+    }
+
+    #[pure]
+    #[ensures(result == self.foo(a.get(), b))]
+    pub fn bar(&self, a: A, b: usize) -> &[u8] {
+        self.foo(a.get(), b)
+    }
+
+    #[pure]
+    pub fn baz(&self) -> &[u8] {
+        self.bar(self.a, 1)
+    }
+}

--- a/prusti-tests/tests/verify/pass/issues/issue-1006.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-1006.rs
@@ -1,4 +1,5 @@
-// ignore-test: new encoder seems to break on this test
+// FIXME: remove this compile flag when the new encoder is finished
+// compile-flags: -Puse_new_encoder=false
 use prusti_contracts::*;
 
 fn main() {}

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-729-1.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-729-1.rs
@@ -1,4 +1,5 @@
-// ignore-test
+// FIXME: remove this compile flag when the new encoder is finished
+// compile-flags: -Puse_new_encoder=false
 
 // error-pattern: Precondition of function snap$__$TY$__Snap$struct$m_A$ might not hold
 // FIXME: https://github.com/viperproject/prusti-dev/issues/729

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -8,6 +8,7 @@ use crate::encoder::{
     stub_function_encoder::StubFunctionEncoder,
 };
 use log::{debug, trace};
+use prusti_common::config;
 use prusti_interface::data::ProcedureDefId;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_middle::ty::subst::SubstsRef;
@@ -292,13 +293,15 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                         }
                         ProcedureSpecificationKind::Pure => {
                             let function = pure_function_encoder.encode_function()?;
-                            // Test the new encoding.
-                            let _ = super::new_encoder::encode_function_decl(
-                                self,
-                                proc_def_id,
-                                proc_def_id,
-                                substs,
-                            )?;
+                            if config::use_new_encoder() {
+                                // Test the new encoding.
+                                let _ = super::new_encoder::encode_function_decl(
+                                    self,
+                                    proc_def_id,
+                                    proc_def_id,
+                                    substs,
+                                )?;
+                            }
                             function
                         }
                         ProcedureSpecificationKind::Impure => {

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -82,15 +82,16 @@ pub(super) fn inline_spec_item<'tcx>(
         let local_span = mir_encoder.get_local_span(arg_local);
         let local = mir_encoder.encode_local(arg_local).unwrap();
         let local_ty = mir.local_decls[arg_local].ty;
+        let is_return_arg = target_return.is_some() && arg_idx == mir.arg_count - 1;
         body_replacements.push((
-            if targets_are_values {
+            if targets_are_values && !is_return_arg {
                 encoder
                     .encode_value_expr(vir_crate::polymorphic::Expr::local(local), local_ty)
                     .with_span(local_span)?
             } else {
                 vir_crate::polymorphic::Expr::local(local)
             },
-            if target_return.is_some() && arg_idx == mir.arg_count - 1 {
+            if is_return_arg {
                 target_return.unwrap().clone()
             } else {
                 target_args[arg_idx].clone()


### PR DESCRIPTION
This PR contains a few changes:

1. A fix in `prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs` for the bug from #1006 plus a regression test.
2. A new configuration flag `use_new_encoder` which toggles the testing of the new encoder in `prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs`. This flag is enabled by default and is currently selectively disabled for two tests: `issue-1006.rs` and `issue-729-1.rs`.
3. Some additional info logging in `prusti-server/src/process_verification.rs`. This gives some extra feedback during the verification process when the log level is `INFO`. This is handy for large code bases. In my case I have a project with over 300 functions to verify which can take a long time if large parts of the cache get invalidated. This way, it's possible to see the verification results come in in real-time, without having to wait until the entire verification finishes.