### PR TITLE
Generics improvements

### DIFF
--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -151,14 +151,15 @@ impl<'tcx> EnvBody<'tcx> {
         caller_def_id: Option<DefId>,
         body: MirBody<'tcx>,
     ) -> MirBody<'tcx> {
-        if let Entry::Vacant(v) = self
-            .monomorphised_bodies
-            .borrow_mut()
-            .entry((def_id, substs, caller_def_id))
+        if let Entry::Vacant(v) =
+            self.monomorphised_bodies
+                .borrow_mut()
+                .entry((def_id, substs, caller_def_id))
         {
             let monomorphised = if let Some(caller_def_id) = caller_def_id {
                 let param_env = self.tcx.param_env(caller_def_id);
-                self.tcx.subst_and_normalize_erasing_regions(substs, param_env, body.0.clone())
+                self.tcx
+                    .subst_and_normalize_erasing_regions(substs, param_env, body.0.clone())
             } else {
                 ty::EarlyBinder(body.0).subst(self.tcx, substs)
             };
@@ -204,7 +205,8 @@ impl<'tcx> EnvBody<'tcx> {
         substs: SubstsRef<'tcx>,
         caller_def_id: DefId,
     ) -> MirBody<'tcx> {
-        if let Some(body) = self.get_monomorphised(def_id.to_def_id(), substs, Some(caller_def_id)) {
+        if let Some(body) = self.get_monomorphised(def_id.to_def_id(), substs, Some(caller_def_id))
+        {
             return body;
         }
         let body = self.get_closure_body_identity(def_id);

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -68,6 +68,23 @@ impl<'tcx> PreLoadedBodies<'tcx> {
     }
 }
 
+/// Key representing a concrete monomorphisation, consisting of:
+///
+/// - the `DefId` of the monomorphised function (callee),
+/// - the substitutions applied to it, and
+/// - (optionally) the `DefId` of the caller.
+///
+/// The `DefId` of the caller is important as it determines the `ParamEnv`,
+/// from which we can resolve projection types (e.g. `<T as Foo>::AT` might
+/// resolve to `i32` if the `ParamEnv` of the caller has `T: Foo<AT = i32>`).
+/// However, such normalisation also erases the regions when using the current
+/// compiler APIs. As such, the caller `DefId` is left as `None` if:
+///
+/// - we are encoding an impure function, where the method is encoded only once
+///   and calls are performed indirectly via contract exhale/inhale; or
+/// - when the caller is unknown, e.g. to check a pure function definition.
+type MonomorphKey<'tcx> = (DefId, SubstsRef<'tcx>, Option<DefId>);
+
 /// Store for all the `mir::Body` which we've taken out of the compiler
 /// or imported from external crates, all of which are indexed by DefId
 pub struct EnvBody<'tcx> {
@@ -82,7 +99,7 @@ pub struct EnvBody<'tcx> {
     specs: PreLoadedBodies<'tcx>,
 
     /// Copies of above MIR bodies with the given substs applied.
-    monomorphised_bodies: RefCell<FxHashMap<(DefId, SubstsRef<'tcx>), MirBody<'tcx>>>,
+    monomorphised_bodies: RefCell<FxHashMap<MonomorphKey<'tcx>, MirBody<'tcx>>>,
 }
 
 impl<'tcx> EnvBody<'tcx> {
@@ -116,25 +133,36 @@ impl<'tcx> EnvBody<'tcx> {
         }
     }
 
