### PR TITLE
Sanitize generated labels for `impl` arguments

### DIFF
--- a/prusti-tests/tests/verify/pass/issues/issue-1037-1.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-1037-1.rs
@@ -1,0 +1,2 @@
+fn foo(args: impl IntoIterator) { drop(args) }
+fn main() {}

--- a/prusti-tests/tests/verify/pass/issues/issue-1037-2.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-1037-2.rs
@@ -1,0 +1,2 @@
+fn foo(args: impl IntoIterator<Item = u32>) { drop(args) }
+fn main() {}

--- a/prusti-tests/tests/verify/pass/issues/issue-1037-3.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-1037-3.rs
@@ -1,0 +1,17 @@
+extern crate prusti_contracts;
+use prusti_contracts::*;
+#[ensures(result > 0)]
+fn to_pos_u32(args: impl Into<u32>) -> u32 {
+    let result = args.into();
+    if result == 0 {
+        1
+    } else {
+        result
+    }
+}
+
+fn main() {
+    let x : u16 = 5;
+    let y = to_pos_u32(x);
+    assert!(y > 0);
+}

--- a/prusti-tests/tests/verify/pass/issues/issue-1037-4.rs
+++ b/prusti-tests/tests/verify/pass/issues/issue-1037-4.rs
@@ -1,0 +1,20 @@
+extern crate prusti_contracts;
+use prusti_contracts::*;
+#[ensures(result > 0)]
+fn to_pos_u32(args: impl Into<u32>) -> u32 {
+    let result = args.into();
+    if result == 0 {
+        1
+    } else {
+        result
+    }
+}
+
+fn main() {
+    let x1 : u16 = 5;
+    let y1 = to_pos_u32(x1);
+    assert!(y1 > 0);
+    let x2 : u8 = 5;
+    let y2 = to_pos_u32(x2);
+    assert!(y2 > 0);
+}

--- a/prusti-viper/src/encoder/mir/generics/interface.rs
+++ b/prusti-viper/src/encoder/mir/generics/interface.rs
@@ -58,7 +58,13 @@ impl<'v, 'tcx: 'v> MirGenericsEncoderInterface<'tcx> for super::super::super::En
             .collect::<Result<Vec<_>, _>>()?)
     }
     fn encode_param(&self, name: Symbol, index: u32) -> vir_high::ty::TypeVar {
-        let identifier = format!("{}${}", name.as_str(), index);
+        let sanitized_name = name
+            .as_str()
+            .replace(' ', "_")
+            .replace('>', "_gt_")
+            .replace('<', "_lt_")
+            .replace('=', "_eq_");
+        let identifier = format!("{}${}", sanitized_name, index);
         vir_high::ty::TypeVar::generic_type(identifier)
     }
 }

--- a/vir/defs/polymorphic/ast/common.rs
+++ b/vir/defs/polymorphic/ast/common.rs
@@ -425,7 +425,14 @@ impl Type {
                     Self::encode_arguments(&[val_type.clone()])
                 )
             }
-            Type::TypeVar(TypeVar { label }) => format!("__TYPARAM__$_{}$__", label),
+            Type::TypeVar(TypeVar { label }) => {
+                assert!(
+                    TypeVar::is_valid_label(label),
+                    "Label {} is not valid",
+                    label
+                );
+                format!("__TYPARAM__$_{}$__", label)
+            }
             x => unreachable!("{}", x),
         }
     }
@@ -619,6 +626,12 @@ impl From<TypeVar> for SnapshotType {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TypeVar {
     pub label: String,
+}
+
+impl TypeVar {
+    pub fn is_valid_label(label: &str) -> bool {
+        !label.contains(' ') && !label.contains('<') && !label.contains('>') && !label.contains('=')
+    }
 }
 
 impl fmt::Display for TypeVar {


### PR DESCRIPTION
The type variable names for `impl` function parameters potentially contain spaces, braces, equality signs. This PR sanitizes them so that the resulting viper identifiers are valid.

I'm not quite sure if the resulting encoding is usable for verification; on the other hand making this change prevents Prusti from crashing.

Fixes #1037 