### PR TITLE
Remove the verbose flag from cargo builds

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up the environment
         run: python x.py setup
       - name: Build with cargo
-        run: python x.py build --release --all --verbose
+        run: python x.py build --release --all
       - name: Run benchmark
         run: python x.py run-benchmarks
       - name: Publish to GitHub pages

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up the environment
         run: python x.py setup
       - name: Build with cargo
-        run: python x.py build --all --verbose
+        run: python x.py build --all
         env:
           RUSTFLAGS: -Zinstrument-coverage
       - name: Run cargo tests, enabling debug dumps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up the environment
         run: python x.py setup
       - name: Build with cargo --release
-        run: python x.py build --release --all --verbose
+        run: python x.py build --release --all
       - name: Run cargo tests --release
         run: python x.py test --release --all --verbose
       - name: Upload Prusti artifact

--- a/.github/workflows/test-on-crates.yml
+++ b/.github/workflows/test-on-crates.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo --release
-        run: python x.py build --release --all --verbose
+        run: python x.py build --release --all
       - name: Test Prusti on a collection of crates
         run: ./target/release/test-crates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
-        run: python x.py build --all --verbose
+        run: python x.py build --all
       - name: Run "quick" cargo tests
         run: python x.py test --all --verbose quick
 
@@ -60,7 +60,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
-        run: python x.py build --all --verbose
+        run: python x.py build --all
       - name: Check and report Clippy errors
         run: |
           rustup component add clippy
@@ -93,7 +93,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
-        run: python x.py build --all --verbose
+        run: python x.py build --all
       - name: Check and report formatting warnings
         run: |
           rustup component add rustfmt
@@ -136,7 +136,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
-        run: python x.py build --all --verbose
+        run: python x.py build --all
       - name: Run "quick" cargo tests
         run: |
           python x.py verify-test prusti-tests/tests/verify/pass/rosetta/Knuth_shuffle.rs
@@ -218,7 +218,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v1.3.0
       - name: Build with cargo
-        run: python x.py build --all --verbose
+        run: python x.py build --all
       - name: Run cargo tests
         run: python x.py test --all --verbose
       - name: Run a subset of tests with Carbon
@@ -248,7 +248,7 @@ jobs:
       - name: Set up the environment
         run: python x.py setup
       - name: Build with cargo
-        run: python x.py build --release --all --verbose
+        run: python x.py build --release --all
       - name: Run cargo-prusti on Prusti
         run: python x.py prusti
         env:


### PR DESCRIPTION
The `--verbose` flag of `cargo build` makes the CI logs very long. I think we never actually needed that flag.