### PR TITLE
Make rust-analyzer use x.py

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "rust-analyzer.rustc.source": "discover",
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
-        "./x.py",
+        "python3",
+        "x.py",
         "check",
         "--quiet",
         "--workspace",
@@ -9,7 +10,8 @@
         "--all-targets",
     ],
     "rust-analyzer.checkOnSave.overrideCommand": [
-        "./x.py",
+        "python3",
+        "x.py",
         "check",
         "--workspace",
         "--message-format=json",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,18 @@
 {
-    "rust-analyzer.rustc.source": "discover"
+    "rust-analyzer.rustc.source": "discover",
+    "rust-analyzer.cargo.buildScripts.overrideCommand": [
+        "./x.py",
+        "check",
+        "--quiet",
+        "--workspace",
+        "--message-format=json",
+        "--all-targets",
+    ],
+    "rust-analyzer.checkOnSave.overrideCommand": [
+        "./x.py",
+        "check",
+        "--workspace",
+        "--message-format=json",
+        "--all-targets",
+    ],
 }


### PR DESCRIPTION
[rust-analyzer](https://rust-analyzer.github.io) is a very popular extension for VS Code providing support for Rust. In my setup, however, it failed on the Prusti codebase because it uses standard `cargo` rather than `x.py`. This PR amends the workspace settings file that's already been committed to the repository to configure rust-analyzer appropriately.

The configured values may look non-trivial, but they are in fact exact copies of the default command as specified in their respective setting's comment, e.g. "By default, a cargo invocation will be constructed for the configured targets and features, with the following base command line: `cargo check --quiet --workspace --message-format=json --all-targets`", except of course with `cargo` replaced by `./x.py`.

If any of the authors currently use VS Code, I'd love to get your feedback on this!