### PR TITLE
Fix env list parsing

### DIFF
--- a/prusti-common/src/config.rs
+++ b/prusti-common/src/config.rs
@@ -178,7 +178,14 @@ lazy_static::lazy_static! {
 
         // 4. Override with env variables (`PRUSTI_VIPER_BACKEND`, ...)
         settings.merge(
-            Environment::with_prefix("PRUSTI").ignore_empty(true)
+            Environment::with_prefix("PRUSTI")
+                .ignore_empty(true)
+                .try_parsing(true)
+                .with_list_parse_key("delete_basic_blocks")
+                .with_list_parse_key("extra_jvm_args")
+                .with_list_parse_key("extra_verifier_args")
+                .with_list_parse_key("verify_only_basic_block_path")
+                .list_separator("_")
         ).unwrap();
         check_keys(&settings, &allowed_keys, "environment variables");
 
@@ -241,7 +248,7 @@ fn read_setting<T>(name: &'static str) -> T
 where
     T: Deserialize<'static>,
 {
-    read_optional_setting(name).unwrap_or_else(|| panic!("Failed to read setting {:?}", name))
+    SETTINGS.read().unwrap().get(name).expect(&format!("Failed to read setting {}", name))
 }
 
 // The following methods are all convenience wrappers for the actual call to

--- a/prusti-common/src/config.rs
+++ b/prusti-common/src/config.rs
@@ -185,7 +185,7 @@ lazy_static::lazy_static! {
                 .with_list_parse_key("extra_jvm_args")
                 .with_list_parse_key("extra_verifier_args")
                 .with_list_parse_key("verify_only_basic_block_path")
-                .list_separator("_")
+                .list_separator(" ")
         ).unwrap();
         check_keys(&settings, &allowed_keys, "environment variables");
 

--- a/prusti-common/src/config.rs
+++ b/prusti-common/src/config.rs
@@ -248,7 +248,7 @@ fn read_setting<T>(name: &'static str) -> T
 where
     T: Deserialize<'static>,
 {
-    SETTINGS.read().unwrap().get(name).expect(&format!("Failed to read setting {}", name))
+    SETTINGS.read().unwrap().get(name).unwrap_or_else(|e| panic!("Failed to read setting {} due to {}", name, e))
 }
 
 // The following methods are all convenience wrappers for the actual call to


### PR DESCRIPTION
Prusti did not accept `Vec<String>` arguments passed as environment variables. This PR fixes that.

As an example, with the export `export PRUSTI_EXTRA_VERIFIER_ARGS="--proverEnableResourceBounds"`,

Prusti would crash saying:

```
thread 'rustc' panicked at 'Failed to read setting "extra_verifier_args"', prusti-common/src/config.rs:242:51
```

This PR also makes that error more descriptive (revealing the underlying error from config-rs)