### PR TITLE
Update dependencies (rustc nightly-2022-07-01, viper v-2022-06-09-1135)

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -55,6 +55,7 @@ jobs:
           body: |
             * [x] Update Viper version to `${{ env.VIPER_VERSION }}`.
             * [x] Update rustc version to `${{ env.NIGHTLY_VERSION }}`.
+            * [ ] Run `cargo audit` and fix the issues.
             * [ ] Manualy update outdated dependencies (see the list below).
             * [ ] Manualy run `cargo update`.
             

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "async-attributes"
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8b508d585e01084059b60f06ade4cb7415cd2e4084b71dd1cb44e7d3fb9880"
+checksum = "5262ed948da60dd8956c6c5aca4d4163593dddb7b32d73267c93dab7b2e98940"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -114,6 +114,7 @@ dependencies = [
  "async-lock",
  "blocking",
  "futures-lite",
+ "num_cpus",
  "once_cell",
 ]
 
@@ -164,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -183,7 +184,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -484,9 +484,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "3.2.5"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.5"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "diffy"
@@ -893,9 +893,9 @@ checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "encoding_rs"
@@ -1254,12 +1254,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
@@ -1418,12 +1412,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1592,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
@@ -1666,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -1870,7 +1864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2023,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2206,9 +2200,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -2489,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
 
 [[package]]
 name = "rustwide"
@@ -2604,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
@@ -2630,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
@@ -2785,9 +2779,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3059,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -3077,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
 ]
@@ -3168,9 +3162,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "81dee68f85cab8cf68dec42158baf3a79a1cdc065a8b103025965d6ccb7f6cbd"
 dependencies = [
  "tinyvec",
 ]

