### PR TITLE
Lifetime encoding Fixes and Extensions

### DIFF
--- a/prusti-interface/src/environment/debug_utils/to_text.rs
+++ b/prusti-interface/src/environment/debug_utils/to_text.rs
@@ -64,6 +64,20 @@ impl ToText
     }
 }
 
+impl ToText for prusti_rustc_interface::middle::ty::BoundRegionKind {
+    fn to_text(&self) -> String {
+        match self {
+            prusti_rustc_interface::middle::ty::BoundRegionKind::BrAnon(id) => {
+                format!("lft_br_anon_{}", id)
+            }
+            prusti_rustc_interface::middle::ty::BoundRegionKind::BrNamed(_, name) => {
+                format!("lft_br_named_{}", name)
+            }
+            prusti_rustc_interface::middle::ty::BoundRegionKind::BrEnv => "lft_br_env".to_string(),
+        }
+    }
+}
+
 impl ToText for BTreeSet<prusti_rustc_interface::middle::ty::RegionVid> {
     fn to_text(&self) -> String {
         let strings: Vec<_> = self.iter().map(|r| r.to_text()).collect();

--- a/prusti-tests/tests/verify/fail/unsupported/async.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/async.rs
@@ -1,4 +1,4 @@
-pub async fn connect<D>(dst: D) //~ ERROR unsupported type
+pub async fn connect<D>(dst: D)
 where
     D: std::convert::TryInto<u32>
 { //~ ERROR unsupported type

--- a/prusti-tests/tests/verify/fail/unsupported/async2.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/async2.rs
@@ -2,10 +2,10 @@ pub struct QueryClient {
 }
 impl QueryClient
 {
-    pub async fn accounts( //~ ERROR unsupported type
+    pub async fn accounts(
         &mut self,
         _request: u32
-    ) -> Result<u32, u32> { //~ ERROR generator fields are not supported yet
+    ) -> Result<u32, u32> { //~ ERROR unsupported type
         unimplemented!()
     }
 }

--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/enums.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/enums.rs
@@ -1,0 +1,141 @@
+// compile-flags: -Punsafe_core_proof=true
+
+use prusti_contracts::*;
+fn main() {}
+
+enum Enum1 {
+    A(i32),
+    B(i32),
+}
+fn test1() {
+    let x = Enum1::A(4);
+    let y = &x;
+}
+fn test1_assert_false() {
+    let x = Enum1::A(4);
+    let y = &x;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+fn test2() {
+    let mut x = Enum1::A(4);
+    let mut y = &mut x;
+    let z = &mut y;
+}
+fn test2_assert_false() {
+    let mut x = Enum1::A(4);
+    let mut y = &mut x;
+    let z = &mut y;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+enum Enum2<'a> {
+    A(&'a mut i32),
+    B(&'a i32)
+}
+fn test3() {
+    let mut n = 4;
+    let x = Enum2::A(&mut n);
+    let y = &x;
+}
+fn test3_assert_false() {
+    let mut n = 4;
+    let x = Enum2::A(&mut n);
+    let y = &x;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+fn test4() {
+    let n = 4;
+    let x = Enum2::B(&n);
+    let y = &x;
+}
+fn test4_assert_false() {
+    let n = 4;
+    let x = Enum2::B(&n);
+    let y = &x;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+fn test5() {
+    let mut n = 4;
+    let mut x = Enum2::A(&mut n);
+    let y = &mut x;
+}
+fn test5_assert_false() {
+    let mut n = 4;
+    let mut x = Enum2::A(&mut n);
+    let y = &mut x;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+fn test6() {
+    let n = 4;
+    let mut x = Enum2::B(&n);
+    let y = &mut x;
+}
+fn test6_assert_false() {
+    let n = 4;
+    let mut x = Enum2::B(&n);
+    let y = &mut x;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+struct A<'a>{
+    x: &'a mut i32,
+}
+struct B<'a>{
+    x: &'a mut i32,
+}
+enum Enum3<'a, 'b> {
+    A(&'b mut A<'a>),
+    B(&'b mut B<'a>),
+}
+fn test7(){
+    let mut n = 5;
+    let mut b = B{ x: &mut n };
+    let mut x = Enum3::B(&mut b);
+    let y = &mut x;
+}
+fn test7_assert_false(){
+    let mut n = 5;
+    let mut b = B{ x: &mut n };
+    let mut x = Enum3::B(&mut b);
+    let y = &mut x;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+struct C<'a>{
+    x: &'a mut i32,
+}
+struct D<'a>{
+    x: &'a i32,
+}
+enum Enum4<'a, 'b> {
+    A(&'b mut D<'a>),
+    B(&'b C<'a>),
+}
+fn test8(){
+    // Enum with shared reference to struct with mutable reference
+    let mut n = 5;
+    let mut c = C{ x: &mut n };
+    let mut x = Enum4::B(&c);
+    let r = &mut x;
+}
+fn test8_assert_false(){
+    let mut n = 5;
+    let mut c = C{ x: &mut n };
+    let mut x = Enum4::B(&c);
+    let r = &mut x;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+fn test9(){
+    // Enum with mutable reference to struct with shared reference
+    let n = 5;
+    let mut d = D{ x: &n };
+    let mut a = Enum4::A(&mut d);
+    let r = &mut a;
+}
+fn test9_assert_false(){
+    let n = 5;
+    let mut b = D{ x: &n };
+    let mut e = Enum4::A(&mut b);
+    let r = &mut e;
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}

--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/loops.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/loops.rs
@@ -1,0 +1,39 @@
+// compile-flags: -Punsafe_core_proof=true
+
+use prusti_contracts::*;
+fn main(){}
+
+#[trusted]
+struct WrapperIterator<'a, T>{
+    iter_mut: std::slice::IterMut<'a, T>,
+}
+impl<'a, T> WrapperIterator<'a, T> {
+    #[trusted]
+    fn new(x: &'a mut Vec<T>) -> Self {
+        WrapperIterator {
+            iter_mut: x.iter_mut(),
+        }
+    }
+}
+impl<'a, T> Iterator for WrapperIterator<'a, T> {
+    type Item = &'a mut T;
+    #[trusted]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter_mut.next()
+    }
+}
+fn test1() {
+    let mut ve = Vec::new();
+    let mut v: WrapperIterator<i32> = WrapperIterator::new(&mut ve);
+    for x in &mut v {
+        // *x = 4;
+    }
+}
+fn test1_assert_false() {
+    let mut ve = Vec::new();
+    let mut v: WrapperIterator<i32> = WrapperIterator::new(&mut ve);
+    for x in &mut v {
+        // *x = 4;
+    }
+    assert!(false) //~ ERROR
+}

--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/simple.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/simple.rs
@@ -6,23 +6,42 @@ fn main() {}
 pub fn mutable_borrow() {
     let mut a = 4;
     let x = &mut a;
+    *x = 2;
+    assert!(*x == 2);
 }
 pub fn mutable_borrow_assert_false() {
     let mut a = 4;
     let x = &mut a;
-    assert!(false);      //~ ERROR: the asserted expression might not hold
+    *x = 2;
+    assert!(*x == 4);      //~ ERROR: the asserted expression might not hold
+}
+
+pub fn mutable_reborrow() {
+    let mut a = 4;
+    let mut x = &mut a;
+    let y = &mut (*x);
+    *y = 3;
+    assert!(*y == 3);
+}
+pub fn mutable_reborrow_assert_false() {
+    let mut a = 4;
+    let mut x = &mut a;
+    let y = &mut (*x);
+    *y = 3;
+    assert!(*y == 4);      //~ ERROR: the asserted expression might not hold
 }
 
 pub fn shared_borrow() {
     let mut a = 4;
     let x = &a;
     let y = &a;
+    assert!(*y == 4);
 }
 pub fn shared_borrow_assert_false() {
     let mut a = 4;
     let x = &a;
     let y = &a;
-    assert!(false);      //~ ERROR: the asserted expression might not hold
+    assert!(*y == 5);      //~ ERROR: the asserted expression might not hold
 }
 
 pub fn shared_reborrow() {
@@ -30,11 +49,20 @@ pub fn shared_reborrow() {
     let x = &a;
     let y = &(*x);
     let z = &(*x);
+    assert!(*z == 4);
 }
 pub fn shared_reborrow_assert_false() {
     let mut a = 4;
     let x = &a;
     let y = &(*x);
     let z = &(*x);
-    assert!(false);      //~ ERROR: the asserted expression might not hold
+    assert!(*z == 5);      //~ ERROR: the asserted expression might not hold
 }
+
+// FIXME: Fix overlapping shared references
+// pub fn shared_borrow() {
+//     let mut a = 4;
+//     let x = &a;
+//     let y = &a;
+//     assert!(*x == 4);
+// }

--- a/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/structs.rs
+++ b/prusti-tests/tests/verify_overflow/fail/unsafe_core_proof/structs.rs
@@ -23,12 +23,13 @@ fn simple_struct_shared() {
     let mut x = S1{ x: 4 };
     let y = &x;
     let z = &x;
+    assert!(z.x == 4);
 }
 fn simple_struct_shared_assert_false() {
     let mut x = S1{ x: 4 };
     let y = &x;
     let z = &x;
-    assert!(false);      //~ ERROR: the asserted expression might not hold
+    assert!(z.x == 5);      //~ ERROR: the asserted expression might not hold
 }
 
 struct S2<'a> {
@@ -36,43 +37,101 @@ struct S2<'a> {
 }
 fn struct_with_mut_reference () {
     let mut n = 4;
-    let mut t = S2{ x: &mut n};
+    let t = S2{ x: &mut n};
+    let u = &t;
 }
 fn struct_with_mut_reference_assert_false () {
     let mut n = 4;
     let mut t = S2{ x: &mut n};
+    let u = &t;
     assert!(false);      //~ ERROR: the asserted expression might not hold
 }
 
 struct S3<'a> {
     x: &'a u32,
 }
-// FIXME: Use lifetimes from generic arguments.
-//  fn struct_with_shared_reference () {
-//      let mut n = 4;
-//      let mut t = S3{ x: &n};
-//      let mut u = S3{ x: &n};
-//  }
+fn struct_with_shared_reference () {
+    let n = 4;
+    let mut t1 = S3{ x: &n};
+    let mut t2 = S3{ x: &n};
+    let u = &mut t2;
+}
 fn struct_with_shared_reference_assert_false () {
-    let mut n = 4;
-    let mut t = S3{ x: &n};
-    let mut u = S3{ x: &n};
+    let n = 4;
+    let mut t1 = S3{ x: &n};
+    let mut t2 = S3{ x: &n};
+    let u = &mut t2;
     assert!(false);      //~ ERROR: the asserted expression might not hold
 }
 
+struct S4I<'a> {
+    x: &'a mut u32,
+}
+struct S4O<'a, 'b> {
+    x: &'b mut S4I<'a>,
+}
+fn nested_struct_with_mutable_reference () {
+    let mut n = 4;
+    let mut i = S4I { x: &mut n };
+    let mut o = S4O { x: &mut i };
+}
+fn nested_struct_with_mutable_reference_assert_false () {
+    let mut n = 4;
+    let mut i = S4I { x: &mut n };
+    let mut o = S4O { x: &mut i };
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+struct S5I<'a> {
+    x: &'a u32,
+}
+struct S5O<'a, 'b> {
+    x: &'b S5I<'a>,
+}
+fn nested_struct_with_shared_reference () {
+    let n = 4;
+    let i = S5I { x: &n };
+    let o = S5O { x: &i };
+}
+fn nested_struct_with_shared_reference_assert_false () {
+    let n = 4;
+    let i = S5I { x: &n };
+    let o = S5O { x: &i };
+    assert!(false);      //~ ERROR: the asserted expression might not hold
+}
+
+// FIXME: Nested structs with "shared" lifetimes don't work due to "lifetime extension"
+// struct S6I<'a> {
+//     x: &'a u32,
+// }
+// struct S6O<'a> {
+//     x: &'a S6I<'a>,
+// }
+// fn nested_struct_same_lifetime_with_shared_reference () {
+//     let n = 4;
+//     let i = S6I { x: &n };
+//     let o = S6O { x: &i };
+// }
+// fn nested_struct_same_lifetime_with_shared_reference_assert_false () {
+//     let n = 4;
+//     let i = S6I { x: &n };
+//     let o = S6O { x: &i };
+//     assert!(false);            the asserted expression might not hold
+// }
+
 // FIXME: accessing references of structs panics
-// struct S3<'a> {
+// struct S7<'a> {
 //     x: &'a mut u32,
 // }
 // fn struct_with_reference_and_access () {
 //     let mut n = 4;
-//     let mut t = S2{ x: &mut n};
+//     let mut t = S7{ x: &mut n};
 //     *t.x = 5;
 // }
 // FIXME: accessing references of structs panics
 // fn struct_with_reference_and_access_assert_false () {
 //     let mut n = 4;
-//     let mut t = S2{ x: &mut n};
+//     let mut t = S7{ x: &mut n};
 //     *t.x = 5;
 //     assert!(false);           the asserted expression might not hold
 // }

--- a/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/semantics.rs
@@ -397,7 +397,7 @@ impl CollectPermissionChanges for vir_high::ast::rvalue::Reborrow {
         consumed_permissions.push(Permission::Owned(self.place.clone()));
         if self.is_mut {
             produced_permissions.push(Permission::MutBorrowed(MutBorrowed {
-                lifetime: self.place_lifetime.clone(),
+                lifetime: self.operand_lifetime.clone(),
                 place: self.place.clone(),
             }));
         } else {
@@ -416,7 +416,7 @@ impl CollectPermissionChanges for vir_high::ast::rvalue::Ref {
     ) -> SpannedEncodingResult<()> {
         consumed_permissions.push(Permission::Owned(self.place.clone()));
         produced_permissions.push(Permission::MutBorrowed(MutBorrowed {
-            lifetime: self.lifetime.clone(),
+            lifetime: self.operand_lifetime.clone(),
             place: self.place.clone(),
         }));
         Ok(())

--- a/prusti-viper/src/encoder/high/procedures/inference/state.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/state.rs
@@ -3,7 +3,10 @@ use crate::encoder::errors::SpannedEncodingResult;
 use log::debug;
 use std::collections::{BTreeMap, BTreeSet};
 use vir_crate::{
-    high::{self as vir_high, operations::ty::Typed},
+    high::{
+        self as vir_high,
+        operations::{lifetimes::WithLifetimes, ty::Typed},
+    },
     middle as vir_mid,
 };
 

--- a/prusti-viper/src/encoder/high/procedures/inference/visitor/context.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/visitor/context.rs
@@ -48,9 +48,8 @@ impl<'p, 'v, 'tcx> super::super::ensurer::Context for Visitor<'p, 'v, 'tcx> {
             }
             vir_high::TypeDecl::TypeVar(_) => unimplemented!("ty: {}", ty),
             vir_high::TypeDecl::Tuple(tuple_decl) => expand_fields(place, tuple_decl.iter_fields()),
-            vir_high::TypeDecl::Struct(struct_decl) => {
-                expand_fields(place, struct_decl.iter_fields())
-            }
+            vir_high::TypeDecl::Trusted(decl) => expand_fields(place, decl.iter_fields()),
+            vir_high::TypeDecl::Struct(decl) => expand_fields(place, decl.iter_fields()),
             vir_high::TypeDecl::Union(_) => {
                 let variant_name = place.get_variant_name(guiding_place);
                 let variant_place = place.clone().into_variant(variant_name.clone());
@@ -90,7 +89,6 @@ impl<'p, 'v, 'tcx> super::super::ensurer::Context for Visitor<'p, 'v, 'tcx> {
             vir_high::TypeDecl::Never => unimplemented!("ty: {}", ty),
             vir_high::TypeDecl::Closure(_) => unimplemented!("ty: {}", ty),
             vir_high::TypeDecl::Unsupported(_) => unimplemented!("ty: {}", ty),
-            vir_high::TypeDecl::Trusted(_) => unimplemented!("ty: {}", ty),
         };
         Ok(expansion)
     }

--- a/prusti-viper/src/encoder/high/procedures/inference/visitor/context.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/visitor/context.rs
@@ -46,9 +46,9 @@ impl<'p, 'v, 'tcx> super::super::ensurer::Context for Visitor<'p, 'v, 'tcx> {
                 // Primitive type. Convert.
                 vec![(ExpandedPermissionKind::MemoryBlock, place.clone())]
             }
+            vir_high::TypeDecl::Trusted(_) => unimplemented!("ty: {}", ty),
             vir_high::TypeDecl::TypeVar(_) => unimplemented!("ty: {}", ty),
             vir_high::TypeDecl::Tuple(tuple_decl) => expand_fields(place, tuple_decl.iter_fields()),
-            vir_high::TypeDecl::Trusted(decl) => expand_fields(place, decl.iter_fields()),
             vir_high::TypeDecl::Struct(decl) => expand_fields(place, decl.iter_fields()),
             vir_high::TypeDecl::Union(_) => {
                 let variant_name = place.get_variant_name(guiding_place);

--- a/prusti-viper/src/encoder/high/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/high/pure_functions/interface.rs
@@ -89,6 +89,7 @@ impl<'v, 'tcx: 'v> HighPureFunctionEncoderInterface<'tcx>
     }
 
     /// Encode subslicing of an array/slice.
+    // FIXME: Check if encode_subslice_call is used and tested
     fn encode_subslice_call(
         &self,
         container: vir_high::Expression,
@@ -101,7 +102,8 @@ impl<'v, 'tcx: 'v> HighPureFunctionEncoderInterface<'tcx>
         let return_type = vir_high::Type::reference(
             pure_lifetime,
             vir_high::ty::Uniqueness::Shared,
-            vir_high::Type::slice(element_type.clone()),
+            // FIXME: add slice lifetimes for subslice_call
+            vir_high::Type::slice(element_type.clone(), vec![]),
         );
         Ok(vir_high::Expression::function_call(
             name,

--- a/prusti-viper/src/encoder/high/types/fields.rs
+++ b/prusti-viper/src/encoder/high/types/fields.rs
@@ -26,6 +26,7 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
         // For composed data structures, we typically use a snapshot rather than a field.
         // To unify how parameters are passed to functions, we treat them like a reference.
         vir::Type::Tuple(_)
+        | vir::Type::Trusted(_)
         | vir::Type::Struct(_)
         | vir::Type::Enum(_)
         | vir::Type::Closure(_)
@@ -49,8 +50,7 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
         | vir::Type::Never
         | vir::Type::Str
         | vir::Type::Projection(_)
-        | vir::Type::Unsupported(_)
-        | vir::Type::Trusted(_) => {
+        | vir::Type::Unsupported(_) => {
             return Err(EncodingError::unsupported(format!(
                 "{} type is not supported",
                 ty

--- a/prusti-viper/src/encoder/high/types/interface.rs
+++ b/prusti-viper/src/encoder/high/types/interface.rs
@@ -258,12 +258,12 @@ impl<'v, 'tcx: 'v> HighTypeEncoderInterface<'tcx> for super::super::super::Encod
             | vir_mid::TypeDecl::Int(_)
             | vir_mid::TypeDecl::Float(_)
             | vir_mid::TypeDecl::TypeVar(_)
-            | vir_mid::TypeDecl::Trusted(_)
             | vir_mid::TypeDecl::Reference(_)
             | vir_mid::TypeDecl::Pointer(_)
             | vir_mid::TypeDecl::Sequence(_)
             | vir_mid::TypeDecl::Map(_) => false,
             vir_mid::TypeDecl::Tuple(decl) => decl.arguments.is_empty(),
+            vir_mid::TypeDecl::Trusted(decl) => decl.fields.is_empty(),
             vir_mid::TypeDecl::Struct(decl) => decl.fields.is_empty(),
             vir_mid::TypeDecl::Enum(decl) => decl.variants.is_empty(),
             vir_mid::TypeDecl::Union(decl) => decl.variants.is_empty(),

--- a/prusti-viper/src/encoder/high/types/interface.rs
+++ b/prusti-viper/src/encoder/high/types/interface.rs
@@ -257,13 +257,13 @@ impl<'v, 'tcx: 'v> HighTypeEncoderInterface<'tcx> for super::super::super::Encod
             vir_mid::TypeDecl::Bool
             | vir_mid::TypeDecl::Int(_)
             | vir_mid::TypeDecl::Float(_)
+            | vir_mid::TypeDecl::Trusted(_)
             | vir_mid::TypeDecl::TypeVar(_)
             | vir_mid::TypeDecl::Reference(_)
             | vir_mid::TypeDecl::Pointer(_)
             | vir_mid::TypeDecl::Sequence(_)
             | vir_mid::TypeDecl::Map(_) => false,
             vir_mid::TypeDecl::Tuple(decl) => decl.arguments.is_empty(),
-            vir_mid::TypeDecl::Trusted(decl) => decl.fields.is_empty(),
             vir_mid::TypeDecl::Struct(decl) => decl.fields.is_empty(),
             vir_mid::TypeDecl::Enum(decl) => decl.variants.is_empty(),
             vir_mid::TypeDecl::Union(decl) => decl.variants.is_empty(),

--- a/prusti-viper/src/encoder/middle/core_proof/builtin_methods/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/builtin_methods/interface.rs
@@ -30,7 +30,10 @@ use vir_crate::{
         identifier::WithIdentifier,
     },
     low::{self as vir_low, macros::method_name},
-    middle::{self as vir_mid, operations::ty::Typed},
+    middle::{
+        self as vir_mid,
+        operations::{lifetimes::WithLifetimes, ty::Typed},
+    },
 };
 
 #[derive(Default)]

--- a/prusti-viper/src/encoder/middle/core_proof/compute_address/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/compute_address/interface.rs
@@ -112,6 +112,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ComputeAddressInterface for Lowerer<'p, 'v, 'tcx> {
                 | vir_mid::TypeDecl::Int(_)
                 | vir_mid::TypeDecl::Float(_)
                 | vir_mid::TypeDecl::Pointer(_)
+                | vir_mid::TypeDecl::Trusted(_)
                 | vir_mid::TypeDecl::TypeVar(_)
                 | vir_mid::TypeDecl::Sequence(_)
                 | vir_mid::TypeDecl::Map(_) => {
@@ -120,13 +121,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ComputeAddressInterface for Lowerer<'p, 'v, 'tcx> {
                 vir_mid::TypeDecl::Tuple(decl) => {
                     for field in decl.iter_fields() {
                         let axiom = self.encode_compute_address_axiom_for_field(ty, &field)?;
-                        self.compute_address_state.axioms.push(axiom);
-                        self.encode_compute_address(&field.ty)?;
-                    }
-                }
-                vir_mid::TypeDecl::Trusted(decl) => {
-                    for field in &decl.fields {
-                        let axiom = self.encode_compute_address_axiom_for_field(ty, field)?;
                         self.compute_address_state.axioms.push(axiom);
                         self.encode_compute_address(&field.ty)?;
                     }

--- a/prusti-viper/src/encoder/middle/core_proof/lifetimes/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lifetimes/interface.rs
@@ -10,6 +10,7 @@ use std::collections::VecDeque;
 use vir_crate::{
     common::expression::{BinaryOperationHelpers, QuantifierHelpers},
     low as vir_low, middle as vir_mid,
+    middle::operations::lifetimes::WithLifetimes,
 };
 
 #[derive(Default)]

--- a/prusti-viper/src/encoder/middle/core_proof/predicates/owned/encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/predicates/owned/encoder.rs
@@ -21,6 +21,7 @@ use vir_crate::{
     common::expression::{ExpressionIterator, QuantifierHelpers},
     low::{self as vir_low},
     middle as vir_mid,
+    middle::operations::lifetimes::WithLifetimes,
 };
 
 pub(super) struct PredicateEncoder<'l, 'p, 'v, 'tcx> {

--- a/prusti-viper/src/encoder/middle/core_proof/predicates/owned/encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/predicates/owned/encoder.rs
@@ -3,6 +3,7 @@ use crate::encoder::{
     high::types::HighTypeEncoderInterface,
     middle::core_proof::{
         compute_address::ComputeAddressInterface,
+        lifetimes::LifetimesInterface,
         lowerer::Lowerer,
         places::PlacesInterface,
         predicates::{PredicatesMemoryBlockInterface, PredicatesOwnedInterface},
@@ -53,14 +54,13 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
 
     pub(super) fn encode_owned_non_aliased(
         &mut self,
-        ty_with_lifetime: &vir_mid::Type,
+        ty: &vir_mid::Type,
     ) -> SpannedEncodingResult<()> {
-        let ty: &mut vir_mid::Type = &mut ty_with_lifetime.clone();
-        ty.erase_lifetime();
-        if self.encoded_owned_predicates.contains(ty) {
+        let ty_without_lifetime = ty.clone().erase_lifetimes();
+        if self.encoded_owned_predicates.contains(&ty_without_lifetime) {
             return Ok(());
         }
-        self.encoded_owned_predicates.insert(ty.clone());
+        self.encoded_owned_predicates.insert(ty_without_lifetime);
         self.lowerer.encode_compute_address(ty)?;
         use vir_low::macros::*;
         let position = Default::default();
@@ -98,19 +98,24 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                     )}
                 }
             }
-            vir_mid::TypeDecl::TypeVar(_) | vir_mid::TypeDecl::Trusted(_) => {
-                vir_low::PredicateDecl::new(
-                    predicate_name! { OwnedNonAliased<ty> },
-                    vars! { place: Place, root_address: Address, snapshot: {snapshot_type} },
-                    None,
-                )
-            }
+            vir_mid::TypeDecl::TypeVar(_) => vir_low::PredicateDecl::new(
+                predicate_name! { OwnedNonAliased<ty> },
+                vars! { place: Place, root_address: Address, snapshot: {snapshot_type} },
+                None,
+            ),
             vir_mid::TypeDecl::Tuple(tuple_decl) => self.encode_owned_non_aliased_with_fields(
                 ty,
                 snapshot,
                 snapshot_type,
                 validity,
                 tuple_decl.iter_fields(),
+            )?,
+            vir_mid::TypeDecl::Trusted(decl) => self.encode_owned_non_aliased_with_fields(
+                ty,
+                snapshot,
+                snapshot_type,
+                validity,
+                decl.iter_fields(),
             )?,
             vir_mid::TypeDecl::Struct(struct_decl) => self.encode_owned_non_aliased_with_fields(
                 ty,
@@ -124,6 +129,13 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                 let discriminant_call =
                     self.lowerer
                         .obtain_enum_discriminant(snapshot.clone().into(), ty, position)?;
+                let mut lifetimes_ty = vec![];
+                for lifetime in ty.get_lifetimes() {
+                    lifetimes_ty.push(vir_low::VariableDecl {
+                        name: lifetime.name.clone(),
+                        ty: ty!(Lifetime),
+                    });
+                }
                 for (&discriminant, variant) in decl.discriminant_values.iter().zip(&decl.variants)
                 {
                     let variant_index = variant.name.clone().into();
@@ -149,10 +161,24 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                         self.encode_owned_non_aliased(&variant_type)?;
                     }
                     let variant_type = &variant_type;
+                    let lifetimes_field_ty: Vec<vir_low::VariableDecl> = variant_type
+                        .get_lifetimes()
+                        .iter()
+                        .map(|x| vir_low::VariableDecl {
+                            name: x.name.clone(),
+                            ty: ty!(Lifetime),
+                        })
+                        .collect();
+                    let lifetimes_field_ty_expr: Vec<vir_low::Expression> = lifetimes_field_ty
+                        .clone()
+                        .iter()
+                        .cloned()
+                        .map(|x| x.into())
+                        .collect();
                     let acc = expr! {
                         ([ discriminant_call.clone() ] == [ discriminant.into() ]) ==>
                         (acc(OwnedNonAliased<variant_type>(
-                            [variant_place], root_address, [variant_snapshot]
+                            [variant_place], root_address, [variant_snapshot]; lifetimes_field_ty_expr
                         )))
                     };
                     variant_predicates.push(acc);
@@ -179,7 +205,12 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                     position,
                 )?;
                 predicate! {
-                    OwnedNonAliased<ty>(place: Place, root_address: Address, snapshot: {snapshot_type})
+                    OwnedNonAliased<ty>(
+                        place: Place,
+                        root_address: Address,
+                        snapshot: {snapshot_type},
+                        *lifetimes_ty
+                    )
                     {(
                         ([validity]) &&
                         (acc(OwnedNonAliased<discriminant_type>(
@@ -240,7 +271,8 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                 let element_type = &decl.element_type;
                 self.lowerer.encode_place_array_index_axioms(ty)?;
                 self.lowerer.ensure_type_definition(element_type)?;
-                let parameters = self.lowerer.extract_non_type_parameters_from_type(ty)?;
+                let parameters: Vec<vir_low::VariableDecl> =
+                    self.lowerer.extract_non_type_parameters_from_type(ty)?;
                 let parameters_validity: vir_low::Expression = self
                     .lowerer
                     .extract_non_type_parameters_from_type_validity(ty)?
@@ -334,19 +366,29 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                 let target_type = &reference.target_type;
                 let deref_place = self.lowerer.reference_deref_place(place.into(), position)?;
                 self.encode_unique_ref(target_type)?;
+                let mut lifetimes_ty = vec![];
+                for lifetime in reference.target_type.get_lifetimes() {
+                    lifetimes_ty.push(vir_low::VariableDecl {
+                        name: lifetime.name.clone(),
+                        ty: ty!(Lifetime),
+                    });
+                }
+                let lifetimes_ty_expr: Vec<vir_low::Expression> =
+                    lifetimes_ty.iter().cloned().map(|x| x.into()).collect();
                 predicate! {
                     OwnedNonAliased<ty>(
                         place: Place,
                         root_address: Address,
                         snapshot: {snapshot_type},
-                        lifetime: Lifetime
+                        lifetime: Lifetime,
+                        *lifetimes_ty
                     )
                     {(
                         ([validity]) &&
                         (acc(MemoryBlock([compute_address], [size_of]))) &&
                         (([bytes]) == (Snap<address_type>::to_bytes([target_address_snapshot]))) &&
                         (acc(UniqueRef<target_type>(
-                            lifetime, [deref_place], [target_address], [current_snapshot], [final_snapshot]
+                            [deref_place], [target_address], [current_snapshot], [final_snapshot], lifetime; lifetimes_ty_expr
                         )))
                     )}
                 }
@@ -371,21 +413,30 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                 )?;
                 let target_type = &reference.target_type;
                 let deref_place = self.lowerer.reference_deref_place(place.into(), position)?;
-                self.encode_unique_ref(target_type)?;
                 self.encode_frac_ref(target_type)?;
+                let mut lifetimes_ty = vec![];
+                for lifetime in reference.target_type.get_lifetimes() {
+                    lifetimes_ty.push(vir_low::VariableDecl {
+                        name: lifetime.name.clone(),
+                        ty: ty!(Lifetime),
+                    });
+                }
+                let lifetimes_ty_expr: Vec<vir_low::Expression> =
+                    lifetimes_ty.iter().cloned().map(|x| x.into()).collect();
                 predicate! {
                     OwnedNonAliased<ty>(
                         place: Place,
                         root_address: Address,
                         snapshot: {snapshot_type},
-                        lifetime: Lifetime
+                        lifetime: Lifetime,
+                        *lifetimes_ty
                     )
                     {(
                         ([validity]) &&
                         (acc(MemoryBlock([compute_address], [size_of]))) &&
                         (([bytes]) == (Snap<address_type>::to_bytes([target_address_snapshot]))) &&
                         (acc(FracRef<target_type>(
-                            lifetime, [deref_place], [target_address], [current_snapshot]
+                            [deref_place], [target_address], [current_snapshot], lifetime; lifetimes_ty_expr
                         )))
                     )}
                 }
@@ -413,8 +464,16 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
             root_address: Address
         }
         let mut field_predicates = Vec::new();
-        let mut lifetimes = Vec::new();
-        for (i, field) in fields.enumerate() {
+        let mut lifetimes_ty = vec![];
+        for lifetime in ty.get_lifetimes() {
+            lifetimes_ty.push(vir_low::VariableDecl {
+                name: lifetime.name.clone(),
+                ty: ty!(Lifetime),
+            });
+        }
+        let mut field_lifetimes = Vec::new();
+
+        for field in fields {
             let field_place = self.lowerer.encode_field_place(
                 ty,
                 &field,
@@ -436,24 +495,27 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                 // encode it as abstract predicate.
                 self.encode_owned_non_aliased(field_ty)?;
             }
-            if let vir_mid::Type::Reference(_) = field_ty {
-                let lifetime =
-                    vir_low::VariableDecl::new(format!("lft_field_{}", i), ty!(Lifetime));
-                lifetimes.push(lifetime.clone());
-                let acc = expr! {
-                    acc(OwnedNonAliased<field_ty>(
-                        [field_place], root_address, [field_value], [lifetime.into()]
-                    ))
-                };
-                field_predicates.push(acc);
-            } else {
-                let acc = expr! {
-                    acc(OwnedNonAliased<field_ty>(
-                        [field_place], root_address, [field_value]
-                    ))
-                };
-                field_predicates.push(acc);
-            }
+            let lifetimes_field_ty: Vec<vir_low::VariableDecl> = field_ty
+                .get_lifetimes()
+                .iter()
+                .map(|x| vir_low::VariableDecl {
+                    name: x.name.clone(),
+                    ty: ty!(Lifetime),
+                })
+                .collect();
+            let lifetimes_field_ty_expr: Vec<vir_low::Expression> = lifetimes_field_ty
+                .clone()
+                .iter()
+                .cloned()
+                .map(|x| x.into())
+                .collect();
+            field_lifetimes.extend(lifetimes_field_ty.clone());
+            let acc = expr! {
+                acc(OwnedNonAliased<field_ty>(
+                    [field_place], root_address, [field_value]; lifetimes_field_ty_expr
+                ))
+            };
+            field_predicates.push(acc);
         }
         if field_predicates.is_empty() {
             // TODO: Extract this into a separate method and deduplicate with
@@ -476,7 +538,7 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
             });
         }
         let predicate_decl = predicate! {
-            OwnedNonAliased<ty>(place: Place, root_address: Address, snapshot: {snapshot_type}, *lifetimes)
+            OwnedNonAliased<ty>(place: Place, root_address: Address, snapshot: {snapshot_type}, *lifetimes_ty)
             {(
                 ([validity]) &&
                 ([field_predicates.into_iter().conjoin()])
@@ -486,10 +548,15 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
     }
 
     fn encode_frac_ref(&mut self, ty: &vir_mid::Type) -> SpannedEncodingResult<()> {
-        if self.encoded_frac_borrow_predicates.contains(ty) {
+        let ty_without_lifetime = ty.clone().erase_lifetimes();
+        if self
+            .encoded_frac_borrow_predicates
+            .contains(&ty_without_lifetime)
+        {
             return Ok(());
         }
-        self.encoded_frac_borrow_predicates.insert(ty.clone());
+        self.encoded_frac_borrow_predicates
+            .insert(ty_without_lifetime);
         self.lowerer.encode_compute_address(ty)?;
         use vir_low::macros::*;
         let type_decl = self.lowerer.encoder.get_type_decl_mid(ty)?;
@@ -512,17 +579,16 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
             | vir_mid::TypeDecl::Pointer(_)
             | vir_mid::TypeDecl::Sequence(_)
             | vir_mid::TypeDecl::Map(_)
-            | vir_mid::TypeDecl::TypeVar(_)
-            | vir_mid::TypeDecl::Trusted(_) => vir_low::PredicateDecl::new(
+            | vir_mid::TypeDecl::TypeVar(_) => vir_low::PredicateDecl::new(
                 predicate_name! {FracRef<ty>},
-                vec![lifetime, place, root_address, snapshot],
+                vec![place, root_address, snapshot, lifetime],
                 None,
             ),
             vir_mid::TypeDecl::Tuple(_decl) => unimplemented!(),
-            vir_mid::TypeDecl::Struct(decl) => {
-                // TODO: test or add unimplemented!
+            vir_mid::TypeDecl::Trusted(vir_mid::type_decl::Trusted { fields, .. })
+            | vir_mid::TypeDecl::Struct(vir_mid::type_decl::Struct { fields, .. }) => {
                 let mut field_predicates = Vec::new();
-                for field in &decl.fields {
+                for field in fields {
                     let field_place = self.lowerer.encode_field_place(
                         ty,
                         field,
@@ -536,13 +602,29 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                         Default::default(),
                     )?;
                     let field_ty = &field.ty;
+                    let lifetimes_field_ty: Vec<vir_low::VariableDecl> = field_ty
+                        .get_lifetimes()
+                        .iter()
+                        .map(|x| vir_low::VariableDecl {
+                            name: x.name.clone(),
+                            ty: ty!(Lifetime),
+                        })
+                        .collect();
+                    let lifetimes_field_ty_expr: Vec<vir_low::Expression> = lifetimes_field_ty
+                        .clone()
+                        .iter()
+                        .cloned()
+                        .map(|x| x.into())
+                        .collect();
+                    // NOTE: field_ty may be a mutable reference
                     self.encode_frac_ref(field_ty)?;
                     let acc = expr! {
                         acc(FracRef<field_ty>(
-                            lifetime,
                             [field_place],
                             root_address,
-                            [field_snapshot]
+                            [field_snapshot],
+                            lifetime;
+                            lifetimes_field_ty_expr
                         ))
                     };
                     field_predicates.push(acc);
@@ -550,9 +632,19 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                 if field_predicates.is_empty() {
                     // FIXME: Add backing MemoryBlock unimplemented!();
                 }
+                let mut arguments = vec![place, root_address, snapshot, lifetime];
+                let lifetimes_ty: Vec<vir_low::VariableDecl> = ty
+                    .get_lifetimes()
+                    .iter()
+                    .map(|x| vir_low::VariableDecl {
+                        name: x.name.clone(),
+                        ty: ty!(Lifetime),
+                    })
+                    .collect();
+                arguments.extend(lifetimes_ty);
                 vir_low::PredicateDecl::new(
                     predicate_name! {FracRef<ty>},
-                    vec![lifetime, place, root_address, snapshot],
+                    arguments,
                     Some(expr! {
                         [current_validity] &&
                         [field_predicates.into_iter().conjoin()]
@@ -580,12 +672,27 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                         position,
                     )?;
                     let variant_type = ty.clone().variant(variant_index);
+                    let lifetimes_variant_ty: Vec<vir_low::VariableDecl> = variant_type
+                        .get_lifetimes()
+                        .iter()
+                        .map(|x| vir_low::VariableDecl {
+                            name: x.name.clone(),
+                            ty: ty!(Lifetime),
+                        })
+                        .collect();
+                    let lifetimes_variant_ty_expr: Vec<vir_low::Expression> = lifetimes_variant_ty
+                        .clone()
+                        .iter()
+                        .cloned()
+                        .map(|x| x.into())
+                        .collect();
+                    // NOTE: variant_type may be a mutable reference
                     self.encode_frac_ref(&variant_type)?;
                     let variant_type = &variant_type;
                     let acc = expr! {
                         ([ discriminant_call.clone() ] == [ discriminant.into() ]) ==>
                         (acc(FracRef<variant_type>(
-                            lifetime, [variant_place], root_address, [variant_snapshot]
+                            [variant_place], root_address, [variant_snapshot], lifetime; lifetimes_variant_ty_expr
                         )))
                     };
                     variant_predicates.push(acc);
@@ -604,14 +711,38 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                     discriminant_call,
                     position,
                 )?;
+                let lifetimes_discriminant_ty: Vec<vir_low::VariableDecl> = discriminant_type
+                    .get_lifetimes()
+                    .iter()
+                    .map(|x| vir_low::VariableDecl {
+                        name: x.name.clone(),
+                        ty: ty!(Lifetime),
+                    })
+                    .collect();
+                let lifetimes_discriminant_ty_expr: Vec<vir_low::Expression> =
+                    lifetimes_discriminant_ty
+                        .iter()
+                        .cloned()
+                        .map(|x| x.into())
+                        .collect();
+                let lifetimes_ty: Vec<vir_low::VariableDecl> = ty
+                    .get_lifetimes()
+                    .iter()
+                    .map(|x| vir_low::VariableDecl {
+                        name: x.name.clone(),
+                        ty: ty!(Lifetime),
+                    })
+                    .collect();
+                let mut arguments = vec![place, root_address.clone(), snapshot, lifetime.clone()];
+                arguments.extend(lifetimes_ty);
                 vir_low::PredicateDecl::new(
                     predicate_name! {FracRef<ty>},
-                    vec![lifetime.clone(), place, root_address.clone(), snapshot],
+                    arguments,
                     Some(expr! {
                         [current_validity] &&
                         (acc(FracRef<discriminant_type>(
-                            lifetime, [discriminant_place], root_address,
-                            [discriminant_snapshot]
+                            [discriminant_place], root_address,
+                            [discriminant_snapshot], lifetime; lifetimes_discriminant_ty_expr
                         ))) &&
                         [variant_predicates.into_iter().conjoin()]
                     }),
@@ -621,8 +752,21 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                 unimplemented!();
             }
             // vir_mid::TypeDecl::Array(Array) => {},
-            vir_mid::TypeDecl::Reference(reference) if reference.uniqueness.is_unique() => {
-                unimplemented!();
+            vir_mid::TypeDecl::Reference(reference) => {
+                // NOTE: regardless if the reference is shared or unique, we encode FracRef here
+                let target_type = &reference.target_type;
+                self.encode_frac_ref(target_type)?;
+                let mut parameters = vec![place, root_address, snapshot, lifetime];
+                let lifetimes_ty: Vec<vir_low::VariableDecl> = ty
+                    .get_lifetimes()
+                    .iter()
+                    .map(|x| vir_low::VariableDecl {
+                        name: x.name.clone(),
+                        ty: ty!(Lifetime),
+                    })
+                    .collect();
+                parameters.extend(lifetimes_ty);
+                vir_low::PredicateDecl::new(predicate_name! {FracRef<ty>}, parameters, None)
             }
             // vir_mid::TypeDecl::Never => {},
             // vir_mid::TypeDecl::Closure(Closure) => {},
@@ -634,10 +778,15 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
     }
 
     fn encode_unique_ref(&mut self, ty: &vir_mid::Type) -> SpannedEncodingResult<()> {
-        if self.encoded_mut_borrow_predicates.contains(ty) {
+        let ty_without_lifetime = ty.clone().erase_lifetimes();
+        if self
+            .encoded_mut_borrow_predicates
+            .contains(&ty_without_lifetime)
+        {
             return Ok(());
         }
-        self.encoded_mut_borrow_predicates.insert(ty.clone());
+        self.encoded_mut_borrow_predicates
+            .insert(ty_without_lifetime);
         self.lowerer.encode_compute_address(ty)?;
         use vir_low::macros::*;
         let position = Default::default();
@@ -661,22 +810,24 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
             | vir_mid::TypeDecl::Pointer(_)
             | vir_mid::TypeDecl::Sequence(_)
             | vir_mid::TypeDecl::Map(_)
-            | vir_mid::TypeDecl::TypeVar(_)
-            | vir_mid::TypeDecl::Trusted(_) => vir_low::PredicateDecl::new(
-                predicate_name! {UniqueRef<ty>},
-                vec![
-                    lifetime,
+            | vir_mid::TypeDecl::TypeVar(_) => {
+                let mut parameters = vec![
                     place,
                     root_address,
                     current_snapshot,
                     final_snapshot,
-                ],
-                None,
-            ),
+                    lifetime,
+                ];
+                let lifetimes_ty = self.lowerer.extract_lifetime_variables(ty)?;
+                parameters.extend(lifetimes_ty);
+                vir_low::PredicateDecl::new(predicate_name! {UniqueRef<ty>}, parameters, None)
+            }
             vir_mid::TypeDecl::Tuple(_decl) => unimplemented!(),
-            vir_mid::TypeDecl::Struct(decl) => {
+            vir_mid::TypeDecl::Trusted(vir_mid::type_decl::Trusted { fields, .. })
+            | vir_mid::TypeDecl::Struct(vir_mid::type_decl::Struct { fields, .. }) => {
                 let mut field_predicates = Vec::new();
-                for field in &decl.fields {
+                let mut field_lifetimes = Vec::new();
+                for field in fields {
                     let field_place = self.lowerer.encode_field_place(
                         ty,
                         field,
@@ -696,14 +847,47 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                         Default::default(),
                     )?;
                     let field_ty = &field.ty;
+                    let lifetimes_field_ty: Vec<vir_low::VariableDecl> = field_ty
+                        .get_lifetimes()
+                        .iter()
+                        .map(|x| vir_low::VariableDecl {
+                            name: x.name.clone(),
+                            ty: ty!(Lifetime),
+                        })
+                        .collect();
+                    let lifetimes_field_ty_expr: Vec<vir_low::Expression> = lifetimes_field_ty
+                        .clone()
+                        .iter()
+                        .cloned()
+                        .map(|x| x.into())
+                        .collect();
+                    field_lifetimes.extend(lifetimes_field_ty.clone());
+                    if field_ty.is_reference() {
+                        let reference = field_ty.clone().unwrap_reference();
+                        if reference.uniqueness.is_shared() {
+                            self.encode_frac_ref(field_ty)?;
+                            let acc = expr! {
+                                acc(FracRef<field_ty>(
+                                    [field_place],
+                                    root_address,
+                                    [current_field_snapshot],
+                                    lifetime;
+                                    lifetimes_field_ty_expr
+                                ))
+                            };
+                            field_predicates.push(acc);
+                            continue;
+                        }
+                    }
                     self.encode_unique_ref(field_ty)?;
                     let acc = expr! {
                         acc(UniqueRef<field_ty>(
-                            lifetime,
                             [field_place],
                             root_address,
                             [current_field_snapshot],
-                            [final_field_snapshot]
+                            [final_field_snapshot],
+                            lifetime;
+                            lifetimes_field_ty_expr
                         ))
                     };
                     field_predicates.push(acc);
@@ -711,15 +895,25 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                 if field_predicates.is_empty() {
                     // FIXME: add MemoryBlock predicate unimplemented!();
                 }
+                let mut arguments = vec![
+                    place,
+                    root_address,
+                    current_snapshot,
+                    final_snapshot,
+                    lifetime,
+                ];
+                let lifetimes_ty: Vec<vir_low::VariableDecl> = ty
+                    .get_lifetimes()
+                    .iter()
+                    .map(|x| vir_low::VariableDecl {
+                        name: x.name.clone(),
+                        ty: ty!(Lifetime),
+                    })
+                    .collect();
+                arguments.extend(lifetimes_ty);
                 vir_low::PredicateDecl::new(
                     predicate_name! {UniqueRef<ty>},
-                    vec![
-                        lifetime,
-                        place,
-                        root_address,
-                        current_snapshot,
-                        final_snapshot,
-                    ],
+                    arguments,
                     Some(expr! {
                         [current_validity] &&
                         [field_predicates.into_iter().conjoin()]
@@ -759,14 +953,49 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                         final_snapshot.clone().into(),
                         position,
                     )?;
-                    let variant_type = ty.clone().variant(variant_index);
-                    self.encode_unique_ref(&variant_type)?;
-                    let variant_type = &variant_type;
+                    let variant_type = &ty.clone().variant(variant_index);
+                    let lifetimes_variant_ty: Vec<vir_low::VariableDecl> = variant_type
+                        .get_lifetimes()
+                        .iter()
+                        .map(|x| vir_low::VariableDecl {
+                            name: x.name.clone(),
+                            ty: ty!(Lifetime),
+                        })
+                        .collect();
+                    let lifetimes_variant_ty_expr: Vec<vir_low::Expression> = lifetimes_variant_ty
+                        .clone()
+                        .iter()
+                        .cloned()
+                        .map(|x| x.into())
+                        .collect();
+                    if variant_type.is_reference() {
+                        let reference = variant_type.clone().unwrap_reference();
+                        if reference.uniqueness.is_shared() {
+                            self.encode_frac_ref(variant_type)?;
+                            let acc = expr! {
+                                ([ discriminant_current_call.clone() ] == [ discriminant.into() ]) ==>
+                                (acc(FracRef<variant_type>(
+                                    [variant_place],
+                                    root_address,
+                                    [current_variant_snapshot],
+                                    lifetime;
+                                    lifetimes_variant_ty_expr
+                                )))
+                            };
+                            variant_predicates.push(acc);
+                            continue;
+                        }
+                    }
+                    self.encode_unique_ref(variant_type)?;
                     let acc = expr! {
                         ([ discriminant_current_call.clone() ] == [ discriminant.into() ]) ==>
                         (acc(UniqueRef<variant_type>(
-                            lifetime, [variant_place], root_address,
-                            [current_variant_snapshot], [final_variant_snapshot]
+                            [variant_place],
+                            root_address,
+                            [current_variant_snapshot],
+                            [final_variant_snapshot],
+                            lifetime;
+                            lifetimes_variant_ty_expr
                         )))
                     };
                     variant_predicates.push(acc);
@@ -790,20 +1019,48 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
                     discriminant_final_call,
                     position,
                 )?;
+                let lifetimes_discriminant_ty: Vec<vir_low::VariableDecl> = discriminant_type
+                    .get_lifetimes()
+                    .iter()
+                    .map(|x| vir_low::VariableDecl {
+                        name: x.name.clone(),
+                        ty: ty!(Lifetime),
+                    })
+                    .collect();
+                let lifetimes_discriminant_ty_expr: Vec<vir_low::Expression> =
+                    lifetimes_discriminant_ty
+                        .iter()
+                        .cloned()
+                        .map(|x| x.into())
+                        .collect();
+                let lifetimes_ty: Vec<vir_low::VariableDecl> = ty
+                    .get_lifetimes()
+                    .iter()
+                    .map(|x| vir_low::VariableDecl {
+                        name: x.name.clone(),
+                        ty: ty!(Lifetime),
+                    })
+                    .collect();
+                let mut arguments = vec![
+                    place,
+                    root_address.clone(),
+                    current_snapshot,
+                    final_snapshot,
+                    lifetime.clone(),
+                ];
+                arguments.extend(lifetimes_ty);
                 vir_low::PredicateDecl::new(
                     predicate_name! {UniqueRef<ty>},
-                    vec![
-                        lifetime.clone(),
-                        place,
-                        root_address.clone(),
-                        current_snapshot,
-                        final_snapshot,
-                    ],
+                    arguments,
                     Some(expr! {
                         [current_validity] &&
                         (acc(UniqueRef<discriminant_type>(
-                            lifetime, [discriminant_place], root_address,
-                            [discriminant_current_snapshot], [discriminant_final_snapshot]
+                            [discriminant_place],
+                            root_address,
+                            [discriminant_current_snapshot],
+                            [discriminant_final_snapshot],
+                            lifetime;
+                            lifetimes_discriminant_ty_expr
                         ))) &&
                         [variant_predicates.into_iter().conjoin()]
                     }),
@@ -814,7 +1071,25 @@ impl<'l, 'p, 'v, 'tcx> PredicateEncoder<'l, 'p, 'v, 'tcx> {
             }
             // vir_mid::TypeDecl::Array(Array) => {},
             vir_mid::TypeDecl::Reference(reference) if reference.uniqueness.is_unique() => {
-                unimplemented!();
+                let target_type = &reference.target_type;
+                self.encode_unique_ref(target_type)?;
+                let mut parameters = vec![
+                    place,
+                    root_address,
+                    current_snapshot,
+                    final_snapshot,
+                    lifetime,
+                ];
+                let lifetimes_ty: Vec<vir_low::VariableDecl> = ty
+                    .get_lifetimes()
+                    .iter()
+                    .map(|x| vir_low::VariableDecl {
+                        name: x.name.clone(),
+                        ty: ty!(Lifetime),
+                    })
+                    .collect();
+                parameters.extend(lifetimes_ty);
+                vir_low::PredicateDecl::new(predicate_name! {UniqueRef<ty>}, parameters, None)
             }
             // vir_mid::TypeDecl::Never => {},
             // vir_mid::TypeDecl::Closure(Closure) => {},

--- a/prusti-viper/src/encoder/middle/core_proof/predicates/owned/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/predicates/owned/interface.rs
@@ -1,3 +1,4 @@
+use super::encoder::PredicateEncoder;
 use crate::encoder::{
     errors::SpannedEncodingResult,
     middle::core_proof::{
@@ -9,9 +10,8 @@ use rustc_hash::FxHashSet;
 use vir_crate::{
     low::{self as vir_low},
     middle as vir_mid,
+    middle::operations::lifetimes::WithLifetimes,
 };
-
-use super::encoder::PredicateEncoder;
 
 #[derive(Default)]
 pub(in super::super) struct PredicatesOwnedState {

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/variables/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/variables/interface.rs
@@ -80,10 +80,47 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 | vir_mid::TypeDecl::Pointer(_) => {
                     unreachable!("place: {}", place);
                 }
-                vir_mid::TypeDecl::TypeVar(_) | vir_mid::TypeDecl::Trusted(_) => {
+                vir_mid::TypeDecl::TypeVar(_) => {
                     unimplemented!("ty: {}", type_decl)
                 }
                 vir_mid::TypeDecl::Tuple(decl) => {
+                    // FIXME: Remove duplication with vir_mid::TypeDecl::Struct
+                    let place_field = place.clone().unwrap_field(); // FIXME: Implement a macro that takes a reference to avoid clonning.
+                    for field in decl.iter_fields() {
+                        if field.as_ref() != &place_field.field {
+                            let old_field_snapshot = self.obtain_struct_field_snapshot(
+                                parent_type,
+                                &field,
+                                old_snapshot.clone(),
+                                position,
+                            )?;
+                            let new_field_snapshot = self.obtain_struct_field_snapshot(
+                                parent_type,
+                                &field,
+                                new_snapshot.clone(),
+                                position,
+                            )?;
+                            statements.push(
+                                stmtp! { position => assume ([new_field_snapshot] == [old_field_snapshot])},
+                            );
+                        }
+                    }
+                    Ok((
+                        self.obtain_struct_field_snapshot(
+                            parent_type,
+                            &place_field.field,
+                            old_snapshot,
+                            position,
+                        )?,
+                        self.obtain_struct_field_snapshot(
+                            parent_type,
+                            &place_field.field,
+                            new_snapshot,
+                            position,
+                        )?,
+                    ))
+                }
+                vir_mid::TypeDecl::Trusted(decl) => {
                     // FIXME: Remove duplication with vir_mid::TypeDecl::Struct
                     let place_field = place.clone().unwrap_field(); // FIXME: Implement a macro that takes a reference to avoid clonning.
                     for field in decl.iter_fields() {

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/variables/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/variables/interface.rs
@@ -80,47 +80,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 | vir_mid::TypeDecl::Pointer(_) => {
                     unreachable!("place: {}", place);
                 }
-                vir_mid::TypeDecl::TypeVar(_) => {
+                vir_mid::TypeDecl::Trusted(_) | vir_mid::TypeDecl::TypeVar(_) => {
                     unimplemented!("ty: {}", type_decl)
                 }
                 vir_mid::TypeDecl::Tuple(decl) => {
-                    // FIXME: Remove duplication with vir_mid::TypeDecl::Struct
-                    let place_field = place.clone().unwrap_field(); // FIXME: Implement a macro that takes a reference to avoid clonning.
-                    for field in decl.iter_fields() {
-                        if field.as_ref() != &place_field.field {
-                            let old_field_snapshot = self.obtain_struct_field_snapshot(
-                                parent_type,
-                                &field,
-                                old_snapshot.clone(),
-                                position,
-                            )?;
-                            let new_field_snapshot = self.obtain_struct_field_snapshot(
-                                parent_type,
-                                &field,
-                                new_snapshot.clone(),
-                                position,
-                            )?;
-                            statements.push(
-                                stmtp! { position => assume ([new_field_snapshot] == [old_field_snapshot])},
-                            );
-                        }
-                    }
-                    Ok((
-                        self.obtain_struct_field_snapshot(
-                            parent_type,
-                            &place_field.field,
-                            old_snapshot,
-                            position,
-                        )?,
-                        self.obtain_struct_field_snapshot(
-                            parent_type,
-                            &place_field.field,
-                            new_snapshot,
-                            position,
-                        )?,
-                    ))
-                }
-                vir_mid::TypeDecl::Trusted(decl) => {
                     // FIXME: Remove duplication with vir_mid::TypeDecl::Struct
                     let place_field = place.clone().unwrap_field(); // FIXME: Implement a macro that takes a reference to avoid clonning.
                     for field in decl.iter_fields() {

--- a/prusti-viper/src/encoder/middle/core_proof/types/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/types/interface.rs
@@ -85,6 +85,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 let validity = conjuncts.into_iter().conjoin();
                 self.encode_validity_axioms_primitive(&domain_name, vir_low::Type::Int, validity)?;
             }
+            vir_mid::TypeDecl::Trusted(_) => {
+                // FIXME: ensure type definition for trusted
+            }
             vir_mid::TypeDecl::TypeVar(_decl) => {
                 // FIXME: we should make sure that the snapshot and validity
                 // function is generated, but nothing else.
@@ -106,19 +109,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 )?;
             }
             vir_mid::TypeDecl::Tuple(decl) => {
-                let mut parameters = Vec::new();
-                for field in decl.iter_fields() {
-                    parameters.push(vir_low::VariableDecl::new(
-                        field.name.clone(),
-                        field.ty.to_snapshot(self)?,
-                    ));
-                }
-                self.register_struct_constructor(&domain_name, parameters.clone())?;
-                self.encode_validity_axioms_struct(&domain_name, parameters, true.into())?;
-            }
-            vir_mid::TypeDecl::Trusted(decl) => {
-                // FIXME: we should make sure that the snapshot and validity
-                // function is generated, but nothing else.
                 let mut parameters = Vec::new();
                 for field in decl.iter_fields() {
                     parameters.push(vir_low::VariableDecl::new(

--- a/prusti-viper/src/encoder/middle/core_proof/utils/type_decl_encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/utils/type_decl_encoder.rs
@@ -188,6 +188,9 @@ pub(in super::super) trait TypeDeclWalker {
             vir_mid::TypeDecl::Tuple(tuple_decl) => {
                 self.walk_fields(ty, tuple_decl.iter_fields(), &parameters, lowerer)?;
             }
+            vir_mid::TypeDecl::Trusted(trusted_decl) => {
+                self.walk_fields(ty, trusted_decl.iter_fields(), &parameters, lowerer)?;
+            }
             vir_mid::TypeDecl::Struct(struct_decl) => {
                 self.walk_fields(ty, struct_decl.iter_fields(), &parameters, lowerer)?;
             }
@@ -223,6 +226,7 @@ pub(in super::super) trait TypeDeclWalker {
             | vir_mid::Type::Map(_) => self.after_primitive(ty, parameters, lowerer),
             // vir_mid::Type::TypeVar(TypeVar) => {},
             vir_mid::Type::Tuple(_)
+            | vir_mid::Type::Trusted(_)
             | vir_mid::Type::Struct(_)
             | vir_mid::Type::Enum(_)
             | vir_mid::Type::Union(_)
@@ -231,6 +235,7 @@ pub(in super::super) trait TypeDeclWalker {
                 self.after_primitive(ty, parameters, lowerer)
             }
             vir_mid::Type::Tuple(_)
+            | vir_mid::Type::Trusted(_)
             | vir_mid::Type::Struct(_)
             | vir_mid::Type::Enum(_)
             | vir_mid::Type::Union(_) => self.after_composite(ty, parameters, lowerer),

--- a/prusti-viper/src/encoder/middle/core_proof/utils/type_decl_encoder.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/utils/type_decl_encoder.rs
@@ -176,6 +176,7 @@ pub(in super::super) trait TypeDeclWalker {
             | vir_mid::TypeDecl::Map(_) => {
                 self.walk_primitive(ty, &parameters, lowerer)?;
             }
+            // vir_mid::TypeDecl::Trusted(_) => {}
             // vir_mid::TypeDecl::TypeVar(TypeVar) => {},
             vir_mid::TypeDecl::Tuple(_)
             | vir_mid::TypeDecl::Struct(_)
@@ -187,9 +188,6 @@ pub(in super::super) trait TypeDeclWalker {
             }
             vir_mid::TypeDecl::Tuple(tuple_decl) => {
                 self.walk_fields(ty, tuple_decl.iter_fields(), &parameters, lowerer)?;
-            }
-            vir_mid::TypeDecl::Trusted(trusted_decl) => {
-                self.walk_fields(ty, trusted_decl.iter_fields(), &parameters, lowerer)?;
             }
             vir_mid::TypeDecl::Struct(struct_decl) => {
                 self.walk_fields(ty, struct_decl.iter_fields(), &parameters, lowerer)?;

--- a/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
@@ -51,7 +51,7 @@ use vir_crate::{
         builders::procedure::{
             BasicBlockBuilder, ProcedureBuilder, SuccessorBuilder, SuccessorExitKind,
         },
-        operations::ty::Typed,
+        operations::{lifetimes::WithLifetimes, ty::Typed},
     },
 };
 

--- a/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
@@ -615,32 +615,30 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 );
                 let encoded_place = self.encoder.encode_place_high(self.mir, *place, None)?;
                 let region_name = region.to_text();
+                let operand_lifetime = vir_high::ty::LifetimeConst { name: region_name };
+                let root: vir_high::Expression = self
+                    .encoder
+                    .encode_local_high(self.mir, place.local)?
+                    .into();
+                let place_lifetimes = root.get_lifetimes();
+
                 let encoded_rvalue = if is_reborrow {
-                    let root = self.encoder.encode_local_high(self.mir, place.local)?;
-                    let place_lifetime_name = self.lifetime_name(root.into());
-                    if let Some(place_lifetime_name) = place_lifetime_name {
-                        if let vir_high::Expression::Local(local) = &encoded_target {
-                            self.points_to_reborrow.insert(local.clone());
-                        }
-                        let place_lifetime = vir_high::ty::LifetimeConst {
-                            name: place_lifetime_name,
-                        };
-                        let operand_lifetime = vir_high::ty::LifetimeConst { name: region_name };
-                        vir_high::Rvalue::reborrow(
-                            encoded_place,
-                            operand_lifetime,
-                            place_lifetime,
-                            is_mut,
-                            self.lifetime_token_fractional_permission(self.lifetime_count),
-                            encoded_target.clone(),
-                        )
-                    } else {
-                        unreachable!()
+                    if let vir_high::Expression::Local(local) = &encoded_target {
+                        self.points_to_reborrow.insert(local.clone());
                     }
+                    vir_high::Rvalue::reborrow(
+                        encoded_place,
+                        operand_lifetime,
+                        place_lifetimes,
+                        is_mut,
+                        self.lifetime_token_fractional_permission(self.lifetime_count),
+                        encoded_target.clone(),
+                    )
                 } else {
                     vir_high::Rvalue::ref_(
                         encoded_place,
-                        vir_high::ty::LifetimeConst::new(region_name),
+                        operand_lifetime,
+                        place_lifetimes,
                         is_mut,
                         self.lifetime_token_fractional_permission(self.lifetime_count),
                         encoded_target.clone(),
@@ -922,7 +920,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             &deref_base,
             encoded_target.clone(),
         )?;
-
         match operand {
             mir::Operand::Move(source) => {
                 let encoded_source =
@@ -1450,9 +1447,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             for arg in args {
                 if let &mir::Operand::Move(place) = arg {
                     let place_high = self.encoder.encode_place_high(self.mir, place, None)?;
-                    let lifetime_name = self.lifetime_name(place_high);
-                    if let Some(lifetime_name) = lifetime_name {
-                        subst_lifetimes.push(lifetime_name);
+                    let lifetimes = place_high.get_lifetimes();
+                    for lifetime in lifetimes {
+                        subst_lifetimes.push(lifetime.name.clone());
                     }
                 }
             }

--- a/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/mod.rs
@@ -527,12 +527,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
         span: Span,
         substs: SubstsRef<'tcx>,
     ) -> SpannedEncodingResult<Option<ExprBackwardInterpreterState>> {
+        let lifetimes = self.encoder.get_lifetimes_substs(&substs)?;
+        use vir_high::{expression::BuiltinFunc::*, ty::*};
         let type_arguments = self
             .encoder
             .encode_generic_arguments_high(def_id, substs)
             .with_span(span)?;
-
-        use vir_high::{expression::BuiltinFunc::*, ty::*};
 
         let subst_with = |val| {
             let mut state = states[target_block].clone();
@@ -554,7 +554,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
 
             let key_type = type_arguments[0].clone();
             let val_type = type_arguments[1].clone();
-            let map_type = Type::map(key_type, val_type.clone());
+            let map_type = Type::map(key_type, val_type.clone(), lifetimes);
 
             return builtin(match proc_name {
                 "empty" => (EmptyMap, map_type),
@@ -569,7 +569,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
             assert_eq!(type_arguments.len(), 1);
 
             let elem_type = type_arguments[0].clone();
-            let seq_type = Type::sequence(elem_type.clone());
+            let seq_type = Type::sequence(elem_type.clone(), lifetimes);
 
             return builtin(match proc_name {
                 "empty" => (EmptySeq, seq_type),

--- a/prusti-viper/src/encoder/mir/types/interface.rs
+++ b/prusti-viper/src/encoder/mir/types/interface.rs
@@ -2,8 +2,9 @@ use super::TypeEncoder;
 use crate::encoder::{
     errors::{EncodingError, EncodingResult, SpannedEncodingError, SpannedEncodingResult},
     high::types::HighTypeEncoderInterface,
+    mir::types::interface::ty::SubstsRef,
 };
-
+use prusti_interface::environment::debug_utils::to_text::ToText;
 use prusti_rustc_interface::{
     errors::MultiSpan,
     middle::{mir, ty},
@@ -38,6 +39,18 @@ pub(crate) trait MirTypeEncoderInterface<'tcx> {
         declaration_span: Span,
     ) -> SpannedEncodingResult<vir_high::FieldDecl>;
     fn encode_value_field_high(&self, ty: ty::Ty<'tcx>) -> EncodingResult<vir_high::FieldDecl>;
+    fn get_lifetimes_substs(
+        &self,
+        substs: &SubstsRef<'tcx>,
+    ) -> SpannedEncodingResult<Vec<vir_high::ty::LifetimeConst>>;
+    fn get_lifetimes_substs_as_type_decl(
+        &self,
+        substs: &SubstsRef<'tcx>,
+    ) -> SpannedEncodingResult<Vec<vir_high::type_decl::LifetimeConst>>;
+    fn get_lifetimes_high(
+        &self,
+        ty: &ty::Ty<'tcx>,
+    ) -> SpannedEncodingResult<Vec<vir_high::ty::LifetimeConst>>;
     fn encode_type_high(&self, ty: ty::Ty<'tcx>) -> SpannedEncodingResult<vir_high::Type>;
     fn encode_place_type_high(&self, ty: mir::tcx::PlaceTy<'tcx>)
         -> EncodingResult<vir_high::Type>;
@@ -150,6 +163,106 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
         let encoded_type = self.encode_type_high(ty)?;
         crate::encoder::high::types::create_value_field(encoded_type)
     }
+    fn get_lifetimes_substs(
+        &self,
+        substs: &SubstsRef<'tcx>,
+    ) -> SpannedEncodingResult<Vec<vir_high::ty::LifetimeConst>> {
+        let mut lifetimes = vec![];
+        for kind in substs.iter() {
+            match kind.unpack() {
+                ty::subst::GenericArgKind::Type(arg_ty) => {
+                    let lifetime = self.get_lifetimes_high(&arg_ty)?;
+                    lifetimes.extend(lifetime);
+                }
+                ty::subst::GenericArgKind::Lifetime(region) => {
+                    lifetimes.push(vir_high::ty::LifetimeConst {
+                        name: region.to_text(),
+                    });
+                }
+                _ => {}
+            }
+        }
+        Ok(lifetimes)
+    }
+    fn get_lifetimes_substs_as_type_decl(
+        &self,
+        substs: &SubstsRef<'tcx>,
+    ) -> SpannedEncodingResult<Vec<vir_high::type_decl::LifetimeConst>> {
+        let lifetime_const = self.get_lifetimes_substs(substs)?;
+        let mut lifetimes = vec![];
+        for lifetime in lifetime_const {
+            lifetimes.push(vir_high::type_decl::LifetimeConst {
+                name: lifetime.name.clone(),
+            })
+        }
+        Ok(lifetimes)
+    }
+    fn get_lifetimes_high(
+        &self,
+        ty: &ty::Ty<'tcx>,
+    ) -> SpannedEncodingResult<Vec<vir_high::ty::LifetimeConst>> {
+        let lifetimes = match ty.kind() {
+            ty::TyKind::Bool
+            | ty::TyKind::Char
+            | ty::TyKind::Int(_)
+            | ty::TyKind::Uint(_)
+            | ty::TyKind::Float(_)
+            | ty::TyKind::Foreign(_)
+            | ty::TyKind::Str
+            | ty::TyKind::Error(_)
+            | ty::TyKind::Never => {
+                vec![]
+            }
+            ty::TyKind::Adt(_, substs)
+            | ty::TyKind::Closure(_, substs)
+            | ty::TyKind::Opaque(_, substs)
+            | ty::TyKind::FnDef(_, substs) => self.get_lifetimes_substs(substs)?,
+            ty::TyKind::Array(ty, _) | ty::TyKind::Slice(ty) => self.get_lifetimes_high(ty)?,
+            ty::TyKind::Dynamic(_, region) | ty::TyKind::Ref(region, _, _) => {
+                vec![vir_high::ty::LifetimeConst {
+                    name: region.to_text(),
+                }]
+            }
+            ty::TyKind::Tuple(ty_list) => {
+                let mut lifetimes = vec![];
+                for item_ty in ty_list.iter() {
+                    lifetimes.extend(self.get_lifetimes_high(&item_ty)?);
+                }
+                lifetimes
+            }
+            ty::TyKind::RawPtr(type_and_mut) => self.get_lifetimes_high(&type_and_mut.ty)?,
+            ty::TyKind::FnPtr(poly_fn_sig) => {
+                let ty_list = poly_fn_sig.inputs_and_output().bound_vars();
+                let mut lifetimes = vec![];
+                for bound_variable_kind in ty_list.iter() {
+                    if let ty::BoundVariableKind::Region(bound_region_kind) = bound_variable_kind {
+                        lifetimes.push(vir_high::ty::LifetimeConst {
+                            name: bound_region_kind.to_text(),
+                        });
+                    }
+                }
+                lifetimes
+            }
+            ty::TyKind::Param(_param_ty) => {
+                // FIXME: extract lifetimes from TyKind::Param()
+                vec![]
+            }
+            ty::TyKind::Projection(projection_ty) => {
+                self.get_lifetimes_substs(&projection_ty.substs)?
+            }
+            ty::TyKind::Bound(_, _)
+            | ty::TyKind::Placeholder(_)
+            | ty::TyKind::Infer(_)
+            | ty::TyKind::Generator(..)
+            | ty::TyKind::GeneratorWitness(_) => {
+                return Err(SpannedEncodingError::unsupported(
+                    format!("unsupported type to extract lifetimes: {:?}", ty.kind()),
+                    self.get_type_definition_span(*ty),
+                ));
+            }
+        };
+        Ok(lifetimes)
+    }
     fn encode_type_high(&self, ty: ty::Ty<'tcx>) -> SpannedEncodingResult<vir_high::Type> {
         if !self
             .mir_type_encoder_state
@@ -173,8 +286,7 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
                 .encoded_types_inverse
                 .borrow_mut()
                 .insert(encoded_type.clone(), ty);
-            let mut encoded_type = encoded_type;
-            encoded_type.erase_lifetime();
+            let encoded_type = encoded_type.erase_lifetimes();
             self.mir_type_encoder_state
                 .encoded_types_inverse
                 .borrow_mut()
@@ -214,7 +326,7 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
         if let Some(ty_without_variant) = ty.forget_variant() {
             self.mir_type_encoder_state.encoded_types_inverse.borrow()[&ty_without_variant]
         } else if ty == &vir_high::Type::Lifetime {
-            unimplemented!("hello");
+            unimplemented!("encode_type_high for lifetime {:?}", ty);
         } else if ty == &vir_high::Type::Bool {
             // Bools may be generated by our encoding without having them in the
             // original program.
@@ -271,12 +383,14 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
                     variant: Some(variant),
                     name,
                     arguments,
+                    lifetimes,
                 }) => {
                     let encoded_enum = self
                         .encode_type_def(&vir_high::Type::enum_(
                             name.clone(),
                             arguments.clone(),
                             None,
+                            lifetimes.clone(),
                         ))?
                         .unwrap_enum();
                     vir_high::TypeDecl::Struct(encoded_enum.into_variant(&variant.index).unwrap())
@@ -285,12 +399,14 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
                     variant: Some(variant),
                     name,
                     arguments,
+                    lifetimes,
                 }) => {
                     let encoded_union = self
                         .encode_type_def(&vir_high::Type::union_(
                             name.clone(),
                             arguments.clone(),
                             None,
+                            lifetimes.clone(),
                         ))?
                         .unwrap_union();
                     vir_high::TypeDecl::Struct(encoded_union.into_variant(&variant.index).unwrap())

--- a/vir/defs/high/ast/rvalue.rs
+++ b/vir/defs/high/ast/rvalue.rs
@@ -34,20 +34,32 @@ pub struct Repeat {
     pub count: u64,
 }
 
-#[display(fmt = "&{} {}", lifetime, place)]
+#[display(
+    fmt = "&{} {}<{}>",
+    operand_lifetime,
+    place,
+    "display::cjoin(place_lifetimes)"
+)]
 pub struct Ref {
     pub place: Expression,
-    pub lifetime: LifetimeConst,
+    pub operand_lifetime: LifetimeConst,
+    pub place_lifetimes: Vec<LifetimeConst>,
     pub is_mut: bool,
     pub lifetime_token_permission: Expression,
     pub target: Expression,
 }
 
-#[display(fmt = "{} := &'{} (*{})", target, operand_lifetime, place)]
+#[display(
+    fmt = "{} := &'{} (*{}<{}>)",
+    target,
+    operand_lifetime,
+    place,
+    "display::cjoin(place_lifetimes)"
+)]
 pub struct Reborrow {
     pub place: Expression,
     pub operand_lifetime: LifetimeConst,
-    pub place_lifetime: LifetimeConst,
+    pub place_lifetimes: Vec<LifetimeConst>,
     pub is_mut: bool,
     pub lifetime_token_permission: Expression,
     pub target: Expression,

--- a/vir/defs/high/ast/ty.rs
+++ b/vir/defs/high/ast/ty.rs
@@ -61,15 +61,22 @@ pub enum Int {
     Unbounded,
 }
 
-#[display(fmt = "Sequence({})", element_type)]
+#[display(fmt = "Sequence({})<{}>", element_type, "display::cjoin(lifetimes)")]
 pub struct Sequence {
     pub element_type: Box<Type>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
-#[display(fmt = "Map({} -> {})", key_type, val_type)]
+#[display(
+    fmt = "Map({} -> {})<{}>",
+    key_type,
+    val_type,
+    "display::cjoin(lifetimes)"
+)]
 pub struct Map {
     pub key_type: Box<Type>,
     pub val_type: Box<Type>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
 pub enum Float {
@@ -102,17 +109,28 @@ pub enum TypeVar {
     GenericType(GenericType),
 }
 
-#[display(fmt = "({})", "display::cjoin(arguments)")]
+#[display(
+    fmt = "({})<{}>",
+    "display::cjoin(arguments)",
+    "display::cjoin(lifetimes)"
+)]
 pub struct Tuple {
     /// Type arguments.
     pub arguments: Vec<Type>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
-#[display(fmt = "{}<{}>", name, "display::cjoin(arguments)")]
+#[display(
+    fmt = "{}<{}, {}>",
+    name,
+    "display::cjoin(arguments)",
+    "display::cjoin(lifetimes)"
+)]
 pub struct Struct {
     pub name: String,
     /// Type arguments.
     pub arguments: Vec<Type>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
 #[derive(derive_more::From)]
@@ -121,10 +139,11 @@ pub struct VariantIndex {
 }
 
 #[display(
-    fmt = "{}{}<{}>",
+    fmt = "{}{}<{}, {}>",
     name,
     "display::option!(variant, \"[{}]\", \"\")",
-    "display::cjoin(arguments)"
+    "display::cjoin(arguments)",
+    "display::cjoin(lifetimes)"
 )]
 pub struct Enum {
     pub name: String,
@@ -132,26 +151,40 @@ pub struct Enum {
     pub arguments: Vec<Type>,
     /// A specific variant of the enum that this type represents.
     pub variant: Option<VariantIndex>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
-#[display(fmt = "{}<{}>", name, "display::cjoin(arguments)")]
+#[display(
+    fmt = "{}<{}, {}>",
+    name,
+    "display::cjoin(arguments)",
+    "display::cjoin(lifetimes)"
+)]
 pub struct Union {
     pub name: String,
     /// Type arguments.
     pub arguments: Vec<Type>,
     /// A specific field of the union that this type represents.
     pub variant: Option<VariantIndex>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
-#[display(fmt = "Array({}, {})", length, element_type)]
+#[display(
+    fmt = "Array({}, {})<{}>",
+    length,
+    element_type,
+    "display::cjoin(lifetimes)"
+)]
 pub struct Array {
     pub length: u64,
     pub element_type: Box<Type>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
-#[display(fmt = "Slice({})", element_type)]
+#[display(fmt = "Slice({})<{}>", element_type, "display::cjoin(lifetimes)")]
 pub struct Slice {
     pub element_type: Box<Type>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
 #[derive(Copy, derive_more::IsVariant)]
@@ -188,11 +221,17 @@ pub struct FunctionDef {
     // pub arguments: Vec<Type>,
 }
 
-#[display(fmt = "{}<{}>", name, "display::cjoin(arguments)")]
+#[display(
+    fmt = "{}<{}, {}>",
+    name,
+    "display::cjoin(arguments)",
+    "display::cjoin(lifetimes)"
+)]
 pub struct Projection {
     pub name: String,
     /// Type arguments.
     pub arguments: Vec<Type>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
 #[display(fmt = "{}", name)]
@@ -200,9 +239,15 @@ pub struct Unsupported {
     pub name: String,
 }
 
-#[display(fmt = "{}<{}>", name, "display::cjoin(arguments)")]
+#[display(
+    fmt = "{}<{}, {}>",
+    name,
+    "display::cjoin(arguments)",
+    "display::cjoin(lifetimes)"
+)]
 pub struct Trusted {
     pub name: String,
     /// Type arguments.
     pub arguments: Vec<Type>,
+    pub lifetimes: Vec<LifetimeConst>,
 }

--- a/vir/defs/high/ast/type_decl.rs
+++ b/vir/defs/high/ast/type_decl.rs
@@ -99,6 +99,7 @@ pub struct Enum {
     pub discriminant_bounds: Vec<DiscriminantRange>,
     pub discriminant_values: Vec<DiscriminantValue>,
     pub variants: Vec<Struct>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
 #[display(fmt = "{}", name)]
@@ -108,6 +109,7 @@ pub struct Union {
     pub discriminant_bounds: Vec<DiscriminantRange>,
     pub discriminant_values: Vec<DiscriminantValue>,
     pub variants: Vec<Struct>,
+    pub lifetimes: Vec<LifetimeConst>,
 }
 
 #[display(fmt = "Array({}, {})", length, element_type)]
@@ -153,4 +155,5 @@ pub struct Unsupported {
 #[display(fmt = "{}", name)]
 pub struct Trusted {
     pub name: String,
+    pub fields: Vec<FieldDecl>,
 }

--- a/vir/defs/high/ast/type_decl.rs
+++ b/vir/defs/high/ast/type_decl.rs
@@ -155,5 +155,4 @@ pub struct Unsupported {
 #[display(fmt = "{}", name)]
 pub struct Trusted {
     pub name: String,
-    pub fields: Vec<FieldDecl>,
 }

--- a/vir/defs/high/operations_internal/expression.rs
+++ b/vir/defs/high/operations_internal/expression.rs
@@ -152,6 +152,20 @@ impl Expression {
         }
     }
 
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        pub struct LifetimeFinder {
+            lifetimes: Vec<LifetimeConst>,
+        }
+        impl ExpressionWalker for LifetimeFinder {
+            fn walk_variable_decl(&mut self, variable: &VariableDecl) {
+                self.lifetimes.extend(variable.ty.get_lifetimes());
+            }
+        }
+        let mut finder = LifetimeFinder { lifetimes: vec![] };
+        finder.walk_expression(self);
+        finder.lifetimes
+    }
+
     #[must_use]
     pub fn erase_lifetime(self) -> Expression {
         struct DefaultLifetimeEraser {}

--- a/vir/defs/high/operations_internal/expression.rs
+++ b/vir/defs/high/operations_internal/expression.rs
@@ -152,20 +152,6 @@ impl Expression {
         }
     }
 
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        pub struct LifetimeFinder {
-            lifetimes: Vec<LifetimeConst>,
-        }
-        impl ExpressionWalker for LifetimeFinder {
-            fn walk_variable_decl(&mut self, variable: &VariableDecl) {
-                self.lifetimes.extend(variable.ty.get_lifetimes());
-            }
-        }
-        let mut finder = LifetimeFinder { lifetimes: vec![] };
-        finder.walk_expression(self);
-        finder.lifetimes
-    }
-
     #[must_use]
     pub fn erase_lifetime(self) -> Expression {
         struct DefaultLifetimeEraser {}

--- a/vir/defs/high/operations_internal/lifetimes.rs
+++ b/vir/defs/high/operations_internal/lifetimes.rs
@@ -1,0 +1,157 @@
+use super::{
+    super::ast::{
+        expression::visitors::{
+            default_fold_expression, default_fold_quantifier, default_walk_expression,
+            ExpressionFolder, ExpressionWalker,
+        },
+        position::Position,
+        rvalue::*,
+        ty::{self, LifetimeConst},
+    },
+    ty::Typed,
+};
+
+pub trait WithLifetimes {
+    fn get_lifetimes(&self) -> Vec<ty::LifetimeConst>;
+}
+
+impl WithLifetimes for ty::Type {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        match self {
+            ty::Type::Reference(reference) => reference.get_lifetimes(),
+            ty::Type::Tuple(ty::Tuple { lifetimes, .. })
+            | ty::Type::Struct(ty::Struct { lifetimes, .. })
+            | ty::Type::Sequence(ty::Sequence { lifetimes, .. })
+            | ty::Type::Map(ty::Map { lifetimes, .. })
+            | ty::Type::Enum(ty::Enum { lifetimes, .. })
+            | ty::Type::Array(ty::Array { lifetimes, .. })
+            | ty::Type::Slice(ty::Slice { lifetimes, .. })
+            | ty::Type::Projection(ty::Projection { lifetimes, .. })
+            | ty::Type::Trusted(ty::Trusted { lifetimes, .. })
+            | ty::Type::Union(ty::Union { lifetimes, .. }) => lifetimes.clone(),
+            _ => vec![],
+        }
+    }
+}
+
+impl WithLifetimes for ty::Reference {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = vec![self.lifetime.clone()];
+        let target_lifetimes = self.target_type.get_lifetimes();
+        lifetimes.extend(target_lifetimes);
+        lifetimes
+    }
+}
+
+impl WithLifetimes for Expression {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        pub struct LifetimeFinder {
+            lifetimes: Vec<LifetimeConst>,
+        }
+        impl ExpressionWalker for LifetimeFinder {
+            fn walk_variable_decl(&mut self, variable: &VariableDecl) {
+                self.lifetimes.extend(variable.ty.get_lifetimes());
+            }
+        }
+        let mut finder = LifetimeFinder { lifetimes: vec![] };
+        finder.walk_expression(self);
+        finder.lifetimes
+    }
+}
+
+impl WithLifetimes for Rvalue {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        match self {
+            Self::Repeat(value) => value.get_lifetimes(),
+            Self::AddressOf(value) => value.get_lifetimes(),
+            Self::Len(value) => value.get_lifetimes(),
+            Self::BinaryOp(value) => value.get_lifetimes(),
+            Self::CheckedBinaryOp(value) => value.get_lifetimes(),
+            Self::UnaryOp(value) => value.get_lifetimes(),
+            Self::Aggregate(value) => value.get_lifetimes(),
+            Self::Discriminant(value) => value.get_lifetimes(),
+            Self::Ref(value) => value.get_lifetimes(),
+            Self::Reborrow(value) => value.get_lifetimes(),
+        }
+    }
+}
+
+impl WithLifetimes for Repeat {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.argument.get_lifetimes()
+    }
+}
+
+impl WithLifetimes for Ref {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = vec![self.operand_lifetime.clone()];
+        lifetimes.extend(self.place_lifetimes.clone());
+        lifetimes
+    }
+}
+
+impl WithLifetimes for Reborrow {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = vec![self.operand_lifetime.clone()];
+        lifetimes.extend(self.place_lifetimes.clone());
+        lifetimes
+    }
+}
+
+impl WithLifetimes for AddressOf {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.place.get_lifetimes()
+    }
+}
+
+impl WithLifetimes for Len {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.place.get_lifetimes()
+    }
+}
+
+impl WithLifetimes for BinaryOp {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = self.left.get_lifetimes();
+        lifetimes.extend(self.right.get_lifetimes());
+        lifetimes
+    }
+}
+
+impl WithLifetimes for CheckedBinaryOp {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = self.left.get_lifetimes();
+        lifetimes.extend(self.right.get_lifetimes());
+        lifetimes
+    }
+}
+
+impl WithLifetimes for UnaryOp {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.argument.get_lifetimes()
+    }
+}
+
+impl WithLifetimes for Discriminant {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.place.get_lifetimes()
+    }
+}
+
+impl WithLifetimes for Aggregate {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes: Vec<LifetimeConst> = vec![];
+        for operand in &self.operands {
+            lifetimes.extend(operand.get_lifetimes());
+        }
+        let lifetimes_ty = self.ty.get_lifetimes();
+        lifetimes.extend(lifetimes_ty);
+        lifetimes
+    }
+}
+
+impl WithLifetimes for Operand {
+    fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.expression.get_lifetimes()
+    }
+}

--- a/vir/defs/high/operations_internal/mod.rs
+++ b/vir/defs/high/operations_internal/mod.rs
@@ -4,6 +4,7 @@ pub mod function;
 pub mod graphviz;
 pub mod helpers;
 pub mod identifier;
+pub mod lifetimes;
 pub mod position;
 pub mod predicate;
 pub mod procedure;

--- a/vir/defs/high/operations_internal/rvalue.rs
+++ b/vir/defs/high/operations_internal/rvalue.rs
@@ -1,93 +1,10 @@
-use super::{
-    super::ast::{
-        expression::Expression,
-        position::Position,
-        rvalue::{visitors::RvalueWalker, *},
-        ty::*,
-        variable::*,
-    },
-    ty::Typed,
+use super::super::ast::{
+    expression::Expression,
+    position::Position,
+    rvalue::{visitors::RvalueWalker, *},
+    ty::*,
+    variable::*,
 };
-
-impl Repeat {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        self.argument.get_lifetimes()
-    }
-}
-
-impl Ref {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        let mut lifetimes = vec![self.operand_lifetime.clone()];
-        lifetimes.extend(self.place_lifetimes.clone());
-        lifetimes
-    }
-}
-
-impl Reborrow {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        let mut lifetimes = vec![self.operand_lifetime.clone()];
-        lifetimes.extend(self.place_lifetimes.clone());
-        lifetimes
-    }
-}
-
-impl AddressOf {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        self.place.get_lifetimes()
-    }
-}
-
-impl Len {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        self.place.get_lifetimes()
-    }
-}
-
-impl BinaryOp {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        let mut lifetimes = self.left.get_lifetimes();
-        lifetimes.extend(self.right.get_lifetimes());
-        lifetimes
-    }
-}
-
-impl CheckedBinaryOp {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        let mut lifetimes = self.left.get_lifetimes();
-        lifetimes.extend(self.right.get_lifetimes());
-        lifetimes
-    }
-}
-
-impl UnaryOp {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        self.argument.get_lifetimes()
-    }
-}
-
-impl Discriminant {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        self.place.get_lifetimes()
-    }
-}
-
-impl Aggregate {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        let mut lifetimes: Vec<LifetimeConst> = vec![];
-        for operand in &self.operands {
-            lifetimes.extend(operand.get_lifetimes());
-        }
-        let lifetimes_ty = self.ty.get_lifetimes();
-        lifetimes.extend(lifetimes_ty);
-        lifetimes
-    }
-}
-
-impl Operand {
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        self.expression.get_lifetimes()
-    }
-}
 
 impl Rvalue {
     pub fn check_no_default_position(&self) {
@@ -98,31 +15,5 @@ impl Rvalue {
             }
         }
         Checker.walk_rvalue(self)
-    }
-
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        match self {
-            Rvalue::Repeat(r) => r.get_lifetimes(),
-            Rvalue::Ref(r) => r.get_lifetimes(),
-            Rvalue::Reborrow(r) => r.get_lifetimes(),
-            Rvalue::AddressOf(r) => r.get_lifetimes(),
-            Rvalue::Len(r) => r.get_lifetimes(),
-            Rvalue::BinaryOp(r) => r.get_lifetimes(),
-            Rvalue::CheckedBinaryOp(r) => r.get_lifetimes(),
-            Rvalue::UnaryOp(r) => r.get_lifetimes(),
-            Rvalue::Discriminant(r) => r.get_lifetimes(),
-            Rvalue::Aggregate(r) => r.get_lifetimes(),
-        }
-    }
-
-    pub fn get_lifetimes_as_var(&self) -> Vec<VariableDecl> {
-        let lifetimes_const = self.get_lifetimes();
-        lifetimes_const
-            .iter()
-            .map(|lifetime| VariableDecl {
-                name: lifetime.name.clone(),
-                ty: Type::Lifetime,
-            })
-            .collect()
     }
 }

--- a/vir/defs/high/operations_internal/rvalue.rs
+++ b/vir/defs/high/operations_internal/rvalue.rs
@@ -1,8 +1,93 @@
-use super::super::ast::{
-    expression::Expression,
-    position::Position,
-    rvalue::{visitors::RvalueWalker, Rvalue},
+use super::{
+    super::ast::{
+        expression::Expression,
+        position::Position,
+        rvalue::{visitors::RvalueWalker, *},
+        ty::*,
+        variable::*,
+    },
+    ty::Typed,
 };
+
+impl Repeat {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.argument.get_lifetimes()
+    }
+}
+
+impl Ref {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = vec![self.operand_lifetime.clone()];
+        lifetimes.extend(self.place_lifetimes.clone());
+        lifetimes
+    }
+}
+
+impl Reborrow {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = vec![self.operand_lifetime.clone()];
+        lifetimes.extend(self.place_lifetimes.clone());
+        lifetimes
+    }
+}
+
+impl AddressOf {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.place.get_lifetimes()
+    }
+}
+
+impl Len {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.place.get_lifetimes()
+    }
+}
+
+impl BinaryOp {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = self.left.get_lifetimes();
+        lifetimes.extend(self.right.get_lifetimes());
+        lifetimes
+    }
+}
+
+impl CheckedBinaryOp {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes = self.left.get_lifetimes();
+        lifetimes.extend(self.right.get_lifetimes());
+        lifetimes
+    }
+}
+
+impl UnaryOp {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.argument.get_lifetimes()
+    }
+}
+
+impl Discriminant {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.place.get_lifetimes()
+    }
+}
+
+impl Aggregate {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        let mut lifetimes: Vec<LifetimeConst> = vec![];
+        for operand in &self.operands {
+            lifetimes.extend(operand.get_lifetimes());
+        }
+        let lifetimes_ty = self.ty.get_lifetimes();
+        lifetimes.extend(lifetimes_ty);
+        lifetimes
+    }
+}
+
+impl Operand {
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        self.expression.get_lifetimes()
+    }
+}
 
 impl Rvalue {
     pub fn check_no_default_position(&self) {
@@ -13,5 +98,31 @@ impl Rvalue {
             }
         }
         Checker.walk_rvalue(self)
+    }
+
+    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
+        match self {
+            Rvalue::Repeat(r) => r.get_lifetimes(),
+            Rvalue::Ref(r) => r.get_lifetimes(),
+            Rvalue::Reborrow(r) => r.get_lifetimes(),
+            Rvalue::AddressOf(r) => r.get_lifetimes(),
+            Rvalue::Len(r) => r.get_lifetimes(),
+            Rvalue::BinaryOp(r) => r.get_lifetimes(),
+            Rvalue::CheckedBinaryOp(r) => r.get_lifetimes(),
+            Rvalue::UnaryOp(r) => r.get_lifetimes(),
+            Rvalue::Discriminant(r) => r.get_lifetimes(),
+            Rvalue::Aggregate(r) => r.get_lifetimes(),
+        }
+    }
+
+    pub fn get_lifetimes_as_var(&self) -> Vec<VariableDecl> {
+        let lifetimes_const = self.get_lifetimes();
+        lifetimes_const
+            .iter()
+            .map(|lifetime| VariableDecl {
+                name: lifetime.name.clone(),
+                ty: Type::Lifetime,
+            })
+            .collect()
     }
 }

--- a/vir/defs/high/operations_internal/ty.rs
+++ b/vir/defs/high/operations_internal/ty.rs
@@ -95,37 +95,6 @@ impl Type {
         }
         DefaultLifetimeEraser {}.fold_type(self.clone())
     }
-    pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        match self {
-            Type::Reference(reference) => {
-                let mut lifetimes = vec![reference.lifetime.clone()];
-                let target_lifetimes = reference.target_type.get_lifetimes();
-                lifetimes.extend(target_lifetimes);
-                lifetimes
-            }
-            Type::Tuple(Tuple { lifetimes, .. })
-            | Type::Struct(Struct { lifetimes, .. })
-            | Type::Sequence(Sequence { lifetimes, .. })
-            | Type::Map(Map { lifetimes, .. })
-            | Type::Enum(Enum { lifetimes, .. })
-            | Type::Array(Array { lifetimes, .. })
-            | Type::Slice(Slice { lifetimes, .. })
-            | Type::Projection(Projection { lifetimes, .. })
-            | Type::Trusted(Trusted { lifetimes, .. })
-            | Type::Union(Union { lifetimes, .. }) => lifetimes.clone(),
-            _ => vec![],
-        }
-    }
-    pub fn get_lifetimes_as_var(&self) -> Vec<VariableDecl> {
-        let lifetimes_const = self.get_lifetimes();
-        lifetimes_const
-            .iter()
-            .map(|lifetime| VariableDecl {
-                name: lifetime.name.clone(),
-                ty: Type::Lifetime,
-            })
-            .collect()
-    }
     pub fn contains_type_variables(&self) -> bool {
         match self {
             Self::Sequence(Sequence { element_type, .. })

--- a/vir/defs/high/operations_internal/ty.rs
+++ b/vir/defs/high/operations_internal/ty.rs
@@ -1,6 +1,9 @@
 use super::super::ast::{
     expression::{visitors::ExpressionFolder, *},
-    ty::{visitors::TypeFolder, *},
+    ty::{
+        visitors::{default_walk_reference, default_walk_type, TypeFolder, TypeWalker},
+        *,
+    },
     type_decl::DiscriminantValue,
 };
 use rustc_hash::FxHashMap;
@@ -14,19 +17,23 @@ impl Type {
                 name,
                 arguments,
                 variant: None,
+                lifetimes,
             }) => Type::Enum(Enum {
                 name,
                 arguments,
                 variant: Some(variant),
+                lifetimes,
             }),
             Type::Union(Union {
                 name,
                 arguments,
                 variant: None,
+                lifetimes,
             }) => Type::Union(Union {
                 name,
                 arguments,
                 variant: Some(variant),
+                lifetimes,
             }),
             Type::Enum(_) => {
                 unreachable!("setting variant on enum type that already has variant set");
@@ -47,19 +54,23 @@ impl Type {
                 name,
                 arguments,
                 variant: Some(_),
+                lifetimes,
             }) => Some(Type::Enum(Enum {
                 name: name.clone(),
                 arguments: arguments.clone(),
                 variant: None,
+                lifetimes: lifetimes.clone(),
             })),
             Type::Union(Union {
                 name,
                 arguments,
                 variant: Some(_),
+                lifetimes,
             }) => Some(Type::Union(Union {
                 name: name.clone(),
                 arguments: arguments.clone(),
                 variant: None,
+                lifetimes: lifetimes.clone(),
             })),
             _ => None,
         }
@@ -74,37 +85,58 @@ impl Type {
             _ => false,
         }
     }
-    pub fn erase_lifetime(&mut self) {
-        if let Type::Reference(reference) = self {
-            reference.lifetime = LifetimeConst::erased();
-        }
-    }
-    pub fn erase_lifetimes(self) -> Self {
+    #[must_use]
+    pub fn erase_lifetimes(&self) -> Self {
         struct DefaultLifetimeEraser {}
         impl TypeFolder for DefaultLifetimeEraser {
             fn fold_lifetime_const(&mut self, _lifetime: LifetimeConst) -> LifetimeConst {
                 LifetimeConst::erased()
             }
         }
-        DefaultLifetimeEraser {}.fold_type(self)
+        DefaultLifetimeEraser {}.fold_type(self.clone())
     }
     pub fn get_lifetimes(&self) -> Vec<LifetimeConst> {
-        if let Type::Reference(reference) = self {
-            vec![reference.lifetime.clone()]
-        } else {
-            Vec::new()
+        match self {
+            Type::Reference(reference) => {
+                let mut lifetimes = vec![reference.lifetime.clone()];
+                let target_lifetimes = reference.target_type.get_lifetimes();
+                lifetimes.extend(target_lifetimes);
+                lifetimes
+            }
+            Type::Tuple(Tuple { lifetimes, .. })
+            | Type::Struct(Struct { lifetimes, .. })
+            | Type::Sequence(Sequence { lifetimes, .. })
+            | Type::Map(Map { lifetimes, .. })
+            | Type::Enum(Enum { lifetimes, .. })
+            | Type::Array(Array { lifetimes, .. })
+            | Type::Slice(Slice { lifetimes, .. })
+            | Type::Projection(Projection { lifetimes, .. })
+            | Type::Trusted(Trusted { lifetimes, .. })
+            | Type::Union(Union { lifetimes, .. }) => lifetimes.clone(),
+            _ => vec![],
         }
+    }
+    pub fn get_lifetimes_as_var(&self) -> Vec<VariableDecl> {
+        let lifetimes_const = self.get_lifetimes();
+        lifetimes_const
+            .iter()
+            .map(|lifetime| VariableDecl {
+                name: lifetime.name.clone(),
+                ty: Type::Lifetime,
+            })
+            .collect()
     }
     pub fn contains_type_variables(&self) -> bool {
         match self {
-            Self::Sequence(Sequence { element_type })
+            Self::Sequence(Sequence { element_type, .. })
             | Self::Array(Array { element_type, .. })
-            | Self::Slice(Slice { element_type }) => element_type.is_type_var(),
+            | Self::Slice(Slice { element_type, .. }) => element_type.is_type_var(),
             Self::Reference(Reference { target_type, .. })
             | Self::Pointer(Pointer { target_type, .. }) => target_type.is_type_var(),
             Self::Map(ty) => ty.key_type.is_type_var() || ty.val_type.is_type_var(),
             Self::TypeVar(_) => true,
-            Self::Tuple(Tuple { arguments })
+            Self::Tuple(Tuple { arguments, .. })
+            | Self::Trusted(Trusted { arguments, .. })
             | Self::Struct(Struct { arguments, .. })
             | Self::Enum(Enum { arguments, .. })
             | Self::Union(Union { arguments, .. })
@@ -118,7 +150,6 @@ impl Type {
                 unimplemented!();
             }
             Self::Unsupported(_) => true,
-            Self::Trusted(_) => true,
             _ => false,
         }
     }

--- a/vir/defs/high/operations_internal/type_decl.rs
+++ b/vir/defs/high/operations_internal/type_decl.rs
@@ -1,7 +1,7 @@
 use super::super::ast::{
     field::FieldDecl,
     ty::Type,
-    type_decl::{Enum, Struct, Tuple, TypeDecl, Union},
+    type_decl::{Enum, Struct, Trusted, Tuple, TypeDecl, Union},
 };
 
 impl Enum {
@@ -42,6 +42,12 @@ impl Tuple {
                     argument_type.clone(),
                 ))
             })
+    }
+}
+
+impl Trusted {
+    pub fn iter_fields(&self) -> impl Iterator<Item = std::borrow::Cow<'_, FieldDecl>> {
+        self.fields.iter().map(std::borrow::Cow::Borrowed)
     }
 }
 

--- a/vir/defs/high/operations_internal/type_decl.rs
+++ b/vir/defs/high/operations_internal/type_decl.rs
@@ -45,12 +45,6 @@ impl Tuple {
     }
 }
 
-impl Trusted {
-    pub fn iter_fields(&self) -> impl Iterator<Item = std::borrow::Cow<'_, FieldDecl>> {
-        self.fields.iter().map(std::borrow::Cow::Borrowed)
-    }
-}
-
 impl Struct {
     pub fn iter_fields(&self) -> impl Iterator<Item = std::borrow::Cow<'_, FieldDecl>> {
         self.fields.iter().map(std::borrow::Cow::Borrowed)

--- a/vir/defs/middle/operations_internal/mod.rs
+++ b/vir/defs/middle/operations_internal/mod.rs
@@ -6,6 +6,7 @@ copy_module!(crate::high::operations_internal::predicate);
 copy_module!(crate::high::operations_internal::procedure);
 copy_module!(crate::high::operations_internal::successor);
 copy_module!(crate::high::operations_internal::ty);
+copy_module!(crate::high::operations_internal::lifetimes);
 copy_module!(crate::high::operations_internal::type_decl);
 copy_module!(crate::high::operations_internal::special_variables);
 copy_module!(crate::high::operations_internal::rvalue);

--- a/vir/src/low/macros.rs
+++ b/vir/src/low/macros.rs
@@ -61,7 +61,7 @@ pub macro expr {
     )) ) => {
         {
             let mut arguments = vec![ $( $crate::low::macros::expr!( $argument ) ),* ];
-            $( arguments.extend($argument_list); )?
+            $( arguments.extend($argument_list.clone()); )?
             $crate::low::ast::expression::Expression::predicate_access_predicate_no_pos(
                 format!(
                     "{}${}",
@@ -73,9 +73,10 @@ pub macro expr {
             )
         }
     },
-    ( acc($predicate_name:ident<$ty:tt>( $($argument:tt),*), $perm:tt) ) => {
+    ( acc($predicate_name:ident<$ty:tt>( $($argument:tt),* $(; $argument_list:ident )?), $perm:tt) ) => {
         {
             let mut arguments = vec![ $( $crate::low::macros::expr!( $argument ) ),* ];
+            $( arguments.extend($argument_list); )?
             $crate::low::ast::expression::Expression::predicate_access_predicate_no_pos(
                 format!(
                     "{}${}",


### PR DESCRIPTION
 - Add `lifetimes` vector to type variants (from `mir`)
 - Clean and fix `erase_lifetimes`
 - Add support for `Trusted`
 - Fix/Enhance lifetime encoding for various predicates/methods/functions