-    fn get_monomorphised(&self, def_id: DefId, substs: SubstsRef<'tcx>) -> Option<MirBody<'tcx>> {
+    fn get_monomorphised(
+        &self,
+        def_id: DefId,
+        substs: SubstsRef<'tcx>,
+        caller_def_id: Option<DefId>,
+    ) -> Option<MirBody<'tcx>> {
         self.monomorphised_bodies
             .borrow()
-            .get(&(def_id, substs))
+            .get(&(def_id, substs, caller_def_id))
             .cloned()
     }
     fn set_monomorphised(
         &self,
         def_id: DefId,
         substs: SubstsRef<'tcx>,
+        caller_def_id: Option<DefId>,
         body: MirBody<'tcx>,
     ) -> MirBody<'tcx> {
         if let Entry::Vacant(v) = self
             .monomorphised_bodies
             .borrow_mut()
-            .entry((def_id, substs))
+            .entry((def_id, substs, caller_def_id))
         {
-            v.insert(MirBody(ty::EarlyBinder(body.0).subst(self.tcx, substs)))
-                .clone()
+            let monomorphised = if let Some(caller_def_id) = caller_def_id {
+                let param_env = self.tcx.param_env(caller_def_id);
+                self.tcx.subst_and_normalize_erasing_regions(substs, param_env, body.0.clone())
+            } else {
+                ty::EarlyBinder(body.0).subst(self.tcx, substs)
+            };
+            v.insert(MirBody(monomorphised)).clone()
         } else {
             unreachable!()
         }
@@ -153,11 +181,11 @@ impl<'tcx> EnvBody<'tcx> {
     /// Get the MIR body of a local impure function, monomorphised
     /// with the given type substitutions.
     pub fn get_impure_fn_body(&self, def_id: LocalDefId, substs: SubstsRef<'tcx>) -> MirBody<'tcx> {
-        if let Some(body) = self.get_monomorphised(def_id.to_def_id(), substs) {
+        if let Some(body) = self.get_monomorphised(def_id.to_def_id(), substs, None) {
             return body;
         }
         let body = self.get_impure_fn_body_identity(def_id);
-        self.set_monomorphised(def_id.to_def_id(), substs, body)
+        self.set_monomorphised(def_id.to_def_id(), substs, None, body)
     }
 
     fn get_closure_body_identity(&self, def_id: LocalDefId) -> MirBody<'tcx> {
@@ -170,45 +198,65 @@ impl<'tcx> EnvBody<'tcx> {
 
     /// Get the MIR body of a local closure (e.g. loop invariant or trigger),
     /// monomorphised with the given type substitutions.
-    pub fn get_closure_body(&self, def_id: LocalDefId, substs: SubstsRef<'tcx>) -> MirBody<'tcx> {
-        if let Some(body) = self.get_monomorphised(def_id.to_def_id(), substs) {
+    pub fn get_closure_body(
+        &self,
+        def_id: LocalDefId,
+        substs: SubstsRef<'tcx>,
+        caller_def_id: DefId,
+    ) -> MirBody<'tcx> {
+        if let Some(body) = self.get_monomorphised(def_id.to_def_id(), substs, Some(caller_def_id)) {
             return body;
         }
         let body = self.get_closure_body_identity(def_id);
-        self.set_monomorphised(def_id.to_def_id(), substs, body)
+        self.set_monomorphised(def_id.to_def_id(), substs, Some(caller_def_id), body)
     }
 
     /// Get the MIR body of a local or external pure function,
     /// monomorphised with the given type substitutions.
-    pub fn get_pure_fn_body(&self, def_id: DefId, substs: SubstsRef<'tcx>) -> MirBody<'tcx> {
-        if let Some(body) = self.get_monomorphised(def_id, substs) {
+    pub fn get_pure_fn_body(
+        &self,
+        def_id: DefId,
+        substs: SubstsRef<'tcx>,
+        caller_def_id: DefId,
+    ) -> MirBody<'tcx> {
+        if let Some(body) = self.get_monomorphised(def_id, substs, Some(caller_def_id)) {
             return body;
         }
         let body = self.pure_fns.expect(def_id);
-        self.set_monomorphised(def_id, substs, body)
+        self.set_monomorphised(def_id, substs, Some(caller_def_id), body)
     }
 
     /// Get the MIR body of a local or external expression (e.g. any spec or predicate),
     /// monomorphised with the given type substitutions.
-    pub fn get_expression_body(&self, def_id: DefId, substs: SubstsRef<'tcx>) -> MirBody<'tcx> {
-        if let Some(body) = self.get_monomorphised(def_id, substs) {
+    pub fn get_expression_body(
+        &self,
+        def_id: DefId,
+        substs: SubstsRef<'tcx>,
+        caller_def_id: DefId,
+    ) -> MirBody<'tcx> {
+        if let Some(body) = self.get_monomorphised(def_id, substs, Some(caller_def_id)) {
             return body;
         }
         let body = self
             .specs
             .get(def_id)
             .unwrap_or_else(|| self.predicates.expect(def_id));
-        self.set_monomorphised(def_id, substs, body)
+        self.set_monomorphised(def_id, substs, Some(caller_def_id), body)
     }
 
     /// Get the MIR body of a local or external spec (pres/posts/pledges/type-specs),
     /// monomorphised with the given type substitutions.
-    pub fn get_spec_body(&self, def_id: DefId, substs: SubstsRef<'tcx>) -> MirBody<'tcx> {
-        if let Some(body) = self.get_monomorphised(def_id, substs) {
+    pub fn get_spec_body(
+        &self,
+        def_id: DefId,
+        substs: SubstsRef<'tcx>,
+        caller_def_id: DefId,
+    ) -> MirBody<'tcx> {
+        if let Some(body) = self.get_monomorphised(def_id, substs, Some(caller_def_id)) {
             return body;
         }
         let body = self.specs.expect(def_id);
-        self.set_monomorphised(def_id, substs, body)
+        self.set_monomorphised(def_id, substs, Some(caller_def_id), body)
     }
 
     /// Get Polonius facts of a local procedure.

--- a/prusti-tests/tests/verify_overflow/pass/generic/associated-copy.rs
+++ b/prusti-tests/tests/verify_overflow/pass/generic/associated-copy.rs
@@ -1,0 +1,15 @@
+use prusti_contracts::*;
+
+trait Trait {
+    type Assoc: Copy;
+
+    #[pure] fn output_copy(&self) -> Self::Assoc;
+    #[pure] fn input_copy(&self, x: Self::Assoc) -> bool;
+}
+
+#[requires(x.output_copy() === y)]
+#[requires(x.input_copy(z))]
+fn test<U: Copy, T: Trait<Assoc = U>>(x: &mut T, y: U, z: U) {}
+
+#[trusted]
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/generic/resolution.rs
+++ b/prusti-tests/tests/verify_overflow/pass/generic/resolution.rs
@@ -1,0 +1,231 @@
+use prusti_contracts::*;
+
+// Test generics and type parameter resolution at call sites. There are various
+// aspects/features that can complicate a method call resolution:
+//
+// 1. type parameters in the signature of the method
+// 2. lifetime parameters in the signature of the method
+// 3. type parameters in the impl block containing the method (= its struct)
+// 4. lifetime parameters in the impl block containing the method (= its struct)
+// 5. the method belongs to a trait
+// 6. associated types
+//
+// Test also calls from/to pure functions.
+
+type TupleIntInt = (i32, i32);
+type TupleIntUsize = (i32, usize);
+type TupleUsizeInt = (usize, i32);
+
+trait Valid1 { #[pure] fn valid1(&self) -> bool; }
+trait Valid2 { #[pure] fn valid2(&self) -> bool; }
+
+#[refine_trait_spec] impl Valid1 for i32 {
+    #[pure] fn valid1(&self) -> bool {
+        *self == 3
+    }
+}
+#[refine_trait_spec] impl Valid2 for i32 {
+    #[pure] fn valid2(&self) -> bool {
+        *self == 7
+    }
+}
+
+#[refine_trait_spec] impl Valid1 for TupleIntInt {
+    #[pure] fn valid1(&self) -> bool {
+        let valid = (8, 9);
+        *self == valid
+    }
+}
+#[refine_trait_spec] impl Valid2 for TupleIntInt {
+    #[pure] fn valid2(&self) -> bool {
+        let valid = (4, 5);
+        *self == valid
+    }
+}
+
+#[refine_trait_spec] impl Valid1 for TupleIntUsize {
+    #[pure] fn valid1(&self) -> bool {
+        let valid = (42, 43);
+        *self == valid
+    }
+}
+#[refine_trait_spec] impl Valid1 for TupleUsizeInt {
+    #[pure] fn valid1(&self) -> bool {
+        let valid = (33, 44);
+        *self == valid
+    }
+}
+
+#[refine_trait_spec] impl Valid1 for bool {
+    #[pure] fn valid1(&self) -> bool {
+        *self
+    }
+}
+#[refine_trait_spec] impl Valid2 for bool {
+    #[pure] fn valid2(&self) -> bool {
+        !*self
+    }
+}
+
+#[trusted]
+#[requires(a.valid1() && b.valid2())]
+#[ensures(result.valid1())]
+fn fn1<A: Valid1, B: Valid2, C: Valid1>(a: A, b: B) -> C { unimplemented!() }
+
+#[trusted]
+#[pure]
+#[requires(a.valid1() && b.valid2())]
+#[ensures(result.valid1())]
+fn pure_fn1<A: Valid1 + Copy, B: Valid2 + Copy, C: Valid1 + Copy>(a: A, b: B) -> C { unimplemented!() }
+
+#[requires(
+    pure_fn1::<i32, (i32, i32), bool>(3, (4, 5))
+)]
+fn test_fn1() {
+    assert!(fn1::<i32, (i32, i32), bool>(3, (4, 5)));
+    assert!(pure_fn1::<i32, (i32, i32), bool>(3, (4, 5)));
+}
+
+#[trusted]
+#[requires(a.valid2() && b.valid1())]
+#[ensures(result.valid2())]
+fn fn2<'a, 'b, A: Valid2, B: Valid1, C: Valid2>(a: &'a A, b: &'b B) -> C { unimplemented!() }
+
+#[trusted]
+#[pure]
+#[requires(a.valid2() && b.valid1())]
+#[ensures(result.valid2())]
+fn pure_fn2<'a, 'b, A: Valid2, B: Valid1, C: Valid2 + Copy>(a: &'a A, b: &'b B) -> C { unimplemented!() }
+
+// TODO: fold/unfold error when the precondition is enabled
+/*
+#[requires({
+    let a = 7;
+    let b = (8, 9);
+    pure_fn2::<i32, (i32, i32), bool>(&a, &b);
+})]
+*/
+fn test_fn2() {
+    let a = 7;
+    let b = (8, 9);
+    assert!(!fn2::<i32, (i32, i32), bool>(&a, &b));
+    assert!(!pure_fn2::<i32, (i32, i32), bool>(&a, &b));
+}
+
+struct X1<A, B>(A, B);
+impl<A: Valid1, B: Valid2> X1<A, B> {
+    #[trusted]
+    #[requires(a.valid1() && b.valid2())]
+    #[ensures(result.valid1())]
+    fn fn3<'a, 'b, C: Valid1>(&self, a: &'a A, b: &'b B) -> C { unimplemented!() }
+
+    #[trusted]
+    #[pure]
+    #[requires(a.valid1() && b.valid2())]
+    #[ensures(result.valid1())]
+    fn pure_fn3<'a, 'b, C: Valid1 + Copy>(&self, a: &'a A, b: &'b B) -> C { unimplemented!() }
+}
+
+fn test_fn3() {
+    let a = 3;
+    let b = (4, 5);
+    let x = X1::<i32, (i32, i32)>(0, (0, 0));
+    assert!(x.fn3::<bool>(&a, &b));
+    assert!(x.pure_fn3::<bool>(&a, &b));
+}
+
+// Using `&'a A` or `&'b B` directly in `X2` fails because Prusti tries to
+// encode the reference-typed fields `X2.0` resp. `X2.1`.
+struct X2<'a, 'b, A, B>(std::marker::PhantomData<&'a A>, std::marker::PhantomData<&'b B>);
+impl<'a, 'b, A: Valid2, B: Valid1> X2<'a, 'b, A, B> {
+    #[trusted]
+    #[requires(a.valid2() && b.valid1())]
+    #[ensures(result.valid2())]
+    fn fn4<C: Valid2>(&self, a: &'a A, b: &'b B) -> C { unimplemented!() }
+
+    #[trusted]
+    #[pure]
+    #[requires(a.valid2() && b.valid1())]
+    #[ensures(result.valid2())]
+    fn pure_fn4<C: Valid2 + Copy>(&self, a: &'a A, b: &'b B) -> C { unimplemented!() }
+}
+
+fn test_fn4<'a, 'b>(x: X2<'a, 'b, i32, (i32, i32)>) {
+    let a = 7;
+    let b = (8, 9);
+    assert!(!x.fn4::<bool>(&a, &b));
+    assert!(!x.pure_fn4::<bool>(&a, &b));
+}
+
+trait T1 {
+    #[requires(a.valid1() && b.valid2())]
+    #[ensures(result.valid1())]
+    fn fn5<A: Valid1, B: Valid2, C: Valid1>(&self, a: A, b: B) -> C;
+
+    #[pure]
+    #[requires(a.valid1() && b.valid2())]
+    #[ensures(result.valid1())]
+    fn pure_fn5<A: Valid1 + Copy, B: Valid2 + Copy, C: Valid1 + Copy>(&self, a: A, b: B) -> C;
+}
+
+struct X3 {}
+impl T1 for X3 {
+    #[trusted]
+    fn fn5<A, B, C>(&self, a: A, b: B) -> C { unimplemented!() }
+
+    #[trusted]
+    #[pure]
+    fn pure_fn5<A: Copy, B: Copy, C: Copy>(&self, a: A, b: B) -> C { unimplemented!() }
+}
+
+fn test_fn5<T: T1>(t: T, x: X3) {
+    assert!(t.fn5::<i32, (i32, i32), bool>(3, (4, 5)));
+    assert!(t.pure_fn5::<i32, (i32, i32), bool>(3, (4, 5)));
+    assert!(x.fn5::<i32, (i32, i32), bool>(3, (4, 5)));
+    assert!(x.pure_fn5::<i32, (i32, i32), bool>(3, (4, 5)));
+}
+
+trait T2 {
+    type AT1: Valid1 + Copy;
+    type AT2: Valid1 + Copy;
+
+    // TODO: the c.valid1() && d.valid1() constraint causes a panic;
+    //       we probably need to use the ParamEnv-respecting `local_mir`
+    //       throughout the codebase
+
+    #[requires(a.valid2() && b.valid1()
+        // && c.valid1() && d.valid1()
+    )]
+    #[ensures(result.valid2())]
+    fn fn6<A: Valid2, B: Valid1, C: Valid2>(&self, a: A, b: B, c: Self::AT1, d: Self::AT2) -> C;
+
+    #[pure]
+    #[requires(a.valid2() && b.valid1()
+        // && c.valid1() && d.valid1()
+    )]
+    #[ensures(result.valid2())]
+    fn pure_fn6<A: Valid2 + Copy, B: Valid1 + Copy, C: Valid2 + Copy>(&self, a: A, b: B, c: Self::AT1, d: Self::AT2) -> C;
+}
+
+struct X4 {}
+impl T2 for X4 {
+    type AT1 = (i32, usize);
+    type AT2 = (usize, i32);
+
+    #[trusted]
+    fn fn6<A: Valid2, B: Valid1, C: Valid2>(&self, a: A, b: B, c: (i32, usize), d: (usize, i32)) -> C { unimplemented!() }
+
+    #[trusted]
+    #[pure]
+    fn pure_fn6<A: Valid2 + Copy, B: Valid1 + Copy, C: Valid2 + Copy>(&self, a: A, b: B, c: (i32, usize), d: (usize, i32)) -> C { unimplemented!() }
+}
+
+fn test_fn6<T: T2<AT1 = (i32, usize), AT2 = (usize, i32)>>(t: T, x: X4) {
+    assert!(!t.fn6::<i32, (i32, i32), bool>(7, (8, 9), (42, 43), (33, 44)));
+    assert!(!t.pure_fn6::<i32, (i32, i32), bool>(7, (8, 9), (42, 43), (33, 44)));
+    assert!(!x.fn6::<i32, (i32, i32), bool>(7, (8, 9), (42, 43), (33, 44)));
+    assert!(!x.pure_fn6::<i32, (i32, i32), bool>(7, (8, 9), (42, 43), (33, 44)));
+}
+
+#[trusted]
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/pass/generic/trait-lifetime.rs
+++ b/prusti-tests/tests/verify_overflow/pass/generic/trait-lifetime.rs
@@ -1,0 +1,17 @@
+use prusti_contracts::*;
+
+trait Trait<'a> {
+    type AT;
+}
+
+#[trusted]
+fn test1<'a, T: Trait<'a>>(_t: T) -> T::AT {
+    unimplemented!()
+}
+
+fn test2<'a, T: Trait<'a>>(x: T) {
+    test1(x);
+}
+
+#[trusted]
+fn main() {}

