### PR TITLE
Fix for quantified reference

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/quantifiers/reference.rs
+++ b/prusti-tests/tests/verify_overflow/pass/quantifiers/reference.rs
@@ -1,0 +1,7 @@
+use prusti_contracts::*;
+
+#[requires(forall(|t: &u32| (t != faulty_witness)))]
+fn req(faulty_witness: &u32) {
+}
+
+fn main(){}

--- a/prusti-tests/tests/verify_overflow/pass/quantifiers/reference.rs
+++ b/prusti-tests/tests/verify_overflow/pass/quantifiers/reference.rs
@@ -1,5 +1,6 @@
 use prusti_contracts::*;
 
+// This pre-condition is unsatisfiable, but Prusti should not crash
 #[requires(forall(|t: &u32| (t != faulty_witness)))]
 fn req(faulty_witness: &u32) {
 }

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -44,16 +44,19 @@ pub(super) fn inline_closure<'tcx>(
         let local_span = mir_encoder.get_local_span(arg_local);
         let local = mir_encoder.encode_local(arg_local).unwrap();
         let local_ty = mir.local_decls[arg_local].ty;
-        body_replacements.push((
-            encoder
-                .encode_value_expr(vir_crate::polymorphic::Expr::local(local), local_ty)
-                .with_span(local_span)?,
-            if arg_idx == 0 {
-                cl_expr.clone()
-            } else {
-                vir_crate::polymorphic::Expr::local(args[arg_idx - 1].clone())
-            },
-        ));
+        body_replacements.push(if arg_idx == 0 {
+            (
+                encoder
+                    .encode_value_expr(vir_crate::polymorphic::Expr::local(local), local_ty)
+                    .with_span(local_span)?,
+                cl_expr.clone(),
+            )
+        } else {
+            (
+                vir_crate::polymorphic::Expr::local(local),
+                vir_crate::polymorphic::Expr::local(args[arg_idx - 1].clone()),
+            )
+        });
     }
     Ok(encoder
         .encode_pure_expression(def_id, parent_def_id, substs)?


### PR DESCRIPTION
This fixes a fold/unfold error when handling a quantified reference (see the test case).

It appears the problem occurs in the inlining of the closure generated for the spec: the original implementation did not substitute the argument. This appears to be because the substitution map used the value expr of the argument rather than the argument itself; and the value expr of the argument is not used in the spec. Therefore, the substitution is never applied, and the unsubstituted local cannot be accessed by the fold/unfold algorithm. 

This PR changes the map to instead use the argument itself, rather than its value expr.