### PR TITLE
Fix Lifetime Encoding for Arrays

### DIFF
--- a/prusti-interface/src/environment/mir_body/borrowck/lifetimes/mod.rs
+++ b/prusti-interface/src/environment/mir_body/borrowck/lifetimes/mod.rs
@@ -35,11 +35,25 @@ impl Lifetimes {
             .collect()
     }
 
+    pub fn get_origin_contains_loan_at_start(
+        &self,
+        location: mir::Location,
+    ) -> BTreeMap<String, BTreeSet<String>> {
+        self.get_origin_contains_loan_at_location(RichLocation::Start(location))
+    }
+
     pub fn get_origin_contains_loan_at_mid(
         &self,
         location: mir::Location,
     ) -> BTreeMap<String, BTreeSet<String>> {
-        let info = self.get_origin_contains_loan_at(RichLocation::Mid(location));
+        self.get_origin_contains_loan_at_location(RichLocation::Mid(location))
+    }
+
+    pub fn get_origin_contains_loan_at_location(
+        &self,
+        location: RichLocation,
+    ) -> BTreeMap<String, BTreeSet<String>> {
+        let info = self.get_origin_contains_loan_at(location);
         info.iter()
             .map(|(k, v)| {
                 (

--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/arrays.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/arrays.rs
@@ -1,0 +1,32 @@
+// compile-flags: -Punsafe_core_proof=true
+
+use prusti_contracts::*;
+fn main() {}
+
+fn array_borrow() {
+    let mut a = [1; 4];
+    let b = &mut a[2];
+    *b = 2;
+}
+
+fn array_borrow_assert_false() {
+    let mut a = [1; 4];
+    let b = &mut a[2];
+    *b = 2;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+fn array_reborrow_and_assign() {
+    let mut a = [1; 4];
+    let b = &mut a[2];
+    let c = &mut *b;
+    *c = 2;
+}
+
+fn array_reborrow_and_assign_assert_false() {
+    let mut a = [1; 4];
+    let b = &mut a[2];
+    let c = &mut *b;
+    *c = 2;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}

--- a/prusti-viper/src/encoder/high/procedures/inference/state.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/state.rs
@@ -200,7 +200,18 @@ impl PredicateState {
         &self,
         place: &vir_high::Expression,
     ) -> SpannedEncodingResult<Option<(&vir_high::Expression, &vir_high::ty::LifetimeConst)>> {
-        Ok(self.mut_borrowed.iter().find(|(p, _)| place.has_prefix(p)))
+        Ok(self.mut_borrowed.iter().find(|(p, _)| {
+            let prefix_expr = match p {
+                vir_high::Expression::BuiltinFuncApp(vir_high::BuiltinFuncApp {
+                    function: vir_high::BuiltinFunc::Index,
+                    type_arguments: _,
+                    arguments,
+                    ..
+                }) => &arguments[0],
+                _ => *p,
+            };
+            place.has_prefix(prefix_expr)
+        }))
     }
 
     pub(super) fn clear(&mut self) -> SpannedEncodingResult<()> {

--- a/prusti-viper/src/encoder/middle/core_proof/predicates/owned/encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/predicates/owned/encoder.rs
@@ -237,6 +237,7 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
             }
             vir_mid::TypeDecl::Array(decl) => {
                 let element_type = &decl.element_type;
+                self.lowerer.encode_place_array_index_axioms(ty)?;
                 self.lowerer.ensure_type_definition(element_type)?;
                 let parameters = self.lowerer.extract_non_type_parameters_from_type(ty)?;
                 let parameters_validity: vir_low::Expression = self

--- a/prusti-viper/src/encoder/mir/procedures/encoder/lifetimes.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/lifetimes.rs
@@ -592,6 +592,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> LifetimesEncoder<'tcx> for ProcedureEncoder<'p, 'v, '
                     )?);
                     if let Some(mir_local) = self.procedure.get_var_of_lifetime(&lifetime[..]) {
                         let local = self.encode_local(mir_local)?;
+                        // FIXME: A workaround until Dead is fixed.
                         if !self.points_to_reborrow.contains(&local) {
                             self.encode_dead_variable(block_builder, location, local)?;
                         }

--- a/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
@@ -444,12 +444,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let terminator_index = statements.len();
         let mut original_lifetimes: BTreeSet<String> =
             self.lifetimes.get_loan_live_at_start(location);
-        // FIXME: This misses the lifetimes that need to be generated at the
-        // beginning of the block.
         let mut derived_lifetimes: BTreeMap<String, BTreeSet<String>> =
-            self.lifetimes.get_origin_contains_loan_at_mid(location);
+            self.lifetimes.get_origin_contains_loan_at_start(location);
         while location.statement_index < terminator_index {
-            self.encode_lft_for_statement(
+            self.encode_lft_for_statement_mid(
                 &mut block_builder,
                 location,
                 &mut original_lifetimes,
@@ -462,9 +460,18 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 &statements[location.statement_index],
             )?;
             location.statement_index += 1;
+            if location.statement_index < terminator_index {
+                self.encode_lft_for_statement_start(
+                    &mut block_builder,
+                    location,
+                    &mut original_lifetimes,
+                    &mut derived_lifetimes,
+                    Some(&statements[location.statement_index]),
+                )?;
+            }
         }
         if let Some(terminator) = terminator {
-            self.encode_lft_for_statement(
+            self.encode_lft_for_statement_mid(
                 &mut block_builder,
                 location,
                 &mut original_lifetimes,


### PR DESCRIPTION
Fixes the lifetime encoding for cases where the lifetimes change in the first statement of a basic block. This is the case when creating a reference to an array item.