--- a/jni-gen/src/generators/constructor.rs
+++ b/jni-gen/src/generators/constructor.rs
@@ -32,8 +32,8 @@ pub fn generate_constructor(
         let constructor =
             env.get_object_array_element(constructors.into_inner(), constructor_index)?;
 
-        let constructor_signature =
-            java_str_to_string(&env.get_string(
+        let constructor_signature = java_str_to_string(
+            &env.get_string(
                 env.call_static_method(
                     "org/objectweb/asm/Type",
                     "getConstructorDescriptor",
@@ -42,7 +42,8 @@ pub fn generate_constructor(
                 )?
                 .l()?
                 .into(),
-            )?)?;
+            )?,
+        )?;
 
         indexed_constructors.insert(constructor_signature, constructor);
     }

--- a/jni-gen/src/generators/method.rs
+++ b/jni-gen/src/generators/method.rs
@@ -30,15 +30,16 @@ pub fn generate_method(
     for method_index in 0..num_methods {
         let method = env.get_object_array_element(methods.into_inner(), method_index)?;
 
-        let method_name =
-            java_str_to_string(&env.get_string(
+        let method_name = java_str_to_string(
+            &env.get_string(
                 env.call_method(method, "getName", "()Ljava/lang/String;", &[])?
                     .l()?
                     .into(),
-            )?)?;
+            )?,
+        )?;
 
-        let method_signature =
-            java_str_to_string(&env.get_string(
+        let method_signature = java_str_to_string(
+            &env.get_string(
                 env.call_static_method(
                     "org/objectweb/asm/Type",
                     "getMethodDescriptor",
@@ -47,7 +48,8 @@ pub fn generate_method(
                 )?
                 .l()?
                 .into(),
-            )?)?;
+            )?,
+        )?;
 
         match indexed_methods.remove(&method_name) {
             None => {

--- a/prusti-interface/src/environment/mir_utils/all_places.rs
+++ b/prusti-interface/src/environment/mir_utils/all_places.rs
@@ -1,6 +1,7 @@
-use prusti_rustc_interface::index::vec::Idx;
-use prusti_rustc_interface::middle::mir;
-use prusti_rustc_interface::middle::ty;
+use prusti_rustc_interface::{
+    index::vec::Idx,
+    middle::{mir, ty},
+};
 
 pub trait AllPlaces<'tcx> {
     /// Returns all places that are below the given local variable. Right now, this only handles
@@ -23,4 +24,3 @@ impl<'tcx> AllPlaces<'tcx> for mir::Local {
         places
     }
 }
-

--- a/prusti-interface/src/environment/mir_utils/args_for_mir.rs
+++ b/prusti-interface/src/environment/mir_utils/args_for_mir.rs
@@ -1,6 +1,7 @@
-use prusti_rustc_interface::index::vec::Idx;
-use prusti_rustc_interface::middle::mir;
-use prusti_rustc_interface::middle::ty;
+use prusti_rustc_interface::{
+    index::vec::Idx,
+    middle::{mir, ty},
+};
 
 pub trait ArgsForMir<'tcx> {
     fn get_args(&self) -> Vec<(mir::Local, ty::Ty<'tcx>)>;

--- a/prusti-interface/src/environment/mir_utils/mod.rs
+++ b/prusti-interface/src/environment/mir_utils/mod.rs
@@ -8,6 +8,7 @@
 
 mod all_places;
 mod args_for_mir;
+mod mir_place;
 mod real_edges;
 mod slice_or_array_ref;
 mod split_aggregate_assignment;
@@ -15,15 +16,9 @@ mod statement_as_assign;
 mod statement_at;
 mod tuple_items_for_ty;
 mod ty_as_ty_ref;
-mod mir_place;
 
-pub use self::all_places::*;
-pub use self::args_for_mir::*;
-pub use self::real_edges::*;
-pub use self::slice_or_array_ref::*;
-pub use self::split_aggregate_assignment::*;
-pub use self::statement_as_assign::*;
-pub use self::statement_at::*;
-pub use self::tuple_items_for_ty::*;
-pub use self::ty_as_ty_ref::*;
-pub use self::mir_place::*;
+pub use self::{
+    all_places::*, args_for_mir::*, mir_place::*, real_edges::*, slice_or_array_ref::*,
+    split_aggregate_assignment::*, statement_as_assign::*, statement_at::*, tuple_items_for_ty::*,
+    ty_as_ty_ref::*,
+};

--- a/prusti-interface/src/environment/mir_utils/real_edges.rs
+++ b/prusti-interface/src/environment/mir_utils/real_edges.rs
@@ -8,8 +8,6 @@ use prusti_rustc_interface::middle::mir::{self, TerminatorKind};
 
 use prusti_rustc_interface::index::vec::IndexVec;
 
-
-
 /// A data structure to store the non-virtual CFG edges of a MIR body.
 pub struct RealEdges {
     successors: IndexVec<mir::BasicBlock, Vec<mir::BasicBlock>>,
@@ -48,14 +46,11 @@ impl RealEdges {
 
 fn real_targets(terminator: &mir::Terminator) -> Vec<mir::BasicBlock> {
     match terminator.kind {
-        TerminatorKind::Goto { ref target }
-        | TerminatorKind::Assert { ref target, .. } => {
+        TerminatorKind::Goto { ref target } | TerminatorKind::Assert { ref target, .. } => {
             vec![*target]
         }
 
-        TerminatorKind::SwitchInt { ref targets, .. } => {
-            targets.all_targets().to_vec()
-        }
+        TerminatorKind::SwitchInt { ref targets, .. } => targets.all_targets().to_vec(),
 
         TerminatorKind::Resume
         | TerminatorKind::Abort
@@ -66,9 +61,7 @@ fn real_targets(terminator: &mir::Terminator) -> Vec<mir::BasicBlock> {
         TerminatorKind::DropAndReplace { ref target, .. }
         | TerminatorKind::Drop { ref target, .. } => vec![*target],
 
-        TerminatorKind::Call {
-            target, ..
-        } => match target {
+        TerminatorKind::Call { target, .. } => match target {
             Some(target) => vec![target],
             None => vec![],
         },
@@ -81,9 +74,7 @@ fn real_targets(terminator: &mir::Terminator) -> Vec<mir::BasicBlock> {
             ref real_target, ..
         } => vec![*real_target],
 
-        TerminatorKind::Yield {
-            ref resume, ..
-        } => vec![*resume],
+        TerminatorKind::Yield { ref resume, .. } => vec![*resume],
 
         TerminatorKind::InlineAsm {
             ref destination, ..

--- a/prusti-interface/src/environment/mir_utils/slice_or_array_ref.rs
+++ b/prusti-interface/src/environment/mir_utils/slice_or_array_ref.rs
@@ -1,5 +1,4 @@
-use prusti_rustc_interface::middle::ty::Ty;
-use prusti_rustc_interface::middle::ty::TyKind;
+use prusti_rustc_interface::middle::ty::{Ty, TyKind};
 
 pub trait SliceOrArrayRef<'tcx> {
     fn is_slice_ref(&self) -> bool;

--- a/prusti-interface/src/environment/mir_utils/split_aggregate_assignment.rs
+++ b/prusti-interface/src/environment/mir_utils/split_aggregate_assignment.rs
@@ -1,8 +1,8 @@
-use prusti_rustc_interface::index::vec::Idx;
-use prusti_rustc_interface::middle::mir;
-use prusti_rustc_interface::middle::ty;
-use super::SliceOrArrayRef;
-use super::TupleItemsForTy;
+use super::{SliceOrArrayRef, TupleItemsForTy};
+use prusti_rustc_interface::{
+    index::vec::Idx,
+    middle::{mir, ty},
+};
 
 pub trait SplitAggregateAssignment<'tcx> {
     /// Transforms an assignment into its atomic parts. For a normal assignment like
@@ -21,29 +21,36 @@ pub trait SplitAggregateAssignment<'tcx> {
     /// ```
     ///
     /// Statements that are no assignments are returned untouched.
-    fn split_assignment(self,
+    fn split_assignment(
+        self,
         tcx: ty::TyCtxt<'tcx>,
-        mir: &mir::Body<'tcx>
+        mir: &mir::Body<'tcx>,
     ) -> Vec<mir::Statement<'tcx>>;
 }
 
 impl<'tcx> SplitAggregateAssignment<'tcx> for mir::Statement<'tcx> {
-    fn split_assignment(self,
+    fn split_assignment(
+        self,
         tcx: ty::TyCtxt<'tcx>,
-        mir: &mir::Body<'tcx>
+        mir: &mir::Body<'tcx>,
     ) -> Vec<mir::Statement<'tcx>> {
         let (lhs, rhs) = match self.kind {
             mir::StatementKind::Assign(box (lhs, rhs)) => (lhs, rhs),
-            _ => return vec![self]
+            _ => return vec![self],
         };
 
         let atomic_assignments = match rhs {
             mir::Rvalue::Aggregate(box kind, operands) => {
-                assert_eq!(kind, mir::AggregateKind::Tuple,
-                    "The only supported aggregates are tuples.");
+                assert_eq!(
+                    kind,
+                    mir::AggregateKind::Tuple,
+                    "The only supported aggregates are tuples."
+                );
                 let local = lhs.as_local().unwrap();
                 let items_ty = mir.local_decls[local].ty.tuple_items().unwrap();
-                operands.into_iter().zip(items_ty.into_iter())
+                operands
+                    .into_iter()
+                    .zip(items_ty.into_iter())
                     .enumerate()
                     .map(|(i, (rhs, ty))| {
                         let field = mir::Field::new(i);
@@ -53,16 +60,19 @@ impl<'tcx> SplitAggregateAssignment<'tcx> for mir::Statement<'tcx> {
                     })
                     .collect()
             }
-            mir::Rvalue::Use(_) |
-            mir::Rvalue::Ref(_, _, _) => vec![(lhs, rhs)],
+            mir::Rvalue::Use(_) | mir::Rvalue::Ref(_, _, _) => vec![(lhs, rhs)],
             // slice creation is ok
-            mir::Rvalue::Cast(mir::CastKind::Pointer(ty::adjustment::PointerCast::Unsize), _, cast_ty)
-                if cast_ty.is_slice_ref() => vec![(lhs, rhs)],
-            _ => unreachable!("Rvalue {:?} is not supported", rhs)
+            mir::Rvalue::Cast(
+                mir::CastKind::Pointer(ty::adjustment::PointerCast::Unsize),
+                _,
+                cast_ty,
+            ) if cast_ty.is_slice_ref() => vec![(lhs, rhs)],
+            _ => unreachable!("Rvalue {:?} is not supported", rhs),
         };
 
         let source_info = self.source_info;
-        atomic_assignments.into_iter()
+        atomic_assignments
+            .into_iter()
             .map(|(lhs, rhs)| {
                 let kind = mir::StatementKind::Assign(box (lhs, rhs));
                 mir::Statement { source_info, kind }

--- a/prusti-interface/src/environment/mir_utils/statement_as_assign.rs
+++ b/prusti-interface/src/environment/mir_utils/statement_as_assign.rs
@@ -14,4 +14,3 @@ impl<'tcx> StatementAsAssign<'tcx> for mir::Statement<'tcx> {
         }
     }
 }
-

--- a/prusti-interface/src/environment/mir_utils/statement_at.rs
+++ b/prusti-interface/src/environment/mir_utils/statement_at.rs
@@ -21,4 +21,3 @@ impl<'tcx> StatementAt<'tcx> for mir::Body<'tcx> {
         }
     }
 }
-

--- a/prusti-interface/src/environment/mir_utils/tuple_items_for_ty.rs
+++ b/prusti-interface/src/environment/mir_utils/tuple_items_for_ty.rs
@@ -15,4 +15,3 @@ impl<'tcx> TupleItemsForTy<'tcx> for ty::Ty<'tcx> {
         }
     }
 }
-

--- a/prusti-interface/src/environment/mir_utils/ty_as_ty_ref.rs
+++ b/prusti-interface/src/environment/mir_utils/ty_as_ty_ref.rs
@@ -1,7 +1,7 @@
-use prusti_rustc_interface::middle::mir::terminator::Mutability;
-use prusti_rustc_interface::middle::ty::Region;
-use prusti_rustc_interface::middle::ty::Ty;
-use prusti_rustc_interface::middle::ty::TyKind;
+use prusti_rustc_interface::middle::{
+    mir::Mutability,
+    ty::{Region, Ty, TyKind},
+};
 
 pub trait TyAsRef<'tcx> {
     fn as_ty_ref(&self) -> Option<(Region<'tcx>, Ty<'tcx>, Mutability)>;
@@ -10,9 +10,8 @@ pub trait TyAsRef<'tcx> {
 impl<'tcx> TyAsRef<'tcx> for Ty<'tcx> {
     fn as_ty_ref(&self) -> Option<(Region<'tcx>, Ty<'tcx>, Mutability)> {
         match self.kind() {
-            TyKind::Ref(region, ty, mutability) =>
-                Some((*region, *ty, *mutability)),
-            _ => None
+            TyKind::Ref(region, ty, mutability) => Some((*region, *ty, *mutability)),
+            _ => None,
         }
     }
 }

--- a/prusti-interface/src/specs/typed.rs
+++ b/prusti-interface/src/specs/typed.rs
@@ -326,7 +326,7 @@ pub struct Pledge {
 
 /// A specification, such as preconditions or a `#[pure]` annotation.
 /// Contains information about the refinement of these specifications.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpecificationItem<T> {
     /// Represents an empty specification, i.e. when the user has not defined the property
     Empty,

--- a/prusti-viper/src/encoder/middle/core_proof/lowerer/functions/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lowerer/functions/interface.rs
@@ -64,14 +64,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 .encode_snapshot_valid_call_for_type(result.clone(), &function_decl.return_type)?;
             posts.push(result_validity);
             let gas_amount = self.function_gas_constant(2)?;
-            let function =
-                vir_low::FunctionDecl::new(
-                    caller_function_name,
-                    parameters.clone(),
-                    return_type.clone(),
-                    pres.clone(),
-                    posts.clone(),
-                    Some(self.create_domain_func_app(
+            let function = vir_low::FunctionDecl::new(
+                caller_function_name,
+                parameters.clone(),
+                return_type.clone(),
+                pres.clone(),
+                posts.clone(),
+                Some(
+                    self.create_domain_func_app(
                         "Functions",
                         function_name.clone(),
                         parameters
@@ -81,8 +81,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                             .collect(),
                         return_type.clone(),
                         Default::default(),
-                    )?),
-                );
+                    )?,
+                ),
+            );
             self.functions_state
                 .functions
                 .insert(function_name.clone(), function);

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5304,7 +5304,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             let block = &self.mir.basic_blocks()[location.block];
             assert_eq!(block.statements.len(), location.statement_index, "expected terminator location");
             match &block.terminator().kind {
-                mir::terminator::TerminatorKind::Call{ args, destination, .. } => {
+                mir::TerminatorKind::Call{ args, destination, .. } => {
                     let tcx = self.encoder.env().tcx();
                     let arg_tys = args.iter().map(|arg| arg.ty(self.mir, tcx)).collect();
                     let return_ty = destination.ty(self.mir, tcx).ty;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-06-15"
+channel = "nightly-2022-07-01"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-std", "rustfmt", "clippy" ]
 profile = "minimal"

--- a/x.py
+++ b/x.py
@@ -69,6 +69,7 @@ RUSTFMT_PATHS = [
     'prusti-interface/src/environment/mir_sets/mod.rs',
     'prusti-interface/src/environment/mir_body/mod.rs',
     'prusti-interface/src/environment/debug_utils/mod.rs',
+    'prusti-interface/src/environment/mir_utils/mod.rs',
     'prusti-tests/tests/verify_partial/**/*.rs',
     'prusti-viper/src/encoder/foldunfold/mod.rs',
     'prusti-viper/src/encoder/mir/mod.rs',


### PR DESCRIPTION
* [x] Update Viper version to `v-2022-06-09-1135`.
* [x] Update rustc version to `nightly-2022-07-01`.
* [x] Manualy update outdated dependencies (see the list below).
* [x] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ cargo outdated --root-deps-only --workspace

info: syncing channel updates for 'nightly-2022-07-01-x86_64-unknown-linux-gnu'
info: latest update on 2022-07-01, rust version 1.64.0-nightly (7425fb293 2022-06-30)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'llvm-tools-preview'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustc-dev'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'llvm-tools-preview'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustc-dev'
info: installing component 'rustfmt'
    Updating git repository `https://github.com/rust-lang/cargo.git`
analysis
================
Name        Project  Compat  Latest  Kind    Platform
----        -------  ------  ------  ----    --------
serde_json  1.0.81   ---     1.0.82  Normal  ---
syn         1.0.96   ---     1.0.98  Normal  ---

vir
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.39   ---     1.0.40  Normal  ---
quote        1.0.18   ---     1.0.20  Normal  ---
syn          1.0.96   ---     1.0.98  Normal  ---

vir-gen
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.39   ---     1.0.40  Normal  ---
quote        1.0.18   ---     1.0.20  Normal  ---
syn          1.0.96   ---     1.0.98  Normal  ---

prusti-contracts-internal
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.39   ---     1.0.40  Normal  ---

prusti-specs
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
proc-macro2  1.0.39   ---     1.0.40  Normal  ---
quote        1.0.18   ---     1.0.20  Normal  ---
serde_json   1.0.81   ---     1.0.82  Normal  ---
syn          1.0.96   ---     1.0.98  Normal  ---

prusti-server
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
clap  3.2.5    ---     3.2.8   Normal  ---

prusti-smt-solver
================
Name       Project  Compat  Latest  Kind    Platform
----       -------  ------  ------  ----    --------
async-std  1.11.0   ---     1.12.0  Normal  ---

test-crates
================
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
clap  3.2.5    ---     3.2.8   Normal  ---
```
</details>

@vakaras could you take care of this?