### PR TITLE
Increase assert_timeout for core proof test

### DIFF
--- a/prusti-tests/tests/verify_overflow/fail/core_proof/arrays.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/arrays.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Punsafe_core_proof=true
+// compile-flags: -Punsafe_core_proof=true -Passert_timeout=180000
 
 use prusti_contracts::*;
 


### PR DESCRIPTION
I notice that CI seems to intermittently fail on this test, it seems like increasing the `assert_timeout` fixes it (locally for me, at least)