### PR TITLE
Create missing Operand/Target Lifetimes for Reborrows

### DIFF
--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -77,6 +77,30 @@ impl<'tcx> Procedure<'tcx> {
 
     }
 
+    pub fn get_lifetime_of_var(&self, var: mir::Local) -> Option<String>{
+        fn get_lifetime_if_matches(local: mir::Local, var: mir::Local, mir: &Mir) -> Option<String>{
+            if local == var {
+                let ty_kind = mir.local_decls[local].ty.kind();
+                if let prusti_rustc_interface::middle::ty::TyKind::Ref(region, _ty, _mutability) = ty_kind {
+                    return Some(region.to_text());
+                }
+            }
+            None
+        }
+        let mir = self.get_mir();
+        for local in mir.vars_and_temps_iter() {
+            if let Some(lifetime) = get_lifetime_if_matches(local, var, mir) {
+                return Some(lifetime);
+            }
+        }
+        for local in mir.args_iter() {
+            if let Some(lifetime) = get_lifetime_if_matches(local, var, mir) {
+                return Some(lifetime);
+            }
+        }
+        None
+    }
+
     pub fn get_var_of_lifetime(&self, lft: &str) -> Option<mir::Local>{
         let mir = self.get_mir();
         for local in mir.vars_and_temps_iter() {

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/clone.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/clone.rs
@@ -1,9 +1,44 @@
 // compile-flags: -Punsafe_core_proof=true
-// ignore-test: #1065
 
 use prusti_contracts::*;
 
 fn main() {}
 
 #[derive(Clone)]
+struct I32Container<i32>(i32);
+
+#[derive(Clone)]
 struct Container<T>(T);
+fn container_client(){
+    let x: i32 = 4;
+    let c: Container<i32> = Container(x);
+    let d = c.clone();
+}
+fn container_client_assert_false(){
+    let x: i32 = 4;
+    let c: Container<i32> = Container(x);
+    let d = c.clone();
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+#[derive(Clone)]
+struct Container2<T,U>{
+    t: T,
+    u: U,
+}
+
+// NOTE: The following implementation was generated with "cargo-expand" and has been
+//   slightly modified to include the assert!(false)
+struct Container3<T>(T);
+impl<T: ::core::clone::Clone> ::core::clone::Clone for Container3<T> {
+    #[inline]
+    fn clone(&self) -> Container3<T> {
+        let x = match *self {
+            Self(ref __self_0_0) => Container3(::core::clone::Clone::clone(&(*__self_0_0))),
+        };
+        assert!(false);      //~ ERROR: the asserted expression might not hold
+        x
+    }
+}
+
+

--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/simple.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/simple.rs
@@ -13,3 +13,28 @@ pub fn mutable_borrow_assert_false() {
     assert!(false);      //~ ERROR: the asserted expression might not hold
 }
 
+pub fn shared_borrow() {
+    let mut a = 4;
+    let x = &a;
+    let y = &a;
+}
+pub fn shared_borrow_assert_false() {
+    let mut a = 4;
+    let x = &a;
+    let y = &a;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+pub fn shared_reborrow() {
+    let mut a = 4;
+    let x = &a;
+    let y = &(*x);
+    let z = &(*x);
+}
+pub fn shared_reborrow_assert_false() {
+    let mut a = 4;
+    let x = &a;
+    let y = &(*x);
+    let z = &(*x);
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}

--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/structs.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/structs.rs
@@ -6,30 +6,56 @@ fn main() {}
 struct S1 {
     x: u32,
 }
-fn simple_struct() {
+fn simple_struct_mut() {
     let mut x = S1{ x: 3};
     let mut y = &mut x;
     y.x = 3;
     x.x = 2;
 }
-fn simple_struct_assert_false() {
+fn simple_struct_mut_assert_false() {
     let mut x = S1{ x: 3};
     let mut y = &mut x;
     y.x = 3;
     x.x = 2;
     assert!(false);      //~ ERROR: the asserted expression might not hold
 }
+fn simple_struct_shared() {
+    let mut x = S1{ x: 4 };
+    let y = &x;
+    let z = &x;
+}
+fn simple_struct_shared_assert_false() {
+    let mut x = S1{ x: 4 };
+    let y = &x;
+    let z = &x;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
 
 struct S2<'a> {
     x: &'a mut u32,
 }
-fn struct_with_reference () {
+fn struct_with_mut_reference () {
     let mut n = 4;
     let mut t = S2{ x: &mut n};
 }
-fn struct_with_reference_assert_false () {
+fn struct_with_mut_reference_assert_false () {
     let mut n = 4;
     let mut t = S2{ x: &mut n};
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+struct S3<'a> {
+    x: &'a u32,
+}
+fn struct_with_shared_reference () {
+    let mut n = 4;
+    let mut t = S3{ x: &n};
+    let mut u = S3{ x: &n};
+}
+fn struct_with_shared_reference_assert_false () {
+    let mut n = 4;
+    let mut t = S3{ x: &n};
+    let mut u = S3{ x: &n};
     assert!(false);      //~ ERROR: the asserted expression might not hold
 }
 

--- a/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
@@ -395,10 +395,14 @@ impl CollectPermissionChanges for vir_high::ast::rvalue::Reborrow {
         produced_permissions: &mut Vec<Permission>,
     ) -> SpannedEncodingResult<()> {
         consumed_permissions.push(Permission::Owned(self.place.clone()));
-        produced_permissions.push(Permission::MutBorrowed(MutBorrowed {
-            lifetime: self.place_lifetime.clone(),
-            place: self.place.clone(),
-        }));
+        if self.is_mut {
+            produced_permissions.push(Permission::MutBorrowed(MutBorrowed {
+                lifetime: self.place_lifetime.clone(),
+                place: self.place.clone(),
+            }));
+        } else {
+            produced_permissions.push(Permission::Owned(self.place.clone()));
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Create missing operand and target lifetimes in case of a reborrow where the lifetimes are not present in the derived lifetimes set and are therefore not created as usual.

Fixes: #1065 