### PR TITLE
Ghost blocks

### DIFF
--- a/prusti-contracts-internal/src/lib.rs
+++ b/prusti-contracts-internal/src/lib.rs
@@ -93,5 +93,5 @@ pub fn ghost_constraint(attr: TokenStream, tokens: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn ghost(tokens: TokenStream) -> TokenStream {
-    tokens
+    prusti_specs::ghost(tokens.into()).into()
 }

--- a/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/src/lib.rs
@@ -2,6 +2,8 @@
 
 #[cfg(not(feature = "prusti"))]
 mod private {
+    use core::marker::PhantomData;
+
     /// A macro for writing a precondition on a function.
     pub use prusti_contracts_impl::requires;
 
@@ -68,7 +70,15 @@ mod private {
     #[non_exhaustive]
     #[derive(PartialEq, Eq, Copy, Clone)]
     pub struct Seq<T> {
-        _phantom: core::marker::PhantomData<T>,
+        _phantom: PhantomData<T>,
+    }
+
+    /// A map type
+    #[non_exhaustive]
+    #[derive(PartialEq, Eq, Copy, Clone)]
+    pub struct Map<K, V> {
+        _key_phantom: PhantomData<K>,
+        _val_phantom: PhantomData<V>,
     }
 
     /// A macro for defining ghost blocks which will be left in for verification
@@ -78,10 +88,18 @@ mod private {
     /// a mathematical (unbounded) integer type
     /// it should not be constructed from running rust code, hence the private unit inside
     pub struct Int(());
+
+    #[non_exhaustive]
+    #[derive(PartialEq, Eq, Copy, Clone)]
+    pub struct Ghost<T> {
+        _phantom: PhantomData<T>,
+    }
 }
 
 #[cfg(feature = "prusti")]
 mod private {
+    use core::{marker::PhantomData, ops::*};
+
     /// A macro for writing a precondition on a function.
     pub use prusti_contracts_internal::requires;
 
@@ -136,8 +154,6 @@ mod private {
         unreachable!();
     }
 
-    use core::ops::*;
-
     /// a mathematical (unbounded) integer type
     /// it should not be constructed from running rust code, hence the private unit inside
     #[derive(Copy, Clone, PartialEq, Eq)]
@@ -184,7 +200,7 @@ mod private {
     #[non_exhaustive]
     #[derive(PartialEq, Eq, Copy, Clone)]
     pub struct Seq<T: Copy> {
-        _phantom: core::marker::PhantomData<T>,
+        _phantom: PhantomData<T>,
     }
 
     impl<T: Copy> Seq<T> {
@@ -236,8 +252,8 @@ mod private {
     #[non_exhaustive]
     #[derive(PartialEq, Eq, Copy, Clone)]
     pub struct Map<K, V> {
-        _key_phantom: core::marker::PhantomData<K>,
-        _val_phantom: core::marker::PhantomData<V>,
+        _key_phantom: PhantomData<K>,
+        _val_phantom: PhantomData<V>,
     }
 
     impl<K, V> Map<K, V> {
@@ -277,6 +293,31 @@ mod private {
     impl<K, V> core::ops::Index<K> for Map<K, V> {
         type Output = V;
         fn index(&self, _key: K) -> &V {
+            panic!()
+        }
+    }
+
+    #[non_exhaustive]
+    #[derive(PartialEq, Eq, Copy, Clone)]
+    pub struct Ghost<T> {
+        _phantom: PhantomData<T>,
+    }
+
+    impl<T> Ghost<T> {
+        pub fn new(_: T) -> Self {
+            panic!()
+        }
+    }
+
+    impl<T> Deref for Ghost<T> {
+        type Target = T;
+        fn deref(&self) -> &T {
+            panic!()
+        }
+    }
+
+    impl<T> DerefMut for Ghost<T> {
+        fn deref_mut(&mut self) -> &mut T {
             panic!()
         }
     }

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -42,7 +42,7 @@ use self::collect_prusti_spec_visitor::CollectPrustiSpecVisitor;
 use self::collect_closure_defs_visitor::CollectClosureDefsVisitor;
 pub use self::loops::{PlaceAccess, PlaceAccessKind, ProcedureLoops};
 pub use self::loops_utils::*;
-pub use self::procedure::{BasicBlockIndex, Procedure, is_marked_specification_block, is_loop_invariant_block, get_loop_invariant};
+pub use self::procedure::{BasicBlockIndex, Procedure, is_marked_specification_block, is_loop_invariant_block, get_loop_invariant, is_ghost_begin_marker, is_ghost_end_marker};
 use self::borrowck::facts::BorrowckFacts;
 use crate::data::ProcedureDefId;
 use prusti_rustc_interface::span::source_map::SourceMap;

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -60,6 +60,8 @@ pub struct SpecCollector<'a, 'tcx: 'a> {
     type_specs: HashMap<LocalDefId, TypeSpecRefs>,
     prusti_assertions: Vec<LocalDefId>,
     prusti_assumptions: Vec<LocalDefId>,
+    ghost_begin: Vec<LocalDefId>,
+    ghost_end: Vec<LocalDefId>,
 }
 
 impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
@@ -75,6 +77,8 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
             type_specs: HashMap::new(),
             prusti_assertions: vec![],
             prusti_assumptions: vec![],
+            ghost_begin: vec![],
+            ghost_end: vec![],
         }
     }
 
@@ -86,6 +90,7 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
         self.determine_type_specs(&mut def_spec);
         self.determine_prusti_assertions(&mut def_spec);
         self.determine_prusti_assumptions(&mut def_spec);
+        self.determine_ghost_begin_ends(&mut def_spec);
         // TODO: remove spec functions (make sure none are duplicated or left over)
 
         def_spec
@@ -233,6 +238,19 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
                     assumption: *local_id,
                 },
             );
+        }
+    }
+    fn determine_ghost_begin_ends(&self, def_spec: &mut typed::DefSpecificationMap) {
+        for local_id in self.ghost_begin.iter() {
+            def_spec.ghost_begin.insert(
+                local_id.to_def_id(),
+                typed::GhostBegin { marker: *local_id },
+            );
+        }
+        for local_id in self.ghost_end.iter() {
+            def_spec
+                .ghost_end
+                .insert(local_id.to_def_id(), typed::GhostEnd { marker: *local_id });
         }
     }
 }
@@ -384,6 +402,14 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for SpecCollector<'a, 'tcx> {
 
             if has_prusti_attr(attrs, "prusti_assumption") {
                 self.prusti_assumptions.push(local_id);
+            }
+
+            if has_prusti_attr(attrs, "ghost_begin") {
+                self.ghost_begin.push(local_id);
+            }
+
+            if has_prusti_attr(attrs, "ghost_end") {
+                self.ghost_end.push(local_id);
             }
         } else {
             // Don't collect specs "for" spec items

--- a/prusti-interface/src/specs/typed.rs
+++ b/prusti-interface/src/specs/typed.rs
@@ -18,6 +18,8 @@ pub struct DefSpecificationMap {
     pub type_specs: HashMap<DefId, TypeSpecification>,
     pub prusti_assertions: HashMap<DefId, PrustiAssertion>,
     pub prusti_assumptions: HashMap<DefId, PrustiAssumption>,
+    pub ghost_begin: HashMap<DefId, GhostBegin>,
+    pub ghost_end: HashMap<DefId, GhostEnd>,
 }
 
 impl DefSpecificationMap {
@@ -43,6 +45,14 @@ impl DefSpecificationMap {
 
     pub fn get_assumption(&self, def_id: &DefId) -> Option<&PrustiAssumption> {
         self.prusti_assumptions.get(def_id)
+    }
+
+    pub fn get_ghost_begin(&self, def_id: &DefId) -> Option<&GhostBegin> {
+        self.ghost_begin.get(def_id)
+    }
+
+    pub fn get_ghost_end(&self, def_id: &DefId) -> Option<&GhostEnd> {
+        self.ghost_end.get(def_id)
     }
 }
 
@@ -124,6 +134,16 @@ pub struct PrustiAssertion {
 #[derive(Debug, Clone)]
 pub struct PrustiAssumption {
     pub assumption: LocalDefId,
+}
+
+#[derive(Debug, Clone)]
+pub struct GhostBegin {
+    pub marker: LocalDefId,
+}
+
+#[derive(Debug, Clone)]
+pub struct GhostEnd {
+    pub marker: LocalDefId,
 }
 
 /// The base container to store a contract of a procedure.

--- a/prusti-specs/Cargo.toml
+++ b/prusti-specs/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 doctest = false # we have no doc tests
 
 [dependencies]
-syn = { version = "1.0", features = ["full", "extra-traits", "visit-mut", "parsing", "printing"] }
+syn = { version = "1.0", features = ["full", "extra-traits", "visit", "visit-mut", "parsing", "printing"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 uuid = { version = "1.0", features = ["v4", "serde"] }

--- a/prusti-specs/src/lib.rs
+++ b/prusti-specs/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(drain_filter)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
+#![feature(proc_macro_span)]
 #![feature(if_let_guard)]
 // This Clippy chcek seems to be always wrong.
 #![allow(clippy::iter_with_drain)]
@@ -21,10 +22,10 @@ mod type_model;
 mod user_provided_type_params;
 
 use proc_macro2::{Span, TokenStream, TokenTree};
-use quote::{quote_spanned, ToTokens};
+use quote::{quote, quote_spanned, ToTokens};
 use rewriter::AstRewriter;
 use std::convert::TryInto;
-use syn::spanned::Spanned;
+use syn::{spanned::Spanned, visit::Visit};
 
 use crate::{
     common::{merge_generics, RewritableReceiver, SelfTypeRewriter},
@@ -652,5 +653,124 @@ pub fn type_model(attr: TokenStream, tokens: TokenStream) -> TokenStream {
             "Only structs can be attributed with a type model",
         )
         .to_compile_error(),
+    }
+}
+
+pub fn ghost(tokens: TokenStream) -> TokenStream {
+    let mut rewriter = rewriter::AstRewriter::new();
+    let callsite_span = Span::call_site();
+
+    let spec_id = rewriter.generate_spec_id();
+    let spec_id_str = spec_id.to_string();
+
+    let make_closure = |kind| {
+        quote! {
+            #[allow(unused_must_use, unused_variables, unused_braces, unused_parens)]
+            if false {
+                #[prusti::spec_only]
+                #[prusti::#kind]
+                #[prusti::spec_id = #spec_id_str]
+                || -> () {};
+            }
+        }
+    };
+
+    struct Visitor {
+        loops: Vec<(Option<syn::Ident>, Span)>,
+        breaks: Vec<(Option<syn::Ident>, Span)>,
+        returns: Option<Span>,
+    }
+
+    impl<'ast> Visit<'ast> for Visitor {
+        fn visit_expr_for_loop(&mut self, ex: &'ast syn::ExprForLoop) {
+            let e = ex.clone();
+            let lbl = e.label.map(|c| c.name.ident);
+            let span = e.body.brace_token.span;
+            self.loops.push((lbl, span));
+            syn::visit::visit_expr_for_loop(self, ex);
+        }
+        fn visit_expr_while(&mut self, ex: &'ast syn::ExprWhile) {
+            let e = ex.clone();
+            let lbl = e.label.map(|c| c.name.ident);
+            let span = e.body.brace_token.span;
+            self.loops.push((lbl, span));
+            syn::visit::visit_expr_while(self, ex);
+        }
+        fn visit_expr_loop(&mut self, ex: &'ast syn::ExprLoop) {
+            let e = ex.clone();
+            let lbl = e.label.map(|c| c.name.ident);
+            let span = e.body.brace_token.span;
+            self.loops.push((lbl, span));
+            syn::visit::visit_expr_loop(self, ex);
+        }
+        fn visit_expr_continue(&mut self, ex: &'ast syn::ExprContinue) {
+            let e = ex.clone();
+            let lbl = e.label.map(|c| c.ident);
+            self.breaks.push((lbl, ex.span()));
+            syn::visit::visit_expr_continue(self, ex);
+        }
+        fn visit_expr_break(&mut self, ex: &'ast syn::ExprBreak) {
+            let e = ex.clone();
+            let lbl = e.label.map(|c| c.ident);
+            self.breaks.push((lbl, ex.span()));
+            syn::visit::visit_expr_break(self, ex);
+        }
+        fn visit_expr_return(&mut self, e: &'ast syn::ExprReturn) {
+            let e = e.clone();
+            self.returns = Some(e.span());
+        }
+    }
+
+    let mut visitor = Visitor {
+        loops: vec![],
+        breaks: vec![],
+        returns: None,
+    };
+
+    let tokens = quote! {
+        {#tokens}
+    };
+
+    let input = syn::parse::<syn::Block>(tokens.clone().into()).unwrap();
+
+    visitor.visit_block(&input);
+
+    let mut exit_errors = visitor.returns.into_iter().collect::<Vec<_>>();
+
+    'breaks: for (break_label, break_span) in visitor.breaks.iter() {
+        for (loop_label, loop_span) in visitor.loops.iter() {
+            let loop_span = loop_span.unwrap();
+            let label_match = break_label == loop_label || break_label.is_none();
+            let break_inside = loop_span.join(break_span.unwrap()).unwrap().eq(&loop_span);
+            if label_match && break_inside {
+                continue 'breaks;
+            }
+        }
+        exit_errors.push(*break_span);
+    }
+
+    let begin = make_closure(quote! {ghost_begin});
+    let end = make_closure(quote! {ghost_end});
+
+    if exit_errors.is_empty() {
+        quote_spanned! {callsite_span=>
+            {
+                #begin
+                let ghost_result = Ghost::new(#tokens);
+                #end
+                ghost_result
+            }
+        }
+    } else {
+        let mut syn_errors = quote! {};
+        for error in exit_errors {
+            let error =
+                syn::Error::new(error, "Can't leave the ghost block early").to_compile_error();
+            syn_errors = quote! {
+                #syn_errors
+                #error
+            }
+        }
+        syn_errors
     }
 }

--- a/prusti-tests/tests/verify_overflow/fail/ghost/ghostblock.rs
+++ b/prusti-tests/tests/verify_overflow/fail/ghost/ghostblock.rs
@@ -1,0 +1,65 @@
+// compile-flags: -Punsafe_core_proof=true
+
+#![allow(unused)]
+
+use prusti_contracts::*;
+
+fn empty_ghost_block() {
+    ghost! {}
+}
+
+fn return_disallowed() {
+    ghost! {
+        return; //~ ERROR: Can't leave the ghost block early
+    }
+}
+
+fn break_disallowed() {
+    while true {
+        ghost! {
+            break; //~ ERROR: Can't leave the ghost block early
+        }
+    }
+}
+
+fn continue_disallowed(x: bool) {
+    while true {
+        ghost! {
+            if x {
+                continue; //~ ERROR: Can't leave the ghost block early
+            } else {
+                continue; //~ ERROR: Can't leave the ghost block early
+            }
+        }
+    }
+}
+
+fn inner_loop_breaks_allowed() {
+    ghost! {
+        while true {
+            break;
+            continue;
+        }
+    }
+}
+
+fn inner_labeled_loop_allowed() {
+    ghost! {
+        'inner: while true {
+            break;
+        }
+    }
+}
+
+fn cannot_break_outer_labeled_loop() {
+    'outer: while true {
+        ghost! {
+            while true {
+                continue 'outer; //~ ERROR: Can't leave the ghost block early
+                break;
+            }
+        }
+    }
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/fail/ghost/valid_ghosts.rs
+++ b/prusti-tests/tests/verify_overflow/fail/ghost/valid_ghosts.rs
@@ -1,0 +1,24 @@
+// compile-flags: -Punsafe_core_proof=true
+
+#![allow(unused)]
+
+use prusti_contracts::*;
+use std::ops::*;
+
+fn test1() {
+    let mut x = Ghost::new(5u32);
+    let g = ghost! {
+        x = Ghost::new(10);
+    };
+    prusti_assert!(x == Ghost::new(10));
+}
+
+fn test2() {
+    let mut x = Ghost::new(5u32);
+    let g = ghost! {
+        x = Ghost::new(10);
+    };
+    prusti_assert!(x == Ghost::new(5));     //~ ERROR: the asserted expression might not hold
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/mir/procedures/encoder/builtin_function_encoder.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/builtin_function_encoder.rs
@@ -222,6 +222,9 @@ impl<'p, 'v, 'tcx> BuiltinFuncAppEncoder<'p, 'v, 'tcx> for super::ProcedureEncod
             "prusti_contracts::Seq::<T>::lookup" => {
                 make_builtin_call(self, block_builder, vir_high::BuiltinFunc::LookupSeq)?
             }
+            "prusti_contracts::Ghost::<T>::new" => {
+                make_manual_assign(self, block_builder, &mut |_, args, _| args[0].clone())?
+            }
             "std::ops::Index::index" | "core::ops::Index::index" => {
                 let lhs = self
                     .encode_statement_operand(location, &args[0])?

--- a/prusti-viper/src/encoder/mir/procedures/encoder/ghost.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/ghost.rs
@@ -1,0 +1,124 @@
+use super::ProcedureEncoder;
+use crate::encoder::{
+    errors::{SpannedEncodingError, SpannedEncodingResult},
+    mir::specifications::SpecificationsInterface,
+};
+use prusti_rustc_interface::middle::{
+    mir::{
+        self,
+        visit::{PlaceContext, Visitor},
+    },
+    ty,
+};
+use rustc_hash::FxHashSet;
+
+impl<'p, 'v: 'p, 'tcx: 'v> super::ProcedureEncoder<'p, 'v, 'tcx> {
+    pub(super) fn encode_ghost_blocks(&mut self) -> SpannedEncodingResult<()> {
+        let ghost_blocks = self.specification_blocks.ghost_blocks();
+
+        if ghost_blocks.is_empty() {
+            return Ok(());
+        }
+
+        // Check that ghost blocks don't transfer control flow outside
+        for &bb in ghost_blocks {
+            let data = &self.mir.basic_blocks()[bb];
+            if let mir::TerminatorKind::Return = data.terminator().kind {
+                unreachable!("Control Flow reached outside the ghost block.\nThis should be prevented by the `ghost!` macro.");
+            }
+        }
+
+        let violations = GhostChecker::find_violations(self);
+        for violation in violations {
+            Err(violation)?;
+        }
+
+        Ok(())
+    }
+}
+
+struct GhostChecker<'a, 'p: 'a, 'v: 'p, 'tcx: 'v> {
+    p: &'a ProcedureEncoder<'p, 'v, 'tcx>,
+    normal_vars: FxHashSet<mir::Local>,
+    violations: Vec<SpannedEncodingError>,
+}
+
+impl<'a, 'p, 'v, 'tcx> GhostChecker<'a, 'p, 'v, 'tcx> {
+    fn is_ghost_place(&self, location: mir::Location) -> bool {
+        self.p.specification_blocks.is_ghost_block(location.block)
+    }
+    fn is_ghost_local(&self, local: &mir::Local) -> bool {
+        let ty = &self.p.mir.local_decls[*local].ty;
+        let ty_str = format!("{:?}", ty);
+
+        let ghost_tys = ["Ghost", "Int", "Seq", "Map"];
+
+        for ghost in ghost_tys {
+            if ty_str.starts_with(&format!("prusti_contracts::{ghost}")) {
+                return true;
+            }
+        }
+
+        // unit types get generated all over, and carry no information, thus okay to leak outside the ghost block
+        ty.is_unit()
+    }
+    fn find_violations(p: &ProcedureEncoder<'p, 'v, 'tcx>) -> Vec<SpannedEncodingError> {
+        let mut checker = GhostChecker {
+            p,
+            normal_vars: Default::default(),
+            violations: Default::default(),
+        };
+
+        // first visit is to find all the normal variables
+        checker.visit_body(p.mir);
+        // second visit is to find all the mutations to the normal variables within ghost code
+        checker.visit_body(p.mir);
+
+        checker.violations
+    }
+}
+
+impl<'a, 'p, 'v, 'tcx> Visitor<'tcx> for GhostChecker<'a, 'p, 'v, 'tcx> {
+    fn visit_local(&mut self, local: &mir::Local, context: PlaceContext, location: mir::Location) {
+        let is_ghost = self.is_ghost_place(location) || self.is_ghost_local(local);
+        if !is_ghost && context.is_use() {
+            self.normal_vars.insert(*local);
+        }
+        if is_ghost && context.is_mutating_use() && self.normal_vars.contains(local) {
+            let stmt =
+                &self.p.mir.basic_blocks()[location.block].statements[location.statement_index];
+            let span = stmt.source_info.span;
+            log::debug!("violating statement: {:?}", stmt);
+            self.violations.push(SpannedEncodingError::incorrect(
+                "mutating non-ghost variable within ghost block",
+                span,
+            ));
+        }
+    }
+    fn visit_terminator(&mut self, term: &mir::Terminator<'tcx>, location: mir::Location) {
+        if self.is_ghost_place(location) {
+            match &term.kind {
+                mir::TerminatorKind::Call {
+                    func: mir::Operand::Constant(box mir::Constant { literal, .. }),
+                    ..
+                } => {
+                    if let ty::TyKind::FnDef(def_id, _call_substs) = literal.ty().kind() {
+                        if !self.p.encoder.is_pure(*def_id, None) {
+                            self.violations.push(SpannedEncodingError::incorrect(
+                                "Only pure function calls are allowed in ghost blocks.",
+                                term.source_info.span,
+                            ));
+                        }
+                    } else {
+                        unimplemented!();
+                    }
+                }
+                mir::TerminatorKind::Call { .. } => {
+                    unimplemented!();
+                }
+                _ => (),
+            }
+        }
+        self.super_terminator(term, location);
+    }
+}

--- a/prusti-viper/src/encoder/mir/procedures/encoder/specification_blocks.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/specification_blocks.rs
@@ -1,5 +1,6 @@
 use prusti_interface::environment::{
-    is_loop_invariant_block, is_marked_specification_block, Procedure,
+    is_ghost_begin_marker, is_ghost_end_marker, is_loop_invariant_block,
+    is_marked_specification_block, Procedure,
 };
 use prusti_rustc_interface::{
     data_structures::graph::WithSuccessors,
@@ -13,6 +14,7 @@ pub(super) struct SpecificationBlocks {
     specification_blocks: BTreeSet<mir::BasicBlock>,
     /// Blocks through which specifications are entered.
     specification_entry_blocks: BTreeSet<mir::BasicBlock>,
+    ghost_blocks: BTreeSet<mir::BasicBlock>,
     /// A set of blocks containing the loop invariant of a given loop in
     /// execution order.
     ///
@@ -113,10 +115,51 @@ impl SpecificationBlocks {
             }
         }
 
+        // collect ghost blocks
+        // ghost blocks are all the blocks that are reachable from a block containing a ghost_begin marking
+        // without going through the corresponding ghost_end marking
+        let mut ghost_blocks = BTreeSet::new();
+        {
+            let mut queue = Vec::new();
+
+            for (bb, data) in mir::traversal::reverse_postorder(body) {
+                if is_ghost_begin_marker(data, tcx) {
+                    queue.push(bb);
+                }
+                if is_ghost_end_marker(data, tcx) {
+                    ghost_blocks.insert(bb);
+                }
+            }
+
+            while let Some(bb) = queue.pop() {
+                if ghost_blocks.contains(&bb) {
+                    continue;
+                }
+                let data = &body.basic_blocks()[bb];
+                ghost_blocks.insert(bb);
+
+                // end marker is only conditionally reachable, as it is inside an `if false {}`
+                // However, if a block has the end marker as successor, the other successors will be outside the ghost block, and shall be ignored.
+                let before_end = data
+                    .terminator()
+                    .successors()
+                    .any(|bb| is_ghost_end_marker(&body.basic_blocks()[bb], tcx));
+
+                for succ in data.terminator.iter().flat_map(|t| t.successors()) {
+                    if before_end {
+                        ghost_blocks.insert(succ);
+                    } else {
+                        queue.push(succ);
+                    }
+                }
+            }
+        }
+
         Self {
             specification_blocks,
             specification_entry_blocks,
             loop_invariant_blocks,
+            ghost_blocks,
         }
     }
 
@@ -128,7 +171,15 @@ impl SpecificationBlocks {
         self.specification_blocks.contains(&bb)
     }
 
+    pub(super) fn is_ghost_block(&self, bb: mir::BasicBlock) -> bool {
+        self.ghost_blocks.contains(&bb)
+    }
+
     pub(super) fn loop_invariant_blocks(&self) -> &BTreeMap<mir::BasicBlock, LoopInvariantBlocks> {
         &self.loop_invariant_blocks
+    }
+
+    pub(super) fn ghost_blocks(&self) -> &BTreeSet<mir::BasicBlock> {
+        &self.ghost_blocks
     }
 }

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -579,6 +579,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
                 "new" => builtin((NewInt, Type::Int(Int::Unbounded))),
                 _ => unreachable!("no further int functions"),
             };
+        } else if let Some(proc_name) = proc_name.strip_prefix("prusti_contracts::Ghost::<T>::") {
+            return match proc_name {
+                "new" => subst_with(encoded_args[0].clone()),
+                _ => unreachable!("no further Ghost functions."),
+            };
         }
 
         // replace all the operations on Ints

--- a/prusti-viper/src/encoder/mir/specifications/interface.rs
+++ b/prusti-viper/src/encoder/mir/specifications/interface.rs
@@ -100,6 +100,12 @@ pub(crate) trait SpecificationsInterface<'tcx> {
     /// Get the prusti assumption
     fn get_prusti_assumption(&self, def_id: DefId) -> Option<typed::PrustiAssumption>;
 
+    /// Get the begin marker of the ghost block
+    fn get_ghost_begin(&self, def_id: DefId) -> Option<typed::GhostBegin>;
+
+    /// Get the end marker of the ghost block
+    fn get_ghost_end(&self, def_id: DefId) -> Option<typed::GhostEnd>;
+
     /// Get the specifications attached to a function.
     fn get_procedure_specs(
         &self,
@@ -134,6 +140,8 @@ impl<'v, 'tcx: 'v> SpecificationsInterface<'tcx> for super::super::super::Encode
         let func_name = self.env().get_unique_item_name(def_id);
         if func_name.starts_with("prusti_contracts::prusti_contracts::Map")
             || func_name.starts_with("prusti_contracts::prusti_contracts::Seq")
+            || func_name.starts_with("prusti_contracts::prusti_contracts::Ghost")
+            || func_name.starts_with("prusti_contracts::prusti_contracts::Int")
         {
             pure = true;
         }
@@ -213,6 +221,22 @@ impl<'v, 'tcx: 'v> SpecificationsInterface<'tcx> for super::super::super::Encode
             .specs
             .borrow()
             .get_assumption(&def_id)
+            .cloned()
+    }
+
+    fn get_ghost_begin(&self, def_id: DefId) -> Option<typed::GhostBegin> {
+        self.specifications_state
+            .specs
+            .borrow()
+            .get_ghost_begin(&def_id)
+            .cloned()
+    }
+
+    fn get_ghost_end(&self, def_id: DefId) -> Option<typed::GhostEnd> {
+        self.specifications_state
+            .specs
+            .borrow()
+            .get_ghost_end(&def_id)
             .cloned()
     }
 

--- a/prusti-viper/src/encoder/mir/specifications/specs.rs
+++ b/prusti-viper/src/encoder/mir/specifications/specs.rs
@@ -9,9 +9,9 @@ use log::{debug, trace};
 use prusti_interface::{
     environment::Environment,
     specs::typed::{
-        DefSpecificationMap, LoopSpecification, ProcedureSpecification, ProcedureSpecificationKind,
-        ProcedureSpecificationKindError, PrustiAssertion, PrustiAssumption, Refinable,
-        SpecificationItem, TypeSpecification,
+        DefSpecificationMap, GhostBegin, GhostEnd, LoopSpecification, ProcedureSpecification,
+        ProcedureSpecificationKind, ProcedureSpecificationKindError, PrustiAssertion,
+        PrustiAssumption, Refinable, SpecificationItem, TypeSpecification,
     },
     PrustiError,
 };
@@ -88,6 +88,16 @@ impl<'tcx> Specifications<'tcx> {
     pub(super) fn get_assumption(&self, def_id: &DefId) -> Option<&PrustiAssumption> {
         trace!("Get assumption specs of {:?}", def_id);
         self.user_typed_specs.get_assumption(def_id)
+    }
+
+    pub(super) fn get_ghost_begin(&self, def_id: &DefId) -> Option<&GhostBegin> {
+        trace!("Get begin ghost block specs of {:?}", def_id);
+        self.user_typed_specs.get_ghost_begin(def_id)
+    }
+
+    pub(super) fn get_ghost_end(&self, def_id: &DefId) -> Option<&GhostEnd> {
+        trace!("Get end ghost block specs of {:?}", def_id);
+        self.user_typed_specs.get_ghost_end(def_id)
     }
 
     pub(super) fn get_and_refine_proc_spec<'a, 'env: 'a>(

--- a/scripts/verify_test.py
+++ b/scripts/verify_test.py
@@ -126,14 +126,15 @@ def verify_test(args):
     if args.test_file.startswith('prusti-tests/'):
         test_path = args.test_file
     else:
-        candidate_test_paths = glob.glob(os.path.join(current_path, "prusti-tests/tests*/*", test))
+        candidate_test_paths = glob.glob(os.path.join(
+            current_path, "prusti-tests/tests*/*", args.test_file))
         if len(candidate_test_paths) == 0:
-            error("Not tests found that match: {}", test)
+            error("Not tests found that match: {}", args.test_file)
         elif len(candidate_test_paths) > 1:
             error(
                 "Expected one test, but found {} tests that match {}. First 5: {}",
                 len(candidate_test_paths),
-                test,
+                args.test_file,
                 candidate_test_paths[:5]
             )
         test_path = candidate_test_paths[0]


### PR DESCRIPTION
(WIP)

This PR adds checks concerning ghost blocks, such that ghost code really is side effect free and does not interfere with non-ghost code in unintended ways.
Example:
```rs
let mut x = 1;
ghost! {
    x = 2;
}
assert!(x == 2);
// This successfully verifies at the moment, even though the ghost block will be completely removed from the program when compiled.
```

---

Progress

- [x] Finding basic blocks belonging to ghost code
- [ ] Performing checks s.t. ghost code does not interfere with regular code


