### PR TITLE
Lifetime Encoding for Basic Structs with References

### DIFF
--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/structs.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/structs.rs
@@ -19,3 +19,33 @@ fn simple_struct_assert_false() {
     x.x = 2;
     assert!(false);      //~ ERROR: the asserted expression might not hold
 }
+
+struct S2<'a> {
+    x: &'a mut u32,
+}
+fn struct_with_reference () {
+    let mut n = 4;
+    let mut t = S2{ x: &mut n};
+}
+fn struct_with_reference_assert_false () {
+    let mut n = 4;
+    let mut t = S2{ x: &mut n};
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+// FIXME: accessing references of structs panics
+// struct S3<'a> {
+//     x: &'a mut u32,
+// }
+// fn struct_with_reference_and_access () {
+//     let mut n = 4;
+//     let mut t = S2{ x: &mut n};
+//     *t.x = 5;
+// }
+// FIXME: accessing references of structs panics
+// fn struct_with_reference_and_access_assert_false () {
+//     let mut n = 4;
+//     let mut t = S2{ x: &mut n};
+//     *t.x = 5;
+//     assert!(false);           the asserted expression might not hold
+// }

--- a/prusti-viper/src/encoder/middle/core_proof/builtin_methods/split_join.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/builtin_methods/split_join.rs
@@ -52,7 +52,7 @@ impl TypeDeclWalker for SplitJoinHelper {
         Ok(())
     }
     fn walk_primitive(&mut self, _: &Type, _: &(), _lowerer: &mut Lowerer) -> R {
-        unreachable!("Trying to split memory block of a primitive type.")
+        unreachable!("Trying to split memory block of a primitive type.");
     }
     fn walk_field(&mut self, ty: &Type, field: &FieldDecl, _: &(), lowerer: &mut Lowerer) -> R {
         let field_size_of = lowerer.encode_type_size_expression(&field.ty)?;

--- a/prusti-viper/src/encoder/middle/core_proof/into_low/cfg.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/into_low/cfg.rs
@@ -373,7 +373,14 @@ impl IntoLow for vir_mid::Statement {
                 let place = lowerer.encode_expression_as_place(&statement.place)?;
                 let address = lowerer.extract_root_address(&statement.place)?;
                 let snapshot = statement.place.to_procedure_snapshot(lowerer)?;
-                let arguments = lowerer.extract_non_type_arguments_from_type(ty)?;
+                let mut arguments = lowerer.extract_non_type_arguments_from_type(ty)?;
+                let lifetimes = lowerer.extract_lifetime_arguments_from_type(ty)?;
+                arguments.extend(
+                    lifetimes
+                        .iter()
+                        .map(|x| x.clone().into())
+                        .collect::<Vec<vir_low::Expression>>(),
+                );
                 let low_statement = if let Some(condition) = statement.condition {
                     let low_condition = lowerer.lower_block_marker_condition(condition)?;
                     stmtp! {


### PR DESCRIPTION
Add lifetime parameters to `OwnedNonAliased` predicate for structs with reference fields. Also the method bodies of `into_memory_block`, `assign` and `write_place` for structs with references are removed as a temporary solution.