### PR TITLE
Document prusti_assert and prusti_assume

### DIFF
--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -19,6 +19,7 @@
   - [Absence of panics](verify/panic.md)
   - [Overflow checks](verify/overflow.md)
   - [Pre- and postconditions](verify/prepost.md)
+  - [Assertions and assumptions](verify/assert_assume.md)
   - [Trusted functions](verify/trusted.md)
   - [Pure functions](verify/pure.md)
   - [Predicates](verify/predicate.md)

--- a/docs/user-guide/src/verify/assert_assume.md
+++ b/docs/user-guide/src/verify/assert_assume.md
@@ -7,12 +7,12 @@ function (via an assumption).
 
 ## Assertions
 
-The `prusti_assert!()` macro instructs Prusti to verify that a certain property
+The `prusti_assert!` macro instructs Prusti to verify that a certain property
 holds at a specific point within the body of a function. In contrast to the
-`assert!()` macro, which only accepts Rust expressions, `prusti_assert!()`
-accepts [specification](../syntax.md) expressions as arguments. Therefore,
-quantifiers and `old()` expressions are allowed within a call to
-`prusti_assert!()`, as in the following example:
+`assert!` macro, which only accepts Rust expressions, `prusti_assert!` accepts
+[specification](../syntax.md) expressions as arguments. Therefore, quantifiers
+and `old` expressions are allowed within a call to `prusti_assert!`, as in
+the following example:
 
 ```rust,noplaypen
 #[requires(*x != 2)]
@@ -22,9 +22,18 @@ fn go(x: &mut u32) {
 }
 ```
 
+Note that the expression given to `prusti_assert!` must be side-effect free.
+Therefore, certain calls might work within an `assert!`, but not within a
+`prusti_assert!`. For example:
+
+```rust,noplaypen
+assert!(map.insert(5));
+prusti_assert!(map.insert(5)); // error
+```
+
 ## Assumptions
 
-The `prusti_assume!()` macro instructs Prusti to assume that a certain property
+The `prusti_assume!` macro instructs Prusti to assume that a certain property
 holds at a point within the body of a function. Of course, if used improperly,
 this can be used to introduce unsoundness. For example, Prusti would verify the
 following function:

--- a/docs/user-guide/src/verify/assert_assume.md
+++ b/docs/user-guide/src/verify/assert_assume.md
@@ -1,0 +1,43 @@
+# Assertions and Assumptions 
+
+> **Note**: Currently, the  [UNSAFE_CORE_PROOF](https://viperproject.github.io/prusti-dev/dev-guide/config/flags.html#unsafe_core_proof)
+> configuration flag must be enabled to use assertions and assumptions.
+
+You can use Prusti to verify that a certain property holds at a certain point
+within the body of a function (via an assertion). It is also possible to
+instruct Prusti to assume that a property holds at a certain point within a
+function (via an assumption).
+
+## Assertions
+
+The `prusti_assert!()` macro instructs Prusti to verify that a certain property
+holds at a specific point within the body of a function. In contrast to the
+`assert!()` macro, which only accepts Rust expressions, `prusti_assert!()`
+accepts [specification](../syntax.md) expressions as arguments. Therefore,
+quantifiers and `old()` expressions are allowed within a call to
+`prusti_assert()`, as in the following example:
+
+```rust,noplaypen
+#[requires(*x != 2)]
+fn go(x: &mut u32) {
+   *x = 2;
+   prusti_assert!(*x != old(*x));
+}
+```
+
+## Assumptions
+
+The `prusti_assume!()` macro instructs Prusti to assume that a certain property
+holds at a point within the body of a function. Of course, if used improperly,
+this can be used to introduce unsoundness. For example, Prusti would verify the
+following function:
+
+```rust,noplaypen
+
+#[ensures(p == np)]
+fn proof(p: u32, np: u32) {
+  prusti_assume!(false);
+}
+
+```
+

--- a/docs/user-guide/src/verify/assert_assume.md
+++ b/docs/user-guide/src/verify/assert_assume.md
@@ -1,8 +1,5 @@
 # Assertions and Assumptions 
 
-> **Note**: Currently, the  [UNSAFE_CORE_PROOF](https://viperproject.github.io/prusti-dev/dev-guide/config/flags.html#unsafe_core_proof)
-> configuration flag must be enabled to use assertions and assumptions.
-
 You can use Prusti to verify that a certain property holds at a certain point
 within the body of a function (via an assertion). It is also possible to
 instruct Prusti to assume that a property holds at a certain point within a
@@ -15,7 +12,7 @@ holds at a specific point within the body of a function. In contrast to the
 `assert!()` macro, which only accepts Rust expressions, `prusti_assert!()`
 accepts [specification](../syntax.md) expressions as arguments. Therefore,
 quantifiers and `old()` expressions are allowed within a call to
-`prusti_assert()`, as in the following example:
+`prusti_assert!()`, as in the following example:
 
 ```rust,noplaypen
 #[requires(*x != 2)]
@@ -33,11 +30,8 @@ this can be used to introduce unsoundness. For example, Prusti would verify the
 following function:
 
 ```rust,noplaypen
-
 #[ensures(p == np)]
 fn proof(p: u32, np: u32) {
   prusti_assume!(false);
 }
-
 ```
-

--- a/docs/user-guide/src/verify/summary.md
+++ b/docs/user-guide/src/verify/summary.md
@@ -10,6 +10,7 @@ More intricate properties require users to write suitable [specifications](synta
 The following features are either currently supported or planned to be supported in Prusti:
 
 - [Pre- and postconditions](prepost.md)
+- [Assertions and assumptions](assert_assume.md)
 - [Trusted functions](trusted.md)
 - [Pure functions](pure.md)
 - [Predicates](predicate.md)


### PR DESCRIPTION
I figured these two macros should be documented, since I didn't realize they existed.

Also I am not sure about the relationship between these and the unsafe core proof; so perhaps that may need some clarification before merging?