### PR TITLE
Improve extern spec lifetime handling

### DIFF
--- a/prusti-interface/src/specs/external.rs
+++ b/prusti-interface/src/specs/external.rs
@@ -159,21 +159,9 @@ impl<'v, 'tcx: 'v> ExternSpecResolver<'v, 'tcx> {
                     // type substitutions applied.
                     // TODO: there is more that we could check, e.g. that trait
                     // constraints are the same (otherwise specs might not make sense)
-                    //
-                    // Note that we only consider types, and exclude lifetimes,
-                    // because the external spec may introduce lifetimes that
-                    // are elided in the resolved method. In particular, a
-                    // function `fn get(&self, k: &K) -> &V` uses the lifetime
-                    // of `self` for elided lifetimes. Because the translation
-                    // of the extern spec does not use `self`, it is necessary
-                    // to explicitly introduce the lifetime:
-                    // `pub fn get<'a>(&'a self, k: &Q) -> Option<&'a V>`
-                    //  For more details see the lifetime elision rules here:
-                    //  https://doc.rust-lang.org/nomicon/lifetime-elision.html
-                    let current_substs = self.env.identity_substs(current_def_id).types().collect::<Vec<_>>();
-                    let resolved_substs = self.env.identity_substs(resolved_def_id).types().collect::<Vec<_>>();
-                    if current_substs.len() != resolved_substs.len() {
-                        let diff = resolved_substs.len() as isize - current_substs.len() as isize;
+                    if self.env.identity_substs(resolved_def_id).len() != self.env.identity_substs(current_def_id).len() {
+                        let diff = self.env.identity_substs(resolved_def_id).len() as isize
+                                            - self.env.identity_substs(current_def_id).len() as isize;
                         self.errors.push(
                             ExternSpecResolverError::InvalidGenerics(diff, resolved_def_id, span),
                         );

--- a/prusti-interface/src/specs/external.rs
+++ b/prusti-interface/src/specs/external.rs
@@ -159,9 +159,21 @@ impl<'v, 'tcx: 'v> ExternSpecResolver<'v, 'tcx> {
                     // type substitutions applied.
                     // TODO: there is more that we could check, e.g. that trait
                     // constraints are the same (otherwise specs might not make sense)
-                    if self.env.identity_substs(resolved_def_id).len() != self.env.identity_substs(current_def_id).len() {
-                        let diff = self.env.identity_substs(resolved_def_id).len() as isize
-                                            - self.env.identity_substs(current_def_id).len() as isize;
+                    //
+                    // Note that we only consider types, and exclude lifetimes,
+                    // because the external spec may introduce lifetimes that
+                    // are elided in the resolved method. In particular, a
+                    // function `fn get(&self, k: &K) -> &V` uses the lifetime
+                    // of `self` for elided lifetimes. Because the translation
+                    // of the extern spec does not use `self`, it is necessary
+                    // to explicitly introduce the lifetime:
+                    // `pub fn get<'a>(&'a self, k: &Q) -> Option<&'a V>`
+                    //  For more details see the lifetime elision rules here:
+                    //  https://doc.rust-lang.org/nomicon/lifetime-elision.html
+                    let current_substs = self.env.identity_substs(current_def_id).types().collect::<Vec<_>>();
+                    let resolved_substs = self.env.identity_substs(resolved_def_id).types().collect::<Vec<_>>();
+                    if current_substs.len() != resolved_substs.len() {
+                        let diff = resolved_substs.len() as isize - current_substs.len() as isize;
                         self.errors.push(
                             ExternSpecResolverError::InvalidGenerics(diff, resolved_def_id, span),
                         );

--- a/prusti-specs/src/common.rs
+++ b/prusti-specs/src/common.rs
@@ -295,11 +295,12 @@ mod receiver_rewriter {
         fn visit_fn_arg_mut(&mut self, fn_arg: &mut FnArg) {
             if let FnArg::Receiver(receiver) = fn_arg {
                 let span = receiver.span();
-                let and = if receiver.reference.is_some() {
-                    // TODO: do lifetimes need to be specified here?
-                    quote_spanned! {span=> &}
-                } else {
-                    quote! {}
+                let and = match &receiver.reference {
+                    Some((_, Some(lifetime))) =>
+                        quote_spanned!{span => &#lifetime},
+                    Some((_, None)) =>
+                        quote_spanned!{span => &},
+                    None => quote! {}
                 };
                 let mutability = &receiver.mutability;
                 let new_ty = self.new_ty;

--- a/prusti-specs/src/extern_spec_rewriter/common.rs
+++ b/prusti-specs/src/extern_spec_rewriter/common.rs
@@ -9,13 +9,12 @@ use crate::untyped::AnyFnItem;
 use syn::visit::Visit;
 use syn::visit_mut::VisitMut;
 
+/// Counts the number of elided lifetimes in receivers and types.
+/// For details see the function `with_explicit_lifetimes`.
 struct ElidedLifetimeCounter {
     num_elided_lifetimes: u32
 }
 
-struct SelfLifetimeInserter {
-
-}
 
 impl ElidedLifetimeCounter {
     fn new() -> ElidedLifetimeCounter {
@@ -37,31 +36,45 @@ impl <'ast> syn::visit::Visit<'ast> for ElidedLifetimeCounter {
     }
 }
 
-impl <'ast> syn::visit_mut::VisitMut for SelfLifetimeInserter {
-    fn visit_type_reference_mut(&mut self, reference: &mut syn::TypeReference) {
-        reference.lifetime = parse_quote_spanned!{reference.span() => 'prusti_self_lifetime };
-    }
-
-    fn visit_receiver_mut(&mut self, receiver: &mut syn::Receiver) {
-        receiver.reference.as_mut().unwrap().1 = parse_quote_spanned!{receiver.span() => 'prusti_self_lifetime };
-    }
-}
 
 fn has_multiple_elided_lifetimes(inputs: &Punctuated<FnArg, syn::token::Comma>) -> bool {
     let mut visitor = ElidedLifetimeCounter::new();
     for input in inputs {
         visitor.visit_fn_arg(input);
     }
-    return visitor.num_elided_lifetimes > 1;
+    visitor.num_elided_lifetimes > 1
 }
 
 fn returns_reference_with_elided_lifetime(return_type: &syn::ReturnType) -> bool {
     let mut visitor = ElidedLifetimeCounter::new();
     visitor.visit_return_type(return_type);
-    return visitor.num_elided_lifetimes >= 1;
+    visitor.num_elided_lifetimes >= 1
 }
 
+/// Rust has a special lifetime elision rule for methods containing `&self` or
+/// `&mut self` (see rule 3 here: https://doc.rust-lang.org/nomicon/lifetime-elision.html)
+///
+/// Because the extern spec replaces `self` with `_self`; Rust will not apply this rule
+/// to the rewritten spec. This function detects if Rust would apply the rule 3 lifetime elision
+/// rules for the original signature; and if so, returns a new signature with explicit lifetime
+/// annotations. The explicit lifetime annotations correspond to what Rust would assign
+/// for the elided lifetimes in the original signature.
 fn with_explicit_lifetimes(sig: &syn::Signature) -> Option<syn::Signature> {
+
+    // This struct is responsible for inserting an explicit lifetime for elided
+    // lifetimes in the receiver and output type.
+    struct SelfLifetimeInserter {}
+
+    impl syn::visit_mut::VisitMut for SelfLifetimeInserter {
+        fn visit_type_reference_mut(&mut self, reference: &mut syn::TypeReference) {
+            reference.lifetime = parse_quote_spanned!{reference.span() => 'prusti_self_lifetime };
+        }
+
+        fn visit_receiver_mut(&mut self, receiver: &mut syn::Receiver) {
+            receiver.reference.as_mut().unwrap().1 = parse_quote_spanned!{receiver.span() => 'prusti_self_lifetime };
+        }
+    }
+
     if !returns_reference_with_elided_lifetime(&sig.output) ||
        !has_multiple_elided_lifetimes(&sig.inputs)
     {
@@ -69,12 +82,18 @@ fn with_explicit_lifetimes(sig: &syn::Signature) -> Option<syn::Signature> {
     }
     let mut new_sig = sig.clone();
     let mut inserter = SelfLifetimeInserter{};
+
+    // Insert explicit lifetime parameter to method signature
     new_sig.generics.params.insert(0, parse_quote_spanned!{new_sig.generics.params.span() => 'prusti_self_lifetime });
+
+    // Assign the explicit lifetime to the reference to self
     if let Some(syn::FnArg::Receiver(r)) = new_sig.inputs.first_mut() {
         inserter.visit_receiver_mut(r)
     }
+
+    // Assign the explicit lifetime to references in the output
     inserter.visit_return_type_mut(&mut new_sig.output);
-    return Some(new_sig);
+    Some(new_sig)
 }
 
 /// Generates a method stub and spec functions for an externally specified function.
@@ -105,7 +124,9 @@ pub(crate) fn generate_extern_spec_method_stub<T: HasSignature + HasAttributes +
     extern_spec_kind: ExternSpecKind,
 ) -> syn::Result<(syn::ImplItemMethod, Vec<syn::ImplItemMethod>)> {
     let base_sig = method.sig();
-    let method_sig = with_explicit_lifetimes(base_sig).unwrap_or(base_sig.clone());
+
+    // Make elided lifetimes explicit, if necessary.
+    let method_sig = with_explicit_lifetimes(base_sig).unwrap_or_else(|| base_sig.clone());
     let method_sig_span = method_sig.span();
     let method_ident = &method_sig.ident;
 

--- a/prusti-tests/tests/verify_overflow/pass/extern-spec/map.rs
+++ b/prusti-tests/tests/verify_overflow/pass/extern-spec/map.rs
@@ -1,0 +1,32 @@
+use prusti_contracts::*;
+
+#[extern_spec]
+impl<T> std::option::Option<T> {
+    #[pure]
+    pub fn is_some(&self) -> bool;
+}
+
+#[extern_spec]
+impl<K, V, S: std::hash::BuildHasher> std::collections::HashMap<K, V, S> {
+    #[pure]
+    #[ensures(result.is_some() == self.contains_key(k))]
+    pub fn get<'a, Q: ?Sized>(&'a self, k: &Q) -> Option<&'a V>
+    where
+        K: core::borrow::Borrow<Q> + std::cmp::Eq + std::hash::Hash,
+        Q: core::hash::Hash + Eq;
+
+    #[pure]
+    fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        K: core::borrow::Borrow<Q> + std::cmp::Eq + std::hash::Hash,
+        Q: core::hash::Hash + Eq;
+}
+
+#[requires(m.contains_key(&key))]
+fn go(key: u32, m: &std::collections::HashMap<u32, bool>) {
+    let result = m.get(&key);
+    assert!(result.is_some())
+}
+
+fn main(){
+}

--- a/prusti-tests/tests/verify_overflow/pass/extern-spec/map_unchanged.rs
+++ b/prusti-tests/tests/verify_overflow/pass/extern-spec/map_unchanged.rs
@@ -1,0 +1,32 @@
+use prusti_contracts::*;
+
+#[extern_spec]
+impl<T> std::option::Option<T> {
+    #[pure]
+    pub fn is_some(&self) -> bool;
+}
+
+#[extern_spec]
+impl<K, V, S: std::hash::BuildHasher> std::collections::HashMap<K, V, S> {
+    #[pure]
+    #[ensures(result.is_some() == self.contains_key(k))]
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: core::borrow::Borrow<Q> + std::cmp::Eq + std::hash::Hash,
+        Q: core::hash::Hash + Eq;
+
+    #[pure]
+    fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        K: core::borrow::Borrow<Q> + std::cmp::Eq + std::hash::Hash,
+        Q: core::hash::Hash + Eq;
+}
+
+#[requires(m.contains_key(&key))]
+fn go(key: u32, m: &std::collections::HashMap<u32, bool>) {
+    let result = m.get(&key);
+    assert!(result.is_some())
+}
+
+fn main(){
+}


### PR DESCRIPTION
Due to lifetime elision rules, lifetimes that can be elided in a method need to be explicitly annotated in an extern spec. This PR weakens the validity check for extern specs to ignore lifetimes (since they wont match).