### PR TITLE
Bugfix before expiry

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/magic-wands/before_expiry.rs
+++ b/prusti-tests/tests/verify_overflow/pass/magic-wands/before_expiry.rs
@@ -1,0 +1,16 @@
+use prusti_contracts::*;
+
+#[pure]
+#[trusted]
+// TODO: add spec for `std::ptr::eq`
+#[ensures(result == true)]
+fn ptr_eq<T>(l: &T, r: &T) -> bool { std::ptr::eq(l, r) }
+
+#[after_expiry(
+    ptr_eq(t, before_expiry(result))
+)]
+fn identity<T>(t: &mut T) -> &mut T {
+    t
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -431,9 +431,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                             "prusti_contracts::before_expiry" => {
                                 trace!("Encoding before_expiry expression {:?}", args[0]);
                                 assert_eq!(args.len(), 1);
-                                let encoded_rhs = self
-                                    .mir_encoder
-                                    .encode_old_expr(vir::Expr::snap_app(encoded_args[0].clone()), WAND_LHS_LABEL);
+                                let encoded_rhs = self.mir_encoder.encode_old_expr(
+                                    vir::Expr::snap_app(encoded_args[0].clone()),
+                                    WAND_LHS_LABEL,
+                                );
                                 let mut state = states[target_block].clone();
                                 state.substitute_value(&encoded_lhs, encoded_rhs);
                                 state

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interpreter.rs
@@ -433,7 +433,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 assert_eq!(args.len(), 1);
                                 let encoded_rhs = self
                                     .mir_encoder
-                                    .encode_old_expr(encoded_args[0].clone(), WAND_LHS_LABEL);
+                                    .encode_old_expr(vir::Expr::snap_app(encoded_args[0].clone()), WAND_LHS_LABEL);
                                 let mut state = states[target_block].clone();
                                 state.substitute_value(&encoded_lhs, encoded_rhs);
                                 state


### PR DESCRIPTION
See the test case for instance where it the bug would manifest. With current master one would get:
`Details: cannot generate fold-unfold Viper statements. The required permission Pred(old[l2](_0.val_ref).val_ref, read) cannot be obtained.`
This is because it essentially tries to deref twice.