### PR TITLE
add `internal_errors_as_warnings` flag to dev guide

### DIFF
--- a/docs/dev-guide/src/config/flags.md
+++ b/docs/dev-guide/src/config/flags.md
@@ -195,7 +195,10 @@ When enabled, debug files dumped by `rustc` will not contain lifetime regions.
 
 ## `INTERNAL_ERRORS_AS_WARNINGS`
 
-When enabled, internal errors are presented as warnings.
+When enabled, internal errors are presented as warnings. 
+
+**Note**: This should only be used for debugging, as enabling this setting could
+hide actual verification errors.
 
 ## `INTERN_NAMES`
 

--- a/docs/dev-guide/src/config/flags.md
+++ b/docs/dev-guide/src/config/flags.md
@@ -32,6 +32,7 @@
 | [`FULL_COMPILATION`](#full_compilation) | `bool` | `false` |
 | [`HIDE_UUIDS`](#hide_uuids) | `bool` | `false` |
 | [`IGNORE_REGIONS`](#ignore_regions) | `bool` | `false` |
+| [`INTERNAL_ERRORS_AS_WARNINGS`](#internal_errors_as_warnings) | `bool` | `false` |
 | [`INTERN_NAMES`](#intern_names) | `bool` | `true` |
 | [`JSON_COMMUNICATION`](#json_communication) | `bool` | `false` |
 | [`LOG`](#log) | `Option<String>` | `None` |
@@ -191,6 +192,10 @@ When enabled, UUIDs of expressions and specifications printed with [`PRINT_TYPEC
 ## `IGNORE_REGIONS`
 
 When enabled, debug files dumped by `rustc` will not contain lifetime regions.
+
+## `INTERNAL_ERRORS_AS_WARNINGS`
+
+When enabled, internal errors are presented as warnings.
 
 ## `INTERN_NAMES`
 


### PR DESCRIPTION
Adds the `internal_errors_as_warnings` flag to the dev guide