### PR TITLE
Add a --check-timeout flag

### DIFF
--- a/docs/dev-guide/src/config/flags.md
+++ b/docs/dev-guide/src/config/flags.md
@@ -9,6 +9,7 @@
 | [`CHECK_FOLDUNFOLD_STATE`](#check_foldunfold_state) | `bool` | `false` |
 | [`CHECK_OVERFLOWS`](#check_overflows) | `bool` | `true` |
 | [`CHECK_PANICS`](#check_panics) | `bool` | `true` |
+| [`CHECK_TIMEOUT`](#check_timeout) | `Option<u32>` | `None` |
 | [`CONTRACTS_LIB`](#contracts_lib) | `String` | `""` |
 | [`COUNTEREXAMPLE`](#counterexample) | `bool` | `false` |
 | [`DELETE_BASIC_BLOCKS`](#delete_basic_blocks) | `Vec<String>` | `vec![]` |
@@ -86,6 +87,14 @@ When enabled, binary operations and numeric casts will be checked for overflows.
 ## `CHECK_PANICS`
 
 When enabled, Prusti will check for an absence of `panic!`s.
+
+## `CHECK_TIMEOUT`
+
+Maximum time (in milliseconds) for the verifier to spend on checks.
+Set to None uses the verifier's default value. Maps to the verifier command-line
+argument `--checkTimeout`.
+For more information see [here]( https://github.com/viperproject/silicon/blob/4c70514379f89e7ec6f96588290ade32518f0527/src/main/scala/Config.scala#L203).
+
 
 ## `CONTRACTS_LIB`
 

--- a/prusti-common/src/config.rs
+++ b/prusti-common/src/config.rs
@@ -67,6 +67,7 @@ lazy_static! {
         // 1. Default values
         settings.set_default("be_rustc", false).unwrap();
         settings.set_default("viper_backend", "Silicon").unwrap();
+        settings.set_default::<Option<u32>>("check_timeout", None).unwrap();
         settings.set_default("check_foldunfold_state", false).unwrap();
         settings.set_default("check_overflows", true).unwrap();
         settings.set_default("check_panics", true).unwrap();
@@ -362,6 +363,15 @@ pub fn quiet() -> bool {
 /// argument `--assertTimeout`.
 pub fn assert_timeout() -> u64 {
     read_setting("assert_timeout")
+}
+
+/// Maximum time (in milliseconds) for the verifier to spend on checks.
+/// Set to None uses the verifier's default value. Maps to the verifier command-line
+/// argument `--checkTimeout`.
+///
+/// For more information see https://github.com/viperproject/silicon/blob/4c70514379f89e7ec6f96588290ade32518f0527/src/main/scala/Config.scala#L203
+pub fn check_timeout() -> Option<u32> {
+    read_setting("check_timeout")
 }
 
 /// When enabled, a more complete `exhale` version is used in the verifier.

--- a/prusti-server/src/verification_request.rs
+++ b/prusti-server/src/verification_request.rs
@@ -56,6 +56,11 @@ impl Default for ViperBackendConfig {
                     "--logLevel".to_string(),
                     "ERROR".to_string(),
                 ]);
+
+                if let Some(check_timeout) = config::check_timeout() {
+                    verifier_args.push("--checkTimeout".to_string());
+                    verifier_args.push(check_timeout.to_string());
+                }
             }
             VerificationBackend::Carbon => {
                 verifier_args.extend(vec!["--disableAllocEncoding".to_string()]);

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/arrays.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/arrays.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Punsafe_core_proof=true
+// compile-flags: -Punsafe_core_proof=true -Pcheck_timeout=50
 
 use prusti_contracts::*;
 


### PR DESCRIPTION
Add the `--check-timeout` flag that is passed to Silicon. 

I think that a too-low timeout is what is causing intermittent verification errors in [arrays.rs](https://github.com/viperproject/prusti-dev/blob/dc6b69046541afc191ef311660e3ad0e9bc9a1e3/prusti-tests/tests/verify_overflow/fail/core_proof/arrays.rs).

Increasing the value seems to make it work: running silicon directly produces different results on the generated viper file when different arguments for `--check-timeout` are used (low values cause it to fail).
