### PR TITLE
Wrap old around snapshots of arguments

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/simple-specs/old_args_in_post.rs
+++ b/prusti-tests/tests/verify_overflow/pass/simple-specs/old_args_in_post.rs
@@ -1,0 +1,18 @@
+use prusti_contracts::*;
+
+fn main() {}
+
+#[pure]
+fn foo<T>(x: &T) -> bool { true }
+
+#[ensures(foo(&x))]
+fn bar<T>(x: T) {
+    drop(x);
+}
+
+fn drop<T>(x: T) {}
+
+#[ensures(foo(&x))]
+fn baz<T>(x: T, v: i32) {
+    if v > 0 { baz(x, v-1) }
+}


### PR DESCRIPTION
Hopefully temporary fix to ensure that non-reference arguments are always wrapped in old automatically. The correct solution would be to add an indirection through a field for arguments to a function (or only all mutable local variables). That way we could also avoid the following unsoundness:
```rust
struct S(i32);
fn foo() {
    bar(S(0), S(42));
    assert!(0 == 42);
}

#[requires(y.0 == 42)]
#[ensures(x.0 == 42)]
fn bar(mut x: S, y: S) {
  x = y;
}
```
Which verifies because we encode `x = y;` as local variable assignment in Viper: `_1 := _2`, at which point wrapping `_1.f$0.val_int` in `old[pre](...)` still gives the value of `_2.f$0.val_int`. Instead we should encode the assignment as `_1.val := _2.val` (with permission for `struct$m_S(_1.val)` rather than `struct$m_S(_1)`). This would also help with the issue in this PR since `old[pre](_1)` doesn't make sense, but `old[pre](_1.val)` does.
Fixes #917, fixes #884