### PR TITLE
Lifetime Encoding for Function Call with Returning References

### DIFF
--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/function_calls.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/function_calls.rs
@@ -66,3 +66,35 @@ fn function_call_return_value_assert_false() {
     let x = f4(&mut a);
     assert!(false);      //~ ERROR: the asserted expression might not hold
 }
+
+fn f5<'a>(x: &'a mut i32) -> &'a mut i32{
+    x
+}
+fn function_call_return_ref() {
+    let mut a = 1;
+    let aa = f5(&mut a);
+    *aa = 2;
+}
+fn function_call_return_ref_assert_false() {
+    let mut a = 1;
+    let aa = f5(&mut a);
+    *aa = 2;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+fn f6<'a, 'b>(x: &'a mut i32, y: &'b mut i32) -> &'b mut i32{
+    y
+}
+fn function_call_return_ref_2() {
+    let mut a = 1;
+    let mut b = 2;
+    let bb = f6(&mut a, &mut b);
+    *bb = 3;
+}
+fn function_call_return_ref_2_assert_false() {
+    let mut a = 1;
+    let mut b = 2;
+    let bb = f6(&mut a, &mut b);
+    *bb = 3;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}

--- a/prusti-viper/src/encoder/middle/core_proof/builtin_methods/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/builtin_methods/interface.rs
@@ -836,8 +836,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 )
             }
         };
+        let valid_result =
+            self.encode_snapshot_valid_call_for_type(result_value.clone().into(), result_type)?;
         let reference_predicate = expr! {
-            acc(OwnedNonAliased<result_type>(target_place, target_address, result_value, operand_lifetime))
+            (acc(OwnedNonAliased<result_type>(target_place, target_address, result_value, operand_lifetime))) &&
+            [valid_result]
         };
         let lifetime_token =
             self.encode_lifetime_token(operand_lifetime.clone(), lifetime_perm.clone().into())?;

--- a/prusti-viper/src/encoder/middle/core_proof/lifetimes/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lifetimes/interface.rs
@@ -70,6 +70,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
         &mut self,
         expressions: &mut VecDeque<vir_low::Expression>,
     ) -> vir_low::Expression {
+        assert!(!expressions.is_empty());
         if expressions.len() == 1 {
             return expressions.pop_front().unwrap();
         }


### PR DESCRIPTION
Fix lifetime encoding for function calls with a reference as return value.