### PR TITLE
Ghost constraint improvements

### DIFF
--- a/prusti-contracts-impl/src/lib.rs
+++ b/prusti-contracts-impl/src/lib.rs
@@ -72,8 +72,8 @@ pub fn model(_attr: TokenStream, _tokens: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn ghost_constraint(_attr: TokenStream, _tokens: TokenStream) -> TokenStream {
-    TokenStream::new()
+pub fn ghost_constraint(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    tokens
 }
 
 #[proc_macro]

--- a/prusti-specs/src/ghost_constraints/mod.rs
+++ b/prusti-specs/src/ghost_constraints/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    generate_for_ensures, generate_for_requires, parse_ghost_constraint, untyped, GeneratedResult,
+    generate_for_ensures, generate_for_requires, do_generate_for_pure, parse_ghost_constraint, untyped, GeneratedResult,
     NestedSpec,
 };
 use proc_macro2::TokenStream;
@@ -25,6 +25,7 @@ pub fn generate(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult
         let (mut generated_items, generated_attrs) = match nested_spec {
             NestedSpec::Ensures(tokens) => generate_for_ensures(tokens, item)?,
             NestedSpec::Requires(tokens) => generate_for_requires(tokens, item)?,
+            NestedSpec::Pure => do_generate_for_pure(item)?,
         };
 
         for generated_item in generated_items.iter_mut() {

--- a/prusti-specs/src/ghost_constraints/mod.rs
+++ b/prusti-specs/src/ghost_constraints/mod.rs
@@ -3,25 +3,18 @@ use crate::{
     NestedSpec,
 };
 use proc_macro2::TokenStream;
-use quote::ToTokens;
-use syn::{parse::ParseStream, parse_quote_spanned, spanned::Spanned};
-use syn::punctuated::Punctuated;
+use syn::{parse_quote_spanned, spanned::Spanned};
 
 pub fn generate(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
     let tokens_span = attr.span();
 
     // Parse ghost constraint information
-    let (trait_bounds_ts, nested_specs) = parse_ghost_constraint(attr)?;
-    let trait_bounds: ProvidedTraitBounds = syn::parse2(trait_bounds_ts).map_err(|err|
-        syn::Error::new(err.span(), "Could not parse trait bounds")
-    )?;
-
-    validate_provided_trait_bounds(&trait_bounds)?;
+    let ghost_constraint = parse_ghost_constraint(attr)?;
 
     let mut new_items = vec![];
     let mut new_attrs = vec![];
 
-    for nested_spec in nested_specs {
+    for nested_spec in ghost_constraint.specs {
         let (mut generated_items, generated_attrs) = match nested_spec {
             NestedSpec::Ensures(tokens) => generate_for_ensures(tokens, item)?,
             NestedSpec::Requires(tokens) => generate_for_requires(tokens, item)?,
@@ -36,7 +29,7 @@ pub fn generate(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult
 
             // Add bounds as a where clause
             item_fn.sig.generics.where_clause = Some(generate_where_clause_for_spec(
-                &trait_bounds,
+                &ghost_constraint.trait_bounds,
                 item_fn.sig.generics.where_clause.as_ref(),
             ));
 
@@ -54,7 +47,7 @@ pub fn generate(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult
 }
 
 fn generate_where_clause_for_spec(
-    trait_bounds: &ProvidedTraitBounds,
+    trait_bounds: &syn::PredicateType,
     existing_where_clause: Option<&syn::WhereClause>,
 ) -> syn::WhereClause {
     let span = trait_bounds.span();
@@ -67,52 +60,5 @@ fn generate_where_clause_for_spec(
         parse_quote_spanned! {span=>
             where #trait_bounds
         }
-    }
-}
-
-fn validate_provided_trait_bounds(trait_bounds: &ProvidedTraitBounds) -> syn::Result<()> {
-    for bound in &trait_bounds.predicate_type.bounds {
-        match bound {
-            syn::TypeParamBound::Lifetime(lt) => {
-                return Err(syn::Error::new(
-                    lt.span(),
-                    "Lifetimes in ghost constraints not allowed",
-                ))
-            }
-            syn::TypeParamBound::Trait(trait_bound) => {
-                if let Some(lt) = &trait_bound.lifetimes {
-                    return Err(syn::Error::new(
-                        lt.span(),
-                        "Lifetimes in ghost constraints not allowed",
-                    ));
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// A `syn::Parse`able representaiton of `syn::PredicateType` (ignoring bound lifetimes)
-struct ProvidedTraitBounds {
-    predicate_type: syn::PredicateType,
-}
-
-impl syn::parse::Parse for ProvidedTraitBounds {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        Ok(ProvidedTraitBounds {
-            predicate_type: syn::PredicateType {
-                lifetimes: None,
-                bounded_ty: input.parse()?,
-                colon_token: input.parse()?,
-                bounds: Punctuated::parse_separated_nonempty(input)?,
-            },
-        })
-    }
-}
-
-impl ToTokens for ProvidedTraitBounds {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        self.predicate_type.to_tokens(tokens);
     }
 }

--- a/prusti-specs/src/lib.rs
+++ b/prusti-specs/src/lib.rs
@@ -242,6 +242,10 @@ fn generate_for_pure(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedR
     do_generate_for_pure(item)
 }
 
+/// Generate spec items and attributes to typecheck and later retrieve "pure" annotations.
+/// 
+/// This the actual generating logic called by `generate_for_pure` after checking that the body is empty.
+/// It's exposed separately for use in ghost constraints.
 fn do_generate_for_pure(item: &untyped::AnyFnItem) -> GeneratedResult {
     Ok((
         vec![],

--- a/prusti-specs/src/lib.rs
+++ b/prusti-specs/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(box_syntax)]
 #![feature(proc_macro_span)]
 #![feature(if_let_guard)]
+#![feature(assert_matches)]
 // This Clippy chcek seems to be always wrong.
 #![allow(clippy::iter_with_drain)]
 

--- a/prusti-specs/src/lib.rs
+++ b/prusti-specs/src/lib.rs
@@ -238,6 +238,10 @@ fn generate_for_pure(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedR
         ));
     }
 
+    do_generate_for_pure(item)
+}
+
+fn do_generate_for_pure(item: &untyped::AnyFnItem) -> GeneratedResult {
     Ok((
         vec![],
         vec![parse_quote_spanned! {item.span()=>

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -413,7 +413,7 @@ impl PrustiTokenStream {
                 other => error(self.source_span, format!("unexpected nested spec type: {}", other).as_ref()),
             }
         } else {
-            error(self.source_span, "expected identifier").into()
+            error(self.source_span, "expected identifier")
         }
     }
 

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -171,7 +171,11 @@ impl PrustiTokenStream {
     {
         let result = f(&mut self)?;
         if !self.is_empty() {
-            let error_span = self.tokens.front().unwrap().span().join(self.tokens.back().unwrap().span()).unwrap();
+            let start = self.tokens.front().unwrap().span();
+            let end = self.tokens.back().unwrap().span();
+            let span = start.join(end);
+            // this is None if the spans are not combinable, which seems to happen when running the cfg(tests) via cargo
+            let error_span = span.unwrap_or(start);
             return error(error_span, "unexpected extra tokens");
         }
         Ok(result)

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -486,17 +486,6 @@ impl PrustiTokenStream {
     }
 }
 
-trait AsPrustiTokenStream {
-    fn as_pts(&self) -> PrustiTokenStream;
-}
-
-// bridge between syn parse streams and prusti token streams
-impl AsPrustiTokenStream for ParseStream<'_> {
-    fn as_pts(&self) -> PrustiTokenStream {
-        PrustiTokenStream::new(self.parse().unwrap())
-    }
-}
-
 // TODO: is there a better place for this type and its logic?
 
 #[derive(Debug)]
@@ -511,7 +500,8 @@ impl Parse for GhostConstraint {
         Ok(GhostConstraint {
             trait_bounds: parse_trait_bounds(input)?,
             comma: input.parse()?,
-            specs: input.as_pts().parse_rest(|pts| pts.pop_group_of_nested_specs(input.span()))?,
+            specs: PrustiTokenStream::new(input.parse().unwrap())
+                .parse_rest(|pts| pts.pop_group_of_nested_specs(input.span()))?,
         })
     }
 }

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -499,8 +499,6 @@ impl PrustiTokenStream {
     }
 }
 
-// TODO: is there a better place for this type and its logic?
-
 #[derive(Debug)]
 pub struct GhostConstraint {
     pub trait_bounds: syn::PredicateType,
@@ -992,7 +990,6 @@ mod tests {
 
         #[test]
         fn no_specs() {
-            // TODO: does it even make sense to compare parsed quotes like this? feels a bit like saying 2 = 2
             let constraint = parse_ghost_constraint(quote!{ T: A, []}).unwrap();
             assert_bounds_eq(constraint.trait_bounds, quote!{ T : A });
             assert!(constraint.specs.is_empty());

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -1004,10 +1004,10 @@ mod tests {
         #[test]
         fn tuple_generics() {
             // just check that parsing succeeds
-            let _ = parse_ghost_constraint(quote!{ T: Fn<(i32,), Output = i32>, []}).unwrap();
-            let _ = parse_ghost_constraint(quote!{ T: Fn<(i32,)>, []}).unwrap();
-            let _ = parse_ghost_constraint(quote!{ T: Fn<(i32, bool)>, []}).unwrap();
-            let _ = parse_ghost_constraint(quote!{ T: Fn<(i32, bool,)>, []}).unwrap();
+            assert!(parse_ghost_constraint(quote!{ T: Fn<(i32,), Output = i32>, []}).is_ok());
+            assert!(parse_ghost_constraint(quote!{ T: Fn<(i32,)>, []}).is_ok());
+            assert!(parse_ghost_constraint(quote!{ T: Fn<(i32, bool)>, []}).is_ok());
+            assert!(parse_ghost_constraint(quote!{ T: Fn<(i32, bool,)>, []}).is_ok());
         }
         
         fn assert_bounds_eq(parsed: syn::PredicateType, quote: TokenStream) {

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -167,7 +167,8 @@ impl PrustiTokenStream {
     {
         let result = f(&mut self)?;
         if !self.is_empty() {
-            return error(self.source_span, "unexpected extra tokens");
+            let error_span = self.tokens.front().unwrap().span().join(self.tokens.back().unwrap().span()).unwrap();
+            return error(error_span, "unexpected extra tokens");
         }
         Ok(result)
     }

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -51,7 +51,11 @@ pub fn parse_prusti_assert_pledge(tokens: TokenStream) -> syn::Result<(TokenStre
 }
 
 pub fn parse_ghost_constraint(tokens: TokenStream) -> syn::Result<GhostConstraint> {
-    syn::parse2(tokens)
+    syn::parse2(tokens).map_err(|mut err| {
+        err.combine(syn::Error::new(err.span(),
+            "expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`"));
+        err
+    })
 }
 
 /*

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -53,7 +53,7 @@ pub fn parse_prusti_assert_pledge(tokens: TokenStream) -> syn::Result<(TokenStre
 pub fn parse_ghost_constraint(tokens: TokenStream) -> syn::Result<GhostConstraint> {
     syn::parse2(tokens).map_err(|mut err| {
         err.combine(error(err.span(),
-            "expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`"));
+            "expected a trait bound and specifications in brackets, e.g.: `ghost_constraint(T: A + B + ..., [requires(...), ...])`"));
         err
     })
 }

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -161,7 +161,7 @@ impl PrustiTokenStream {
         self.tokens.is_empty()
     }
 
-    fn as_single<T, F>(mut self, f: F) -> syn::Result<T>
+    fn parse_rest<T, F>(mut self, f: F) -> syn::Result<T>
     where
         F: FnOnce(&mut Self) -> syn::Result<T>,
     {
@@ -423,7 +423,7 @@ impl PrustiTokenStream {
         let parsed = group_of_specs
             .split(PrustiBinaryOp::Rust(RustOp::Comma), true)
             .into_iter()
-            .map(|stream| stream.as_single(|stream| stream.pop_single_nested_spec()))
+            .map(|stream| stream.parse_rest(|stream| stream.pop_single_nested_spec()))
             .map(|stream| stream.and_then(|s| s.parse()))
             .collect::<syn::Result<Vec<NestedSpec<TokenStream>>>>()?;
         Ok(parsed)
@@ -510,7 +510,7 @@ impl Parse for GhostConstraint {
         Ok(GhostConstraint {
             trait_bounds: parse_trait_bounds(input)?,
             comma: input.parse()?,
-            specs: input.as_pts().as_single(|pts| pts.pop_group_of_nested_specs(input.span()))?,
+            specs: input.as_pts().parse_rest(|pts| pts.pop_group_of_nested_specs(input.span()))?,
         })
     }
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-1.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-1.rs
@@ -2,7 +2,7 @@ use prusti_contracts::*;
 
 trait A { }
 
-#[ghost_constraint(T: 'static + A, [ //~ ERROR: Lifetimes in ghost constraints not allowed
+#[ghost_constraint(T: 'static + A, [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
     ensures(result > 0)
 ])]
 fn foo<T>(_x: T) -> i32 {

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-1.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-1.rs
@@ -5,7 +5,6 @@ trait A { }
 #[ghost_constraint(T: 'static + A, [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
     ensures(result > 0)
 ])]
-//~| ERROR: expected a trait bound and specifications in brackets, e.g.: `ghost_constraint(T: A + B + ..., [requires(...), ...])`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-1.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-1.rs
@@ -5,6 +5,7 @@ trait A { }
 #[ghost_constraint(T: 'static + A, [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
     ensures(result > 0)
 ])]
+//~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-1.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-1.rs
@@ -5,7 +5,7 @@ trait A { }
 #[ghost_constraint(T: 'static + A, [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
     ensures(result > 0)
 ])]
-//~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
+//~| ERROR: expected a trait bound and specifications in brackets, e.g.: `ghost_constraint(T: A + B + ..., [requires(...), ...])`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-2.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-2.rs
@@ -5,7 +5,7 @@ trait A<X> { }
 #[ghost_constraint(T: for<'a> A<&'a i32>, [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
     ensures(result > 0)
 ])]
-//~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
+//~| ERROR: expected a trait bound and specifications in brackets, e.g.: `ghost_constraint(T: A + B + ..., [requires(...), ...])`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-2.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-2.rs
@@ -2,9 +2,10 @@ use prusti_contracts::*;
 
 trait A<X> { }
 
-#[ghost_constraint(T: for<'a> A<&'a i32> , [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
+#[ghost_constraint(T: for<'a> A<&'a i32>, [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
     ensures(result > 0)
 ])]
+//~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-2.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-2.rs
@@ -5,7 +5,6 @@ trait A<X> { }
 #[ghost_constraint(T: for<'a> A<&'a i32>, [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
     ensures(result > 0)
 ])]
-//~| ERROR: expected a trait bound and specifications in brackets, e.g.: `ghost_constraint(T: A + B + ..., [requires(...), ...])`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-2.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-2.rs
@@ -2,7 +2,7 @@ use prusti_contracts::*;
 
 trait A<X> { }
 
-#[ghost_constraint(T: for<'a> A<&'a i32> , [ //~ ERROR: Lifetimes in ghost constraints not allowed
+#[ghost_constraint(T: for<'a> A<&'a i32> , [ //~ ERROR: lifetimes are not allowed in ghost constraint trait bounds
     ensures(result > 0)
 ])]
 fn foo<T>(_x: T) -> i32 {

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-3.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-illegal-3.rs
@@ -5,7 +5,7 @@ struct MyStruct<T> {
 }
 
 impl<T> MyStruct<T> {
-    #[ghost_constraint(Self: MyStruct<i32> , [ //~ ERROR: expected trait, found struct `MyStruct`
+    #[ghost_constraint(Self: MyStruct<i32>, [ //~ ERROR: expected trait, found struct `MyStruct`
         requires(x > 0)
     ])]
     fn set_x(&mut self, x: T) {

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-1.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-1.rs
@@ -3,7 +3,7 @@ use prusti_contracts::*;
 #[ghost_constraint([
     ensures(result > 0) //~ ERROR: expected `,`
 ])]
-//~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
+//~| ERROR: expected a trait bound and specifications in brackets, e.g.: `ghost_constraint(T: A + B + ..., [requires(...), ...])`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-1.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-1.rs
@@ -1,6 +1,6 @@
 use prusti_contracts::*;
 
-#[ghost_constraint([ //~ ERROR: Invalid use of macro. Two arguments expected (a trait bound `T: A + B` and multiple specifications `[requires(...), ensures(...), ...]`)
+#[ghost_constraint([ //~ ERROR: expected `,`
     ensures(result > 0)
 ])]
 fn foo<T>(_x: T) -> i32 {

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-1.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-1.rs
@@ -3,6 +3,7 @@ use prusti_contracts::*;
 #[ghost_constraint([ //~ ERROR: expected `,`
     ensures(result > 0)
 ])]
+//~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-1.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-1.rs
@@ -1,7 +1,7 @@
 use prusti_contracts::*;
 
-#[ghost_constraint([ //~ ERROR: expected `,`
-    ensures(result > 0)
+#[ghost_constraint([
+    ensures(result > 0) //~ ERROR: expected `,`
 ])]
 //~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
 fn foo<T>(_x: T) -> i32 {

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-2.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-2.rs
@@ -3,7 +3,7 @@ use prusti_contracts::*;
 #[ghost_constraint(42, [ //~ ERROR: expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
     ensures(result > 0)
 ])]
-//~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
+//~| ERROR: expected a trait bound and specifications in brackets, e.g.: `ghost_constraint(T: A + B + ..., [requires(...), ...])`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-2.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-2.rs
@@ -3,6 +3,7 @@ use prusti_contracts::*;
 #[ghost_constraint(42, [ //~ ERROR: expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
     ensures(result > 0)
 ])]
+//~| ERROR: expected a trait bound `T: A + B` and specifications in brackets `[requires(...), ensures(...), pure, ...]`
 fn foo<T>(_x: T) -> i32 {
     42
 }

--- a/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-2.rs
+++ b/prusti-tests/tests/parse/fail/ghost-constraints/trait-bounds-invalid-macro-arguments-2.rs
@@ -1,6 +1,6 @@
 use prusti_contracts::*;
 
-#[ghost_constraint(42, [ //~ ERROR: Could not parse trait bounds
+#[ghost_constraint(42, [ //~ ERROR: expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
     ensures(result > 0)
 ])]
 fn foo<T>(_x: T) -> i32 {


### PR DESCRIPTION
I reworked ghost constraint parsing to directly use `syn` for the trait bounds and comma, only then handing the rest over to Prusti's parser. Additionally, I extended them to handle `pure` flags (in addition to the status quo of `requires` and `ensures`). The effects are as follows:
- Any trait bounds that are valid rust are now inherently valid in ghost constraints.
- The separating comma between bounds & specs no longer requires a space if preceded by a `>`.
- Ghost constraints can now specify `pure`ness.
- The `ghost_constraint` proc macro is now correctly a no-op when compiling without prusti, rather than removing the function entirely.

Some considerations for code review:
- I just kinda threw in the logic with the rest of it in preparser.rs; perhaps splitting it (or other parts) off into its own file would make sense? It's a pretty long file at this point.
- I wasn't sure how best to translate the existing unit tests now that we no longer represent the traits as an unparsed `TokenStream`. I ended up providing the strings as `quote!` streams instead, but it feels like that's not really testing anything of value anymore (hence also why I dropped it in the new `tuple_generics` test).
- The errors reported for invalid syntax are better in some ways and worse in other ways compared to the status quo. What I most miss is that the old errors often provided an example of how to structure your ghost constraint—perhaps it would make sense to somehow attach this to whatever error syn outputs?