### PR TITLE
Do not encode invariants in contracts of pure functions

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/invariants/invariants-pure.rs
+++ b/prusti-tests/tests/verify_overflow/pass/invariants/invariants-pure.rs
@@ -1,4 +1,5 @@
 // compile-flags: -Penable_type_invariants=true
+// ignore-test Unnecessary postcondition on `double` since it's pure.
 extern crate prusti_contracts;
 use prusti_contracts::*;
 


### PR DESCRIPTION
(Mostly temporary for NFM)

Since pure functions are used to define the type invariant, assuming it holds in the precondition of a pure function leads to a circular argument. For now, invariants (or at least parts) have to be repeated explicitly for pure function contracts.