--- a/prusti-tests/tests/verify_partial/fail/issues/issue-729-1.rs
+++ b/prusti-tests/tests/verify_partial/fail/issues/issue-729-1.rs
@@ -1,7 +1,7 @@
 // FIXME: remove this compile flag when the new encoder is finished
 // compile-flags: -Puse_new_encoder=false
 
-// error-pattern: Precondition of function snap$__$TY$__Snap$struct$m_A$ might not hold
+// error-pattern: Precondition of function snap$__$TY$__Snap$struct$m_A$struct$m_A$Snap$struct$m_A might not hold
 // FIXME: https://github.com/viperproject/prusti-dev/issues/729
 #![allow(unused_comparisons)]
 use prusti_contracts::*;

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -711,7 +711,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
                 // TODO: Make sure that this encoded function does not end up in
                 // the Viper file because that would be unsound.
                 let identity_substs = self.env.query.identity_substs(proc_def_id);
-                if let Err(error) = self.encode_pure_function_def(proc_def_id, identity_substs) {
+                if let Err(error) = self.encode_pure_function_def(proc_def_id, proc_def_id, identity_substs) {
                     self.register_encoding_error(error);
                     debug!("Error encoding function: {:?}", proc_def_id);
                     // Skip encoding the function as a method.

--- a/prusti-viper/src/encoder/high/types/fields.rs
+++ b/prusti-viper/src/encoder/high/types/fields.rs
@@ -32,7 +32,8 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
         | vir::Type::Closure(_)
         | vir::Type::FunctionDef(_)
         | vir::Type::FnPointer
-        | vir::Type::TypeVar(_) => vir::FieldDecl::new("val_ref", 0usize, ty),
+        | vir::Type::TypeVar(_)
+        | vir::Type::Projection(_) => vir::FieldDecl::new("val_ref", 0usize, ty),
 
         vir::Type::Reference(vir::ty::Reference { target_type, .. }) => {
             vir::FieldDecl::new("val_ref", 0usize, (*target_type).clone())
@@ -49,7 +50,6 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
         | vir::Type::Pointer(_)
         | vir::Type::Never
         | vir::Type::Str
-        | vir::Type::Projection(_)
         | vir::Type::Unsupported(_) => {
             return Err(EncodingError::unsupported(format!(
                 "{} type is not supported",

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -161,7 +161,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         // if the function returns a snapshot, we take a snapshot of the body
         if self.encode_function_return_type()?.is_snapshot() {
             let ty = self.sig.output();
-            if !self.encoder.env().query.type_is_copy(ty, self.proc_def_id) {
+            if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
                 return Err(SpannedEncodingError::unsupported(
                     "return type of pure function does not implement Copy",
                     self.get_return_span(),
@@ -257,7 +257,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 .encoder
                 .env()
                 .query
-                .type_is_copy(self.sig.output(), self.proc_def_id));
+                .type_is_copy(self.sig.output(), self.parent_def_id));
             let mut return_bounds: Vec<_> = self
                 .encoder
                 .encode_type_bounds(
@@ -272,7 +272,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
 
             for (formal_arg, local) in formal_args.iter().zip(self.args_iter()) {
                 let typ = self.get_local_ty(local);
-                debug_assert!(self.encoder.env().query.type_is_copy(typ, self.proc_def_id));
+                debug_assert!(self.encoder.env().query.type_is_copy(typ, self.parent_def_id));
                 let mut bounds = self
                     .encoder
                     .encode_type_bounds(&vir::Expr::local(formal_arg.clone()), typ.skip_binder());
@@ -518,7 +518,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let ty = self.sig.output();
 
         // Return an error for unsupported return types
-        if !self.encoder.env().query.type_is_copy(ty, self.proc_def_id) {
+        if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
             return Err(SpannedEncodingError::incorrect(
                 "return type of pure function does not implement Copy",
                 self.get_return_span(),
@@ -548,7 +548,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 .encoder
                 .env()
                 .query
-                .type_is_copy(local_ty, self.proc_def_id)
+                .type_is_copy(local_ty, self.parent_def_id)
             {
                 return Err(SpannedEncodingError::incorrect(
                     "pure function parameters must be Copy",

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -60,7 +60,10 @@ pub(super) fn encode_body<'p, 'v: 'p, 'tcx: 'v>(
     parent_def_id: DefId,
     substs: SubstsRef<'tcx>,
 ) -> SpannedEncodingResult<vir::Expr> {
-    let mir = encoder.env().body.get_expression_body(proc_def_id, substs, parent_def_id);
+    let mir = encoder
+        .env()
+        .body
+        .get_expression_body(proc_def_id, substs, parent_def_id);
     let interpreter = PureFunctionBackwardInterpreter::new(
         encoder,
         &mir,
@@ -101,7 +104,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         );
 
         let span = encoder.get_spec_span(proc_def_id);
-        let sig = encoder.env().query.get_fn_sig_resolved(proc_def_id, substs, parent_def_id);
+        let sig = encoder
+            .env()
+            .query
+            .get_fn_sig_resolved(proc_def_id, substs, parent_def_id);
 
         PureFunctionEncoder {
             encoder,
@@ -116,11 +122,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
     }
 
     pub fn encode_function(&mut self) -> SpannedEncodingResult<vir::Function> {
-        let mir = self
-            .encoder
-            .env()
-            .body
-            .get_pure_fn_body(self.proc_def_id, self.substs, self.parent_def_id);
+        let mir = self.encoder.env().body.get_pure_fn_body(
+            self.proc_def_id,
+            self.substs,
+            self.parent_def_id,
+        );
         let interpreter = PureFunctionBackwardInterpreter::new(
             self.encoder,
             &mir,
@@ -161,7 +167,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         // if the function returns a snapshot, we take a snapshot of the body
         if self.encode_function_return_type()?.is_snapshot() {
             let ty = self.sig.output();
-            if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
+            if !self
+                .encoder
+                .env()
+                .query
+                .type_is_copy(ty, self.parent_def_id)
+            {
                 return Err(SpannedEncodingError::unsupported(
                     "return type of pure function does not implement Copy",
                     self.get_return_span(),
@@ -272,7 +283,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
 
             for (formal_arg, local) in formal_args.iter().zip(self.args_iter()) {
                 let typ = self.get_local_ty(local);
-                debug_assert!(self.encoder.env().query.type_is_copy(typ, self.parent_def_id));
+                debug_assert!(self
+                    .encoder
+                    .env()
+                    .query
+                    .type_is_copy(typ, self.parent_def_id));
                 let mut bounds = self
                     .encoder
                     .encode_type_bounds(&vir::Expr::local(formal_arg.clone()), typ.skip_binder());
@@ -518,7 +533,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let ty = self.sig.output();
 
         // Return an error for unsupported return types
-        if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
+        if !self
+            .encoder
+            .env()
+            .query
+            .type_is_copy(ty, self.parent_def_id)
+        {
             return Err(SpannedEncodingError::incorrect(
                 "return type of pure function does not implement Copy",
                 self.get_return_span(),

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder.rs
@@ -60,7 +60,7 @@ pub(super) fn encode_body<'p, 'v: 'p, 'tcx: 'v>(
     parent_def_id: DefId,
     substs: SubstsRef<'tcx>,
 ) -> SpannedEncodingResult<vir::Expr> {
-    let mir = encoder.env().body.get_expression_body(proc_def_id, substs);
+    let mir = encoder.env().body.get_expression_body(proc_def_id, substs, parent_def_id);
     let interpreter = PureFunctionBackwardInterpreter::new(
         encoder,
         &mir,
@@ -101,7 +101,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         );
 
         let span = encoder.get_spec_span(proc_def_id);
-        let sig = encoder.env().query.get_fn_sig_resolved(proc_def_id, substs);
+        let sig = encoder.env().query.get_fn_sig_resolved(proc_def_id, substs, parent_def_id);
 
         PureFunctionEncoder {
             encoder,
@@ -120,7 +120,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             .encoder
             .env()
             .body
-            .get_pure_fn_body(self.proc_def_id, self.substs);
+            .get_pure_fn_body(self.proc_def_id, self.substs, self.parent_def_id);
         let interpreter = PureFunctionBackwardInterpreter::new(
             self.encoder,
             &mir,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -3,7 +3,7 @@
 use super::encoder::{FunctionCallInfo, FunctionCallInfoHigh, PureFunctionEncoder};
 use crate::encoder::{
     errors::{SpannedEncodingResult, WithSpan},
-    mir::{generics::MirGenericsEncoderInterface, specifications::SpecificationsInterface},
+    mir::specifications::SpecificationsInterface,
     snapshot::interface::SnapshotEncoderInterface,
     stub_function_encoder::StubFunctionEncoder,
 };
@@ -23,11 +23,7 @@ use vir_crate::{common::identifier::WithIdentifier, high as vir_high, polymorphi
 /// to account for different monomorphisations resulting from the function
 /// being called from callers (with different parameter environments). Each
 /// variant of a pure function will be encoded as a separate Viper function.
-type Key<'tcx> = (
-    ProcedureDefId,
-    SubstsRef<'tcx>,
-    ty::PolyFnSig<'tcx>,
-);
+type Key<'tcx> = (ProcedureDefId, SubstsRef<'tcx>, ty::PolyFnSig<'tcx>);
 
 /// Compute the key for the given call.
 fn compute_key<'v, 'tcx: 'v>(
@@ -39,7 +35,10 @@ fn compute_key<'v, 'tcx: 'v>(
     Ok((
         proc_def_id,
         substs,
-        encoder.env().query.get_fn_sig_resolved(proc_def_id, substs, caller_def_id),
+        encoder
+            .env()
+            .query
+            .get_fn_sig_resolved(proc_def_id, substs, caller_def_id),
     ))
     /*
     let tcx = encoder.env().tcx();
@@ -364,7 +363,10 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 Err(error) => {
                     self.register_encoding_error(error);
                     debug!("Error encoding pure function: {:?}", proc_def_id);
-                    let body = self.env().body.get_pure_fn_body(proc_def_id, substs, parent_def_id);
+                    let body = self
+                        .env()
+                        .body
+                        .get_pure_fn_body(proc_def_id, substs, parent_def_id);
                     // TODO(tymap): does stub encoder need substs?
                     let stub_encoder = StubFunctionEncoder::new(self, proc_def_id, &body, substs);
                     let function = stub_encoder.encode_function()?;

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -10,18 +10,54 @@ use crate::encoder::{
 use log::{debug, trace};
 use prusti_common::config;
 use prusti_interface::data::ProcedureDefId;
-use prusti_rustc_interface::middle::ty::subst::SubstsRef;
+use prusti_rustc_interface::middle::{ty, ty::subst::SubstsRef};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use prusti_interface::specs::typed::ProcedureSpecificationKind;
 use std::cell::RefCell;
 use vir_crate::{common::identifier::WithIdentifier, high as vir_high, polymorphic as vir_poly};
 
-/// Key of stored call infos, consisting of the DefId of the called function
-/// and (the VIR encoding of) the type substitutions applied to it. This means
-/// that each generic variant of a pure function will be encoded as a separate
-/// pure function in Viper.
-type Key = (ProcedureDefId, Vec<vir_high::Type>);
+/// Key of stored call infos, consisting of the `DefId` of the called function,
+/// the normalised type substitutions, and the function signature after type
+/// substitution and normalisation. The second and third components are stored
+/// to account for different monomorphisations resulting from the function
+/// being called from callers (with different parameter environments). Each
+/// variant of a pure function will be encoded as a separate Viper function.
+type Key<'tcx> = (
+    ProcedureDefId,
+    SubstsRef<'tcx>,
+    ty::PolyFnSig<'tcx>,
+);
+
+/// Compute the key for the given call.
+fn compute_key<'v, 'tcx: 'v>(
+    encoder: &crate::encoder::encoder::Encoder<'v, 'tcx>,
+    proc_def_id: ProcedureDefId,
+    caller_def_id: ProcedureDefId,
+    substs: SubstsRef<'tcx>,
+) -> SpannedEncodingResult<Key<'tcx>> {
+    Ok((
+        proc_def_id,
+        substs,
+        encoder.env().query.get_fn_sig_resolved(proc_def_id, substs, caller_def_id),
+    ))
+    /*
+    let tcx = encoder.env().tcx();
+    let sig = if tcx.is_closure(proc_def_id) {
+        substs.as_closure().sig()
+    } else {
+        tcx.fn_sig(proc_def_id)
+    };
+    let param_env = tcx.param_env(caller_def_id);
+    let sig = tcx.subst_and_normalize_erasing_regions(substs, param_env, sig);
+    let substs = tcx.subst_and_normalize_erasing_regions(
+        substs,
+        param_env,
+        encoder.env().identity_substs(proc_def_id),
+    );
+    Ok((proc_def_id, substs, sig.inputs_and_output().skip_binder()))
+    */
+}
 
 type FunctionConstructor<'v, 'tcx> = Box<
     dyn FnOnce(
@@ -52,22 +88,22 @@ pub(crate) enum PureEncodingContext {
 
 #[derive(Default)]
 pub(crate) struct PureFunctionEncoderState<'v, 'tcx: 'v> {
-    bodies_high: RefCell<FxHashMap<Key, vir_high::Expression>>,
-    bodies_poly: RefCell<FxHashMap<Key, vir_poly::Expr>>,
+    bodies_high: RefCell<FxHashMap<Key<'tcx>, vir_high::Expression>>,
+    bodies_poly: RefCell<FxHashMap<Key<'tcx>, vir_poly::Expr>>,
     /// Information necessary to encode a function call. FIXME: Remove this one
     /// and have only call_infos_high.
-    call_infos_poly: RefCell<FxHashMap<Key, FunctionCallInfo>>,
+    call_infos_poly: RefCell<FxHashMap<Key<'tcx>, FunctionCallInfo>>,
     /// Information necessary to encode a function call.
-    call_infos_high: RefCell<FxHashMap<Key, FunctionCallInfoHigh>>,
+    call_infos_high: RefCell<FxHashMap<Key<'tcx>, FunctionCallInfoHigh>>,
     /// Pure functions whose encoding started (and potentially already
     /// finished). This is used to break recursion.
-    pure_functions_encoding_started: RefCell<FxHashSet<Key>>,
+    pure_functions_encoding_started: RefCell<FxHashSet<Key<'tcx>>>,
     // A mapping from the function identifier to an information needed to encode
     // that function.
     function_descriptions:
         RefCell<FxHashMap<vir_poly::FunctionIdentifier, FunctionDescription<'tcx>>>,
     /// Mapping from keys on MIR level to function identifiers on VIR level.
-    function_identifiers: RefCell<FxHashMap<Key, vir_poly::FunctionIdentifier>>,
+    function_identifiers: RefCell<FxHashMap<Key<'tcx>, vir_poly::FunctionIdentifier>>,
     /// Encoded functions. The encoding of these functions was triggered by the
     /// definition collector requesting their definition.
     functions: RefCell<FxHashMap<String, std::rc::Rc<vir_high::FunctionDecl>>>,
@@ -79,6 +115,7 @@ pub(crate) struct PureFunctionEncoderState<'v, 'tcx: 'v> {
 #[derive(Clone, Debug)]
 pub(crate) struct FunctionDescription<'tcx> {
     proc_def_id: ProcedureDefId,
+    parent_def_id: ProcedureDefId,
     substs: SubstsRef<'tcx>,
 }
 
@@ -102,6 +139,7 @@ pub(crate) trait PureFunctionEncoderInterface<'v, 'tcx> {
     fn encode_pure_function_def(
         &self,
         proc_def_id: ProcedureDefId,
+        parent_def_id: ProcedureDefId,
         substs: SubstsRef<'tcx>,
     ) -> SpannedEncodingResult<()>;
 
@@ -159,11 +197,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
         parent_def_id: ProcedureDefId,
         substs: SubstsRef<'tcx>,
     ) -> SpannedEncodingResult<vir_high::Expression> {
-        let mir_span = self.env().query.get_def_span(proc_def_id);
-        let substs_key = self
-            .encode_generic_arguments_high(proc_def_id, substs)
-            .with_span(mir_span)?;
-        let key = (proc_def_id, substs_key);
+        let key = compute_key(self, proc_def_id, parent_def_id, substs)?;
         if !self
             .pure_function_encoder_state
             .bodies_high
@@ -186,7 +220,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 .pure_function_encoder_state
                 .bodies_high
                 .borrow_mut()
-                .insert(key.clone(), body)
+                .insert(key, body)
                 .is_none());
         }
         Ok(self.pure_function_encoder_state.bodies_high.borrow()[&key].clone())
@@ -200,12 +234,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
         parent_def_id: ProcedureDefId,
         substs: SubstsRef<'tcx>,
     ) -> SpannedEncodingResult<vir_poly::Expr> {
-        let mir_span = self.env().query.get_def_span(proc_def_id);
-        let substs_key = self
-            .encode_generic_arguments_high(proc_def_id, substs)
-            .with_span(mir_span)?;
-        let key = (proc_def_id, substs_key);
-
+        let key = compute_key(self, proc_def_id, parent_def_id, substs)?;
         if !self
             .pure_function_encoder_state
             .bodies_poly
@@ -227,7 +256,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
             self.pure_function_encoder_state
                 .bodies_poly
                 .borrow_mut()
-                .insert(key.clone(), body);
+                .insert(key, body);
         }
         Ok(self.pure_function_encoder_state.bodies_poly.borrow()[&key].clone())
     }
@@ -235,6 +264,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
     fn encode_pure_function_def(
         &self,
         proc_def_id: ProcedureDefId,
+        parent_def_id: ProcedureDefId,
         substs: SubstsRef<'tcx>,
     ) -> SpannedEncodingResult<()> {
         trace!("[enter] encode_pure_function_def({:?})", proc_def_id);
@@ -245,11 +275,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
         );
 
         let mir_span = self.env().query.get_def_span(proc_def_id);
-        let substs_key = self
-            .encode_generic_arguments_high(proc_def_id, substs)
-            .with_span(mir_span)?;
-        let key = (proc_def_id, substs_key);
-
+        let key = compute_key(self, proc_def_id, parent_def_id, substs)?;
         if !self
             .pure_function_encoder_state
             .function_identifiers
@@ -266,13 +292,13 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
             self.pure_function_encoder_state
                 .pure_functions_encoding_started
                 .borrow_mut()
-                .insert(key.clone());
+                .insert(key);
 
             let mut pure_function_encoder = PureFunctionEncoder::new(
                 self,
                 proc_def_id,
                 PureEncodingContext::Code,
-                proc_def_id,
+                parent_def_id,
                 substs,
             );
 
@@ -338,7 +364,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 Err(error) => {
                     self.register_encoding_error(error);
                     debug!("Error encoding pure function: {:?}", proc_def_id);
-                    let body = self.env().body.get_pure_fn_body(proc_def_id, substs);
+                    let body = self.env().body.get_pure_fn_body(proc_def_id, substs, parent_def_id);
                     // TODO(tymap): does stub encoder need substs?
                     let stub_encoder = StubFunctionEncoder::new(self, proc_def_id, &body, substs);
                     let function = stub_encoder.encode_function()?;
@@ -371,6 +397,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
             drop(function_descriptions);
             self.encode_pure_function_def(
                 function_description.proc_def_id,
+                function_description.parent_def_id,
                 function_description.substs,
             )?;
         } else {
@@ -391,17 +418,13 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
             proc_def_id
         );
 
-        let mir_span = self.env().query.get_def_span(proc_def_id);
-        let substs_key = self
-            .encode_generic_arguments_high(proc_def_id, substs)
-            .with_span(mir_span)?;
-        let key = (proc_def_id, substs_key);
+        let key = compute_key(self, proc_def_id, parent_def_id, substs)?;
 
         let mut call_infos = self
             .pure_function_encoder_state
             .call_infos_poly
             .borrow_mut();
-        if !call_infos.contains_key(&key) {
+        if let std::collections::hash_map::Entry::Vacant(e) = call_infos.entry(key) {
             // Compute information necessary to encode the function call and
             // memoize it.
             let pure_function_encoder = PureFunctionEncoder::new(
@@ -429,10 +452,11 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 .entry(function_identifier)
                 .or_insert(FunctionDescription {
                     proc_def_id,
+                    parent_def_id,
                     substs,
                 });
 
-            call_infos.insert(key.clone(), function_call_info);
+            e.insert(function_call_info);
         }
         let function_call_info = &call_infos[&key];
 
@@ -454,17 +478,13 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
             proc_def_id
         );
 
-        let mir_span = self.env().query.get_def_span(proc_def_id);
-        let substs_key = self
-            .encode_generic_arguments_high(proc_def_id, substs)
-            .with_span(mir_span)?;
-        let key = (proc_def_id, substs_key);
+        let key = compute_key(self, proc_def_id, parent_def_id, substs)?;
 
         let mut call_infos = self
             .pure_function_encoder_state
             .call_infos_high
             .borrow_mut();
-        if !call_infos.contains_key(&key) {
+        if let std::collections::hash_map::Entry::Vacant(e) = call_infos.entry(key) {
             // Compute information necessary to encode the function call and
             // memoize it.
             let function_call_info = super::new_encoder::encode_function_call_info(
@@ -492,7 +512,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 let _ = self.encode_pure_function_use(proc_def_id, parent_def_id, substs)?;
             }
 
-            call_infos.insert(key.clone(), function_call_info);
+            e.insert(function_call_info);
         }
         let function_call_info = &call_infos[&key];
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -85,7 +85,7 @@ pub(super) fn encode_pure_expression<'p, 'v: 'p, 'tcx: 'v>(
     parent_def_id: DefId,
     substs: SubstsRef<'tcx>,
 ) -> SpannedEncodingResult<vir_high::Expression> {
-    let mir = encoder.env().body.get_spec_body(proc_def_id, substs);
+    let mir = encoder.env().body.get_spec_body(proc_def_id, substs, parent_def_id);
     let interpreter = ExpressionBackwardInterpreter::new(
         encoder,
         &mir,
@@ -171,7 +171,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         );
 
         let span = encoder.get_spec_span(proc_def_id);
-        let sig = encoder.env().query.get_fn_sig_resolved(proc_def_id, substs);
+        let sig = encoder.env().query.get_fn_sig_resolved(proc_def_id, substs, parent_def_id);
 
         Self {
             encoder,
@@ -196,7 +196,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
                 .encoder
                 .env()
                 .body
-                .get_pure_fn_body(self.proc_def_id, self.substs);
+                .get_pure_fn_body(self.proc_def_id, self.substs, self.parent_def_id);
             let interpreter = ExpressionBackwardInterpreter::new(
                 self.encoder,
                 &mir,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -274,7 +274,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let mut parameters = Vec::new();
         for local in self.args_iter() {
             let ty = self.get_local_ty(local);
-            if !self.encoder.env().query.type_is_copy(ty, self.proc_def_id) {
+            if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
                 return Err(SpannedEncodingError::incorrect(
                     "all types used in pure functions must be Copy",
                     self.get_local_span(local),
@@ -301,7 +301,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let ty = self.sig.output();
 
         let span = self.get_return_span();
-        if !self.encoder.env().query.type_is_copy(ty, self.proc_def_id) {
+        if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
             return Err(SpannedEncodingError::incorrect(
                 "return type of pure function does not implement Copy",
                 span,
@@ -389,7 +389,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
     /// Encodes a VIR local with the original MIR type.
     fn encode_mir_local(&self, local: mir::Local) -> SpannedEncodingResult<vir_high::VariableDecl> {
         let ty = self.get_local_ty(local);
-        if !self.encoder.env().query.type_is_copy(ty, self.proc_def_id) {
+        if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
             return Err(SpannedEncodingError::incorrect(
                 "pure function parameters must be Copy",
                 self.get_local_span(local),

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/new_encoder.rs
@@ -85,7 +85,10 @@ pub(super) fn encode_pure_expression<'p, 'v: 'p, 'tcx: 'v>(
     parent_def_id: DefId,
     substs: SubstsRef<'tcx>,
 ) -> SpannedEncodingResult<vir_high::Expression> {
-    let mir = encoder.env().body.get_spec_body(proc_def_id, substs, parent_def_id);
+    let mir = encoder
+        .env()
+        .body
+        .get_spec_body(proc_def_id, substs, parent_def_id);
     let interpreter = ExpressionBackwardInterpreter::new(
         encoder,
         &mir,
@@ -171,7 +174,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         );
 
         let span = encoder.get_spec_span(proc_def_id);
-        let sig = encoder.env().query.get_fn_sig_resolved(proc_def_id, substs, parent_def_id);
+        let sig = encoder
+            .env()
+            .query
+            .get_fn_sig_resolved(proc_def_id, substs, parent_def_id);
 
         Self {
             encoder,
@@ -192,11 +198,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let body = if is_bodyless {
             None
         } else {
-            let mir = self
-                .encoder
-                .env()
-                .body
-                .get_pure_fn_body(self.proc_def_id, self.substs, self.parent_def_id);
+            let mir = self.encoder.env().body.get_pure_fn_body(
+                self.proc_def_id,
+                self.substs,
+                self.parent_def_id,
+            );
             let interpreter = ExpressionBackwardInterpreter::new(
                 self.encoder,
                 &mir,
@@ -274,7 +280,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let mut parameters = Vec::new();
         for local in self.args_iter() {
             let ty = self.get_local_ty(local);
-            if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
+            if !self
+                .encoder
+                .env()
+                .query
+                .type_is_copy(ty, self.parent_def_id)
+            {
                 return Err(SpannedEncodingError::incorrect(
                     "all types used in pure functions must be Copy",
                     self.get_local_span(local),
@@ -301,7 +312,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
         let ty = self.sig.output();
 
         let span = self.get_return_span();
-        if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
+        if !self
+            .encoder
+            .env()
+            .query
+            .type_is_copy(ty, self.parent_def_id)
+        {
             return Err(SpannedEncodingError::incorrect(
                 "return type of pure function does not implement Copy",
                 span,
@@ -389,7 +405,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
     /// Encodes a VIR local with the original MIR type.
     fn encode_mir_local(&self, local: mir::Local) -> SpannedEncodingResult<vir_high::VariableDecl> {
         let ty = self.get_local_ty(local);
-        if !self.encoder.env().query.type_is_copy(ty, self.parent_def_id) {
+        if !self
+            .encoder
+            .env()
+            .query
+            .type_is_copy(ty, self.parent_def_id)
+        {
             return Err(SpannedEncodingError::incorrect(
                 "pure function parameters must be Copy",
                 self.get_local_span(local),

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs
@@ -44,7 +44,7 @@ pub(super) fn inline_closure_high<'tcx>(
     let mir = encoder
         .env()
         .body
-        .get_closure_body(def_id.expect_local(), substs);
+        .get_closure_body(def_id.expect_local(), substs, parent_def_id);
     assert_eq!(mir.arg_count, args.len() + 1);
     let mut body_replacements = vec![];
     for (arg_idx, arg_local) in mir.args_iter().enumerate() {
@@ -75,7 +75,7 @@ pub(super) fn inline_spec_item_high<'tcx>(
     parent_def_id: DefId,
     substs: SubstsRef<'tcx>,
 ) -> SpannedEncodingResult<vir_high::Expression> {
-    let mir = encoder.env().body.get_spec_body(def_id, substs);
+    let mir = encoder.env().body.get_spec_body(def_id, substs, parent_def_id);
     assert_eq!(
         mir.arg_count,
         target_args.len() + if target_return.is_some() { 1 } else { 0 },

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs
@@ -75,7 +75,10 @@ pub(super) fn inline_spec_item_high<'tcx>(
     parent_def_id: DefId,
     substs: SubstsRef<'tcx>,
 ) -> SpannedEncodingResult<vir_high::Expression> {
-    let mir = encoder.env().body.get_spec_body(def_id, substs, parent_def_id);
+    let mir = encoder
+        .env()
+        .body
+        .get_spec_body(def_id, substs, parent_def_id);
     assert_eq!(
         mir.arg_count,
         target_args.len() + if target_return.is_some() { 1 } else { 0 },

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -82,7 +82,10 @@ pub(super) fn inline_spec_item<'tcx>(
         encoder.env().query.identity_substs(def_id).len()
     );
 
-    let mir = encoder.env().body.get_expression_body(def_id, substs, parent_def_id);
+    let mir = encoder
+        .env()
+        .body
+        .get_expression_body(def_id, substs, parent_def_id);
     assert_eq!(
         mir.arg_count,
         target_args.len() + if target_return.is_some() { 1 } else { 0 }

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -39,7 +39,7 @@ pub(super) fn inline_closure<'tcx>(
     let mir = encoder
         .env()
         .body
-        .get_closure_body(def_id.expect_local(), substs);
+        .get_closure_body(def_id.expect_local(), substs, parent_def_id);
     assert_eq!(mir.arg_count, args.len() + 1);
     let mir_encoder = MirEncoder::new(encoder, &mir, def_id);
     let mut body_replacements = vec![];
@@ -82,7 +82,7 @@ pub(super) fn inline_spec_item<'tcx>(
         encoder.env().query.identity_substs(def_id).len()
     );
 
-    let mir = encoder.env().body.get_expression_body(def_id, substs);
+    let mir = encoder.env().body.get_expression_body(def_id, substs, parent_def_id);
     assert_eq!(
         mir.arg_count,
         target_args.len() + if target_return.is_some() { 1 } else { 0 }

--- a/vir/defs/polymorphic/ast/function.rs
+++ b/vir/defs/polymorphic/ast/function.rs
@@ -100,14 +100,10 @@ impl Function {
 pub fn compute_identifier(
     name: &str,
     type_arguments: &[Type],
-    _formal_args: &[LocalVar],
-    _return_type: &Type,
+    formal_args: &[LocalVar],
+    return_type: &Type,
 ) -> String {
     let mut identifier = name.to_string();
-    // Include the signature of the function in the function name
-    if !type_arguments.is_empty() {
-        identifier.push_str("__$TY$__");
-    }
     fn type_name(typ: &Type) -> String {
         match typ {
             Type::Int => "$int$".to_string(),
@@ -126,10 +122,18 @@ pub fn compute_identifier(
             ),
         }
     }
+    identifier.push_str("__$TY$__");
+    // Include the type parameters of the function in the function name
     for arg in type_arguments {
         identifier.push_str(&type_name(arg));
         identifier.push('$');
     }
+    // Include the signature of the function in the function name
+    for arg in formal_args {
+        identifier.push_str(&type_name(&arg.typ));
+        identifier.push('$');
+    }
+    identifier.push_str(&type_name(return_type));
     identifier
 }
 


### PR DESCRIPTION
- [x] Fix `Copy` checks for pure functions (use the caller param env, not the callee).
- [x] Normalise associated types when monomorphising MIR bodies for pure functions.
- [x] Cache encoded pure functions by `DefId` + (full) encoded signature, not just "type parameters".