### PR TITLE
Erase regions for type invariants

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/invariants/map.rs
+++ b/prusti-tests/tests/verify_overflow/pass/invariants/map.rs
@@ -1,0 +1,12 @@
+// compile-flags: -Penable_type_invariants=true
+use std::collections::BTreeSet;
+
+// No invariants are used here, but the encoding of the `union` operation
+// introduces datatypes that only vary in a generic lifetime parameter. For the
+// purpose of type invariants, these datatypes should be treated as the same
+// datatype.
+fn union(lhs: &BTreeSet<u32>) {
+    lhs.union(lhs).cloned();
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/mir/type_invariants/interface.rs
+++ b/prusti-viper/src/encoder/mir/type_invariants/interface.rs
@@ -32,6 +32,8 @@ impl<'v, 'tcx: 'v> TypeInvariantEncoderInterface<'tcx> for super::super::super::
         // match snapshot ref/box peeling
         let ty = crate::encoder::snapshot::encoder::strip_refs_and_boxes(ty);
 
+        let ty = self.env().tcx().erase_regions_ty(ty);
+
         if !needs_invariant_func(ty) {
             return Ok(true.into());
         }


### PR DESCRIPTION
Currently the type invariant encoding for Prusti will panic if it encodes two datatypes that differ only in a lifetime parameters. This is because Prusti encodes them distinct invariants for the two types, but generates the same Viper function name for both.

This implementation resolves this by erasing the memory regions from the types before encoding the invariant. This solves the panic; however, prevents the possibility of having distinct invariants for types only differing by an instantiation of the lifetime parameter. If there is such a use case this design could be re-considered.