### PR TITLE
Generics improvements

### DIFF
--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -55,7 +55,10 @@ struct CachedBody<'tcx> {
     monomorphised_bodies: HashMap<SubstsRef<'tcx>, Rc<mir::Body<'tcx>>>,
     /// Cached borrowck information.
     borrowck_facts: Rc<BorrowckFacts>,
-
+    /// Copies of the MIR body with the given substs applied, called from the
+    /// given caller. This also allows for associated types to be correctly
+    /// normalised.
+    /// TODO: merge more nicely with monomorphised_bodies?
     monomorphised_bodies_with_caller: HashMap<(SubstsRef<'tcx>, LocalDefId), Rc<mir::Body<'tcx>>>,
 }
 

--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -40,7 +40,7 @@ impl<'tcx> Procedure<'tcx> {
         trace!("Encoding procedure {:?}", proc_def_id);
         let tcx = env.tcx();
         // TOOD(tymap): add substs to procedure? check usages
-        let mir = env.local_mir(proc_def_id.expect_local(), env.identity_substs(proc_def_id));
+        let mir = env.local_mir_with_caller(proc_def_id.expect_local(), proc_def_id.expect_local(), env.identity_substs(proc_def_id));
         let real_edges = RealEdges::new(&mir);
         let reachable_basic_blocks = build_reachable_basic_blocks(&mir, &real_edges);
         let nonspec_basic_blocks = build_nonspec_basic_blocks(&mir, &real_edges, &tcx);

--- a/prusti-tests/tests/verify_overflow/pass/generic/associated-copy.rs
+++ b/prusti-tests/tests/verify_overflow/pass/generic/associated-copy.rs
@@ -1,0 +1,15 @@
+use prusti_contracts::*;
+
+trait Trait {
+    type Assoc: Copy;
+
+    #[pure] fn output_copy(&self) -> Self::Assoc;
+    #[pure] fn input_copy(&self, x: Self::Assoc) -> bool;
+}
+
+#[requires(x.output_copy() === y)]
+#[requires(x.input_copy(z))]
+fn test<U: Copy, T: Trait<Assoc = U>>(x: &mut T, y: U, z: U) {}
+
+#[trusted]
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/generic/resolution.rs
+++ b/prusti-tests/tests/verify_overflow/pass/generic/resolution.rs
@@ -1,0 +1,231 @@
+use prusti_contracts::*;
+
+// Test generics and type parameter resolution at call sites. There are various
+// aspects/features that can complicate a method call resolution:
+//
+// 1. type parameters in the signature of the method
+// 2. lifetime parameters in the signature of the method
+// 3. type parameters in the impl block containing the method (= its struct)
+// 4. lifetime parameters in the impl block containing the method (= its struct)
+// 5. the method belongs to a trait
+// 6. associated types
+//
+// Test also calls from/to pure functions.
+
+type TupleIntInt = (i32, i32);
+type TupleIntUsize = (i32, usize);
+type TupleUsizeInt = (usize, i32);
+
+trait Valid1 { #[pure] fn valid1(&self) -> bool; }
+trait Valid2 { #[pure] fn valid2(&self) -> bool; }
+
+#[refine_trait_spec] impl Valid1 for i32 {
+    #[pure] fn valid1(&self) -> bool {
+        *self == 3
+    }
+}
+#[refine_trait_spec] impl Valid2 for i32 {
+    #[pure] fn valid2(&self) -> bool {
+        *self == 7
+    }
+}
+
+#[refine_trait_spec] impl Valid1 for TupleIntInt {
+    #[pure] fn valid1(&self) -> bool {
+        let valid = (8, 9);
+        *self == valid
+    }
+}
+#[refine_trait_spec] impl Valid2 for TupleIntInt {
+    #[pure] fn valid2(&self) -> bool {
+        let valid = (4, 5);
+        *self == valid
+    }
+}
+
+#[refine_trait_spec] impl Valid1 for TupleIntUsize {
+    #[pure] fn valid1(&self) -> bool {
+        let valid = (42, 43);
+        *self == valid
+    }
+}
+#[refine_trait_spec] impl Valid1 for TupleUsizeInt {
+    #[pure] fn valid1(&self) -> bool {
+        let valid = (33, 44);
+        *self == valid
+    }
+}
+
+#[refine_trait_spec] impl Valid1 for bool {
+    #[pure] fn valid1(&self) -> bool {
+        *self
+    }
+}
+#[refine_trait_spec] impl Valid2 for bool {
+    #[pure] fn valid2(&self) -> bool {
+        !*self
+    }
+}
+
+#[trusted]
+#[requires(a.valid1() && b.valid2())]
+#[ensures(result.valid1())]
+fn fn1<A: Valid1, B: Valid2, C: Valid1>(a: A, b: B) -> C { unimplemented!() }
+
+#[trusted]
+#[pure]
+#[requires(a.valid1() && b.valid2())]
+#[ensures(result.valid1())]
+fn pure_fn1<A: Valid1 + Copy, B: Valid2 + Copy, C: Valid1 + Copy>(a: A, b: B) -> C { unimplemented!() }
+
+#[requires(
+    pure_fn1::<i32, (i32, i32), bool>(3, (4, 5))
+)]
+fn test_fn1() {
+    assert!(fn1::<i32, (i32, i32), bool>(3, (4, 5)));
+    assert!(pure_fn1::<i32, (i32, i32), bool>(3, (4, 5)));
+}
+
+#[trusted]
+#[requires(a.valid2() && b.valid1())]
+#[ensures(result.valid2())]
+fn fn2<'a, 'b, A: Valid2, B: Valid1, C: Valid2>(a: &'a A, b: &'b B) -> C { unimplemented!() }
+
+#[trusted]
+#[pure]
+#[requires(a.valid2() && b.valid1())]
+#[ensures(result.valid2())]
+fn pure_fn2<'a, 'b, A: Valid2, B: Valid1, C: Valid2 + Copy>(a: &'a A, b: &'b B) -> C { unimplemented!() }
+
+// TODO: fold/unfold error when the precondition is enabled
+/*
+#[requires({
+    let a = 7;
+    let b = (8, 9);
+    pure_fn2::<i32, (i32, i32), bool>(&a, &b);
+})]
+*/
+fn test_fn2() {
+    let a = 7;
+    let b = (8, 9);
+    assert!(!fn2::<i32, (i32, i32), bool>(&a, &b));
+    assert!(!pure_fn2::<i32, (i32, i32), bool>(&a, &b));
+}
+
+struct X1<A, B>(A, B);
+impl<A: Valid1, B: Valid2> X1<A, B> {
+    #[trusted]
+    #[requires(a.valid1() && b.valid2())]
+    #[ensures(result.valid1())]
+    fn fn3<'a, 'b, C: Valid1>(&self, a: &'a A, b: &'b B) -> C { unimplemented!() }
+
+    #[trusted]
+    #[pure]
+    #[requires(a.valid1() && b.valid2())]
+    #[ensures(result.valid1())]
+    fn pure_fn3<'a, 'b, C: Valid1 + Copy>(&self, a: &'a A, b: &'b B) -> C { unimplemented!() }
+}
+
+fn test_fn3() {
+    let a = 3;
+    let b = (4, 5);
+    let x = X1::<i32, (i32, i32)>(0, (0, 0));
+    assert!(x.fn3::<bool>(&a, &b));
+    assert!(x.pure_fn3::<bool>(&a, &b));
+}
+
+// Using `&'a A` or `&'b B` directly in `X2` fails because Prusti tries to
+// encode the reference-typed fields `X2.0` resp. `X2.1`.
+struct X2<'a, 'b, A, B>(std::marker::PhantomData<&'a A>, std::marker::PhantomData<&'b B>);
+impl<'a, 'b, A: Valid2, B: Valid1> X2<'a, 'b, A, B> {
+    #[trusted]
+    #[requires(a.valid2() && b.valid1())]
+    #[ensures(result.valid2())]
+    fn fn4<C: Valid2>(&self, a: &'a A, b: &'b B) -> C { unimplemented!() }
+
+    #[trusted]
+    #[pure]
+    #[requires(a.valid2() && b.valid1())]
+    #[ensures(result.valid2())]
+    fn pure_fn4<C: Valid2 + Copy>(&self, a: &'a A, b: &'b B) -> C { unimplemented!() }
+}
+
+fn test_fn4<'a, 'b>(x: X2<'a, 'b, i32, (i32, i32)>) {
+    let a = 7;
+    let b = (8, 9);
+    assert!(!x.fn4::<bool>(&a, &b));
+    assert!(!x.pure_fn4::<bool>(&a, &b));
+}
+
+trait T1 {
+    #[requires(a.valid1() && b.valid2())]
+    #[ensures(result.valid1())]
+    fn fn5<A: Valid1, B: Valid2, C: Valid1>(&self, a: A, b: B) -> C;
+
+    #[pure]
+    #[requires(a.valid1() && b.valid2())]
+    #[ensures(result.valid1())]
+    fn pure_fn5<A: Valid1 + Copy, B: Valid2 + Copy, C: Valid1 + Copy>(&self, a: A, b: B) -> C;
+}
+
+struct X3 {}
+impl T1 for X3 {
+    #[trusted]
+    fn fn5<A, B, C>(&self, a: A, b: B) -> C { unimplemented!() }
+
+    #[trusted]
+    #[pure]
+    fn pure_fn5<A: Copy, B: Copy, C: Copy>(&self, a: A, b: B) -> C { unimplemented!() }
+}
+
+fn test_fn5<T: T1>(t: T, x: X3) {
+    assert!(t.fn5::<i32, (i32, i32), bool>(3, (4, 5)));
+    assert!(t.pure_fn5::<i32, (i32, i32), bool>(3, (4, 5)));
+    assert!(x.fn5::<i32, (i32, i32), bool>(3, (4, 5)));
+    assert!(x.pure_fn5::<i32, (i32, i32), bool>(3, (4, 5)));
+}
+
+trait T2 {
+    type AT1: Valid1 + Copy;
+    type AT2: Valid1 + Copy;
+
+    // TODO: the c.valid1() && d.valid1() constraint causes a panic;
+    //       we probably need to use the ParamEnv-respecting `local_mir`
+    //       throughout the codebase
+
+    #[requires(a.valid2() && b.valid1()
+        // && c.valid1() && d.valid1()
+    )]
+    #[ensures(result.valid2())]
+    fn fn6<A: Valid2, B: Valid1, C: Valid2>(&self, a: A, b: B, c: Self::AT1, d: Self::AT2) -> C;
+
+    #[pure]
+    #[requires(a.valid2() && b.valid1()
+        // && c.valid1() && d.valid1()
+    )]
+    #[ensures(result.valid2())]
+    fn pure_fn6<A: Valid2 + Copy, B: Valid1 + Copy, C: Valid2 + Copy>(&self, a: A, b: B, c: Self::AT1, d: Self::AT2) -> C;
+}
+
+struct X4 {}
+impl T2 for X4 {
+    type AT1 = (i32, usize);
+    type AT2 = (usize, i32);
+
+    #[trusted]
+    fn fn6<A: Valid2, B: Valid1, C: Valid2>(&self, a: A, b: B, c: (i32, usize), d: (usize, i32)) -> C { unimplemented!() }
+
+    #[trusted]
+    #[pure]
+    fn pure_fn6<A: Valid2 + Copy, B: Valid1 + Copy, C: Valid2 + Copy>(&self, a: A, b: B, c: (i32, usize), d: (usize, i32)) -> C { unimplemented!() }
+}
+
+fn test_fn6<T: T2<AT1 = (i32, usize), AT2 = (usize, i32)>>(t: T, x: X4) {
+    assert!(!t.fn6::<i32, (i32, i32), bool>(7, (8, 9), (42, 43), (33, 44)));
+    assert!(!t.pure_fn6::<i32, (i32, i32), bool>(7, (8, 9), (42, 43), (33, 44)));
+    assert!(!x.fn6::<i32, (i32, i32), bool>(7, (8, 9), (42, 43), (33, 44)));
+    assert!(!x.pure_fn6::<i32, (i32, i32), bool>(7, (8, 9), (42, 43), (33, 44)));
+}
+
+#[trusted]
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/generic/trait-lifetime.rs
+++ b/prusti-tests/tests/verify_overflow/pass/generic/trait-lifetime.rs
@@ -1,0 +1,12 @@
+use prusti_contracts::*;
+
+trait Trait<'a> {
+    type AT;
+}
+
+fn test<'a, T: Trait<'a>>(_t: T) -> T::AT {
+    unimplemented!()
+}
+
+#[trusted]
+fn main() {}

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-729-1.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-729-1.rs
@@ -1,7 +1,7 @@
 // FIXME: remove this compile flag when the new encoder is finished
 // compile-flags: -Puse_new_encoder=false
 
-// error-pattern: Precondition of function snap$__$TY$__Snap$struct$m_A$ might not hold
+// error-pattern: Precondition of function snap$__$TY$__Snap$struct$m_A$struct$m_A$Snap$struct$m_A might not hold
 // FIXME: https://github.com/viperproject/prusti-dev/issues/729
 #![allow(unused_comparisons)]
 use prusti_contracts::*;

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -712,7 +712,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
                 // TODO: Make sure that this encoded function does not end up in
                 // the Viper file because that would be unsound.
                 let identity_substs = self.env().identity_substs(proc_def_id);
-                if let Err(error) = self.encode_pure_function_def(proc_def_id, identity_substs) {
+                if let Err(error) = self.encode_pure_function_def(proc_def_id, proc_def_id, identity_substs) {
                     self.register_encoding_error(error);
                     debug!("Error encoding function: {:?}", proc_def_id);
                     // Skip encoding the function as a method.

--- a/prusti-viper/src/encoder/high/types/fields.rs
+++ b/prusti-viper/src/encoder/high/types/fields.rs
@@ -32,7 +32,8 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
         | vir::Type::Closure(_)
         | vir::Type::FunctionDef(_)
         | vir::Type::FnPointer
-        | vir::Type::TypeVar(_) => vir::FieldDecl::new("val_ref", 0usize, ty),
+        | vir::Type::TypeVar(_)
+        | vir::Type::Projection(_) => vir::FieldDecl::new("val_ref", 0usize, ty),
 
         vir::Type::Reference(vir::ty::Reference { target_type, .. }) => {
             vir::FieldDecl::new("val_ref", 0usize, (*target_type).clone())
@@ -49,7 +50,6 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
         | vir::Type::Pointer(_)
         | vir::Type::Never
         | vir::Type::Str
-        | vir::Type::Projection(_)
         | vir::Type::Unsupported(_) => {
             return Err(EncodingError::unsupported(format!(
                 "{} type is not supported",

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -105,16 +105,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         // TODO: move this to a signatures module
         let sig = encoder.env().tcx().fn_sig(proc_def_id);
         let sig = encoder.env().tcx().subst_and_normalize_erasing_regions(
-                substs,
-                encoder.env().tcx().param_env(parent_def_id),
-                sig,
-            );
-        //use prusti_rustc_interface::middle::ty::subst::Subst;
-        //let sig = ty::EarlyBinder(encoder.env().tcx().fn_sig(proc_def_id))
-        //    .subst(encoder.env().tcx(), substs);
-        //let sig = encoder
-        //    .env()
-        //    .resolve_assoc_types(sig, encoder.env().tcx().param_env(proc_def_id));
+            substs,
+            encoder.env().tcx().param_env(parent_def_id),
+            sig,
+        );
 
         PureFunctionEncoder {
             encoder,
@@ -129,10 +123,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
     }
 
     pub fn encode_function(&mut self) -> SpannedEncodingResult<vir::Function> {
-        let mir = self
-            .encoder
-            .env()
-            .local_mir_with_caller(self.proc_def_id.expect_local(), self.parent_def_id.expect_local(), self.substs);
+        let mir = self.encoder.env().local_mir_with_caller(
+            self.proc_def_id.expect_local(),
+            self.parent_def_id.expect_local(),
+            self.substs,
+        );
         let interpreter = PureFunctionBackwardInterpreter::new(
             self.encoder,
             &mir,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -269,7 +269,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         if config::check_overflows() {
             debug_assert!(self.encoder.env().type_is_copy(
                 self.sig.output(),
-                self.encoder.env().tcx().param_env(self.proc_def_id)
+                self.encoder.env().tcx().param_env(self.parent_def_id)
             ));
             let mut return_bounds: Vec<_> = self
                 .encoder
@@ -288,7 +288,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 debug_assert!(self
                     .encoder
                     .env()
-                    .type_is_copy(typ, self.encoder.env().tcx().param_env(self.proc_def_id)));
+                    .type_is_copy(typ, self.encoder.env().tcx().param_env(self.parent_def_id)));
                 let mut bounds = self
                     .encoder
                     .encode_type_bounds(&vir::Expr::local(formal_arg.clone()), typ.skip_binder());
@@ -534,7 +534,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let ty = self.sig.output();
 
         // Return an error for unsupported return types
-        let param_env = self.encoder.env().tcx().param_env(self.proc_def_id);
+        let param_env = self.encoder.env().tcx().param_env(self.parent_def_id);
         if !self.encoder.env().type_is_copy(ty, param_env) {
             return Err(SpannedEncodingError::incorrect(
                 "return type of pure function does not implement Copy",
@@ -561,7 +561,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             let var_name = format!("{:?}", local);
             let var_span = self.get_local_span(local);
 
-            let param_env = self.encoder.env().tcx().param_env(self.proc_def_id);
+            let param_env = self.encoder.env().tcx().param_env(self.parent_def_id);
             if !self.encoder.env().type_is_copy(local_ty, param_env) {
                 return Err(SpannedEncodingError::incorrect(
                     "pure function parameters must be Copy",

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -32,10 +32,15 @@ fn compute_key<'v, 'tcx: 'v>(
     substs: SubstsRef<'tcx>,
 ) -> SpannedEncodingResult<Key<'tcx>> {
     //let mir_span = encoder.env().tcx().def_span(proc_def_id);
-    let sig = encoder.env().tcx().fn_sig(proc_def_id);
-    let sig = encoder.env().tcx().subst_and_normalize_erasing_regions(
+    let tcx = encoder.env().tcx();
+    let sig = if tcx.is_closure(proc_def_id) {
+        substs.as_closure().sig()
+    } else {
+        tcx.fn_sig(proc_def_id)
+    };
+    let sig = tcx.subst_and_normalize_erasing_regions(
             substs,
-            encoder.env().tcx().param_env(caller_def_id),
+            tcx.param_env(caller_def_id),
             sig,
         );
     Ok((

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -309,7 +309,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let ty = self.sig.output();
 
         let span = self.get_return_span();
-        let param_env = self.encoder.env().tcx().param_env(self.proc_def_id);
+        let param_env = self.encoder.env().tcx().param_env(self.parent_def_id);
         if !self.encoder.env().type_is_copy(ty, param_env) {
             return Err(SpannedEncodingError::incorrect(
                 "return type of pure function does not implement Copy",
@@ -398,7 +398,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
     /// Encodes a VIR local with the original MIR type.
     fn encode_mir_local(&self, local: mir::Local) -> SpannedEncodingResult<vir_high::VariableDecl> {
         let ty = self.get_local_ty(local);
-        let param_env = self.encoder.env().tcx().param_env(self.proc_def_id);
+        let param_env = self.encoder.env().tcx().param_env(self.parent_def_id);
         if !self.encoder.env().type_is_copy(ty, param_env) {
             return Err(SpannedEncodingError::incorrect(
                 "pure function parameters must be Copy",

--- a/vir/defs/polymorphic/ast/function.rs
+++ b/vir/defs/polymorphic/ast/function.rs
@@ -99,7 +99,7 @@ impl Function {
 
 pub fn compute_identifier(
     name: &str,
-    _type_arguments: &[Type],
+    type_arguments: &[Type],
     formal_args: &[LocalVar],
     return_type: &Type,
 ) -> String {
@@ -123,21 +123,17 @@ pub fn compute_identifier(
         }
     }
     identifier.push_str("__$TY$__");
+    // Include the type parameters of the function in the function name
+    for arg in type_arguments {
+        identifier.push_str(&type_name(arg));
+        identifier.push('$');
+    }
+    // Include the signature of the function in the function name
     for arg in formal_args {
         identifier.push_str(&type_name(&arg.typ));
         identifier.push('$');
     }
     identifier.push_str(&type_name(return_type));
-    /*
-    // Include the signature of the function in the function name
-    if !type_arguments.is_empty() {
-        identifier.push_str("__$TY$__");
-    }
-    for arg in type_arguments {
-        identifier.push_str(&type_name(arg));
-        identifier.push('$');
-    }
-    */
     identifier
 }
 

--- a/vir/defs/polymorphic/ast/function.rs
+++ b/vir/defs/polymorphic/ast/function.rs
@@ -99,15 +99,11 @@ impl Function {
 
 pub fn compute_identifier(
     name: &str,
-    type_arguments: &[Type],
-    _formal_args: &[LocalVar],
-    _return_type: &Type,
+    _type_arguments: &[Type],
+    formal_args: &[LocalVar],
+    return_type: &Type,
 ) -> String {
     let mut identifier = name.to_string();
-    // Include the signature of the function in the function name
-    if !type_arguments.is_empty() {
-        identifier.push_str("__$TY$__");
-    }
     fn type_name(typ: &Type) -> String {
         match typ {
             Type::Int => "$int$".to_string(),
@@ -126,10 +122,22 @@ pub fn compute_identifier(
             ),
         }
     }
+    identifier.push_str("__$TY$__");
+    for arg in formal_args {
+        identifier.push_str(&type_name(&arg.typ));
+        identifier.push('$');
+    }
+    identifier.push_str(&type_name(return_type));
+    /*
+    // Include the signature of the function in the function name
+    if !type_arguments.is_empty() {
+        identifier.push_str("__$TY$__");
+    }
     for arg in type_arguments {
         identifier.push_str(&type_name(arg));
         identifier.push('$');
     }
+    */
     identifier
 }
 


### PR DESCRIPTION
- [x] Improved associated types resolution (thanks @vl0w, from #980). The hope is that this won't erase too many regions...
- [x] Normalise associated types when monomorphising MIR bodies for pure functions.
- [x] Cache encoded pure functions by `DefId` + (full) encoded signature, not just "type parameters".