### PR TITLE
Retry "fetch" if it failed in test-crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,6 +2879,7 @@ dependencies = [
  "color-backtrace",
  "csv",
  "env_logger",
+ "failure",
  "glob",
  "log",
  "prusti",

--- a/test-crates/Cargo.toml
+++ b/test-crates/Cargo.toml
@@ -16,4 +16,4 @@ serde = "1.0"
 toml = "0.5.8"
 glob = "0.3.0"
 clap = { version = "3.1", features = ["derive"] }
-
+failure = "0.1.3"

--- a/test-crates/src/main.rs
+++ b/test-crates/src/main.rs
@@ -132,7 +132,7 @@ struct Args {
 fn attempt_fetch(krate: &Crate, workspace: &Workspace, num_retries: u8) -> Result<(), failure::Error> {
     let mut i = 0;
     while i < num_retries + 1 {
-        if let Err(err) = krate.fetch(&workspace) {
+        if let Err(err) = krate.fetch(workspace) {
             warn!("Error fetching crate {}: {}", krate, err);
             if i == num_retries {
                 // Last attempt failed, return the error


### PR DESCRIPTION
Sometimes the `test-crates` task fails due to an intermittent network failure. This PR ensures that it will retry if a failure occurs.
