### PR TITLE
Fix trait selection bug

### DIFF
--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -489,7 +489,16 @@ impl<'tcx> Environment<'tcx> {
                 )
             });
             match result {
-                Ok(Some(ImplSource::UserDefined(data))) => Some(data.impl_def_id),
+                Ok(Some(ImplSource::UserDefined(data))) => {
+                    for item in self.tcx().associated_items(data.impl_def_id).in_definition_order() {
+                        if let Some(id) = item.trait_item_def_id {
+                            if id == proc_def_id {
+                                return Some(item.def_id);
+                            }
+                        }
+                    }
+                    unreachable!()
+                },
                 _ => None
             }
         } else {

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -473,6 +473,7 @@ impl<'tcx> Environment<'tcx> {
                 let mut sc = SelectionContext::new(&infcx);
                 let obligation = Obligation::new(
                     ObligationCause::dummy(),
+                    // TODO(tymap): don't use reveal_all
                     ty::ParamEnv::reveal_all(),
                     Binder::dummy(TraitPredicate {
                         trait_ref: TraitRef {

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -9,9 +9,10 @@
 use prusti_rustc_interface::middle::mir;
 use prusti_rustc_interface::hir::hir_id::HirId;
 use prusti_rustc_interface::hir::def_id::{DefId, LocalDefId};
-use prusti_rustc_interface::middle::ty::{self, TyCtxt};
+use prusti_rustc_interface::middle::ty::{self, Binder, BoundConstness, ImplPolarity, TraitPredicate, TraitRef, TyCtxt};
 use prusti_rustc_interface::middle::ty::subst::{Subst, SubstsRef};
 use prusti_rustc_interface::trait_selection::infer::{InferCtxtExt, TyCtxtInferExt};
+use prusti_rustc_interface::trait_selection::traits::{ImplSource, Obligation, ObligationCause, SelectionContext};
 use std::path::PathBuf;
 use prusti_rustc_interface::errors::{DiagnosticBuilder, EmissionGuarantee, MultiSpan};
 use prusti_rustc_interface::span::{Span, symbol::Symbol};
@@ -468,21 +469,27 @@ impl<'tcx> Environment<'tcx> {
         // TODO(tymap): remove this method?
         if let Some(trait_id) = self.tcx().trait_of_item(proc_def_id) {
             debug!("Fetching implementations of method '{:?}' defined in trait '{}' with substs '{:?}'", proc_def_id, self.tcx().def_path_str(trait_id), substs);
-
-            // TODO(tymap): don't use reveal_all
-            let param_env = ty::ParamEnv::reveal_all();
-            let key = ty::ParamEnvAnd { param_env, value: (proc_def_id, substs) };
-            let resolved_instance = traits::resolve_instance(self.tcx(), key);
-            match resolved_instance {
-                Ok(method_impl_instance) => {
-                    let impl_method_def_id = method_impl_instance.map(|instance| instance.def_id());
-                    debug!("Resolved to-be called method: {:?}", impl_method_def_id);
-                    impl_method_def_id
-                },
-                Err(err) => {
-                    debug!("Error while resolving the to-be called method: {:?}", err);
-                    None
-                }
+            let result = self.tcx.infer_ctxt().enter(|infcx| {
+                let mut sc = SelectionContext::new(&infcx);
+                let obligation = Obligation::new(
+                    ObligationCause::dummy(),
+                    ty::ParamEnv::reveal_all(),
+                    Binder::dummy(TraitPredicate {
+                        trait_ref: TraitRef {
+                            def_id: trait_id,
+                            substs
+                        },
+                        constness: BoundConstness::NotConst,
+                        polarity: ImplPolarity::Positive,
+                    })
+                );
+                sc.select(
+                    &obligation
+                )
+            });
+            match result {
+                Ok(Some(ImplSource::UserDefined(data))) => Some(data.impl_def_id),
+                _ => None
             }
         } else {
             None
@@ -551,11 +558,10 @@ impl<'tcx> Environment<'tcx> {
     /// Returns false if the predicate is not fulfilled or it could not be evaluated.
     pub fn evaluate_predicate(&self, predicate: ty::Predicate<'tcx>, param_env: ty::ParamEnv<'tcx>) -> bool{
         debug!("Evaluating predicate {:?}", predicate);
-        use prusti_rustc_interface::trait_selection::traits;
         use prusti_rustc_interface::trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
 
-        let obligation = traits::Obligation::new(
-            traits::ObligationCause::dummy(),
+        let obligation = Obligation::new(
+            ObligationCause::dummy(),
             param_env,
             predicate,
         );

--- a/prusti-tests/tests/verify_overflow/pass/extern-spec/derive-clone.rs
+++ b/prusti-tests/tests/verify_overflow/pass/extern-spec/derive-clone.rs
@@ -1,5 +1,3 @@
-
-
 #[prusti_contracts::extern_spec]
 impl<T: Clone> Clone for PeerList<T> {
     fn clone(&self) -> PeerList<T>;

--- a/prusti-tests/tests/verify_overflow/pass/extern-spec/derive-clone.rs
+++ b/prusti-tests/tests/verify_overflow/pass/extern-spec/derive-clone.rs
@@ -1,11 +1,26 @@
-#[derive(Clone)]
+use prusti_contracts::*;
+
+#[derive(Clone, PartialEq)]
 struct PeerList<T> {
     thing: T
 }
 
-#[prusti_contracts::extern_spec]
-impl<T: Clone> Clone for PeerList<T> {
-    fn clone(&self) -> PeerList<T>;
+#[extern_spec]
+impl <T: Clone + Eq> Clone for PeerList<T> {
+    #[ensures(some_property(self) ==> some_property(&result))]
+    pub fn clone(&self) -> PeerList<T>;
+}
+
+#[pure]
+#[trusted]
+fn some_property<T>(list: &PeerList<T>) -> bool {
+    panic!()
+}
+
+#[requires(some_property(t))]
+fn go(t: &PeerList<u32>) {
+    let t2 = t.clone();
+    assert!(some_property(&t2));
 }
 
 fn main(){}

--- a/prusti-tests/tests/verify_overflow/pass/extern-spec/derive-clone.rs
+++ b/prusti-tests/tests/verify_overflow/pass/extern-spec/derive-clone.rs
@@ -1,3 +1,8 @@
+#[derive(Clone)]
+struct PeerList<T> {
+    thing: T
+}
+
 #[prusti_contracts::extern_spec]
 impl<T: Clone> Clone for PeerList<T> {
     fn clone(&self) -> PeerList<T>;

--- a/prusti-tests/tests/verify_overflow/pass/extern-spec/derive-clone.rs
+++ b/prusti-tests/tests/verify_overflow/pass/extern-spec/derive-clone.rs
@@ -1,0 +1,8 @@
+
+
+#[prusti_contracts::extern_spec]
+impl<T: Clone> Clone for PeerList<T> {
+    fn clone(&self) -> PeerList<T>;
+}
+
+fn main(){}

--- a/prusti-tests/tests/verify_overflow/pass/extern-spec/trait-impl/traits-4.rs
+++ b/prusti-tests/tests/verify_overflow/pass/extern-spec/trait-impl/traits-4.rs
@@ -1,5 +1,3 @@
-// ignore-test https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Resolving.20a.20.60clone.60.20call.20to.20a.20.60DefId.60/near/290366147
-
 #![feature(allocator_api)]
 
 use prusti_contracts::*;


### PR DESCRIPTION
For some reason the existing code for trait selection did not find the associated trait for an extern spec in one example. This PR re-uses Rust's existing code for trait selection, which fixes the problem.
