### PR TITLE
Print Prusti version, clarify error message

### DIFF
--- a/prusti-interface/src/specs/checker/version_checks.rs
+++ b/prusti-interface/src/specs/checker/version_checks.rs
@@ -21,7 +21,8 @@ impl<'tcx> SpecCheckerStrategy<'tcx> for MismatchedVersionsChecker {
             if env.compare_prusti_version(&min_prusti_version).is_lt() {
                 check_version.errors.push(PrustiError::incorrect(
                     format!(
-                        "Running Prusti version '{}' when the min required version is '{min_prusti_version}'! \
+                        "Running Prusti version '{}' when the minimum version required by \
+                        `prusti-contracts`/`prusti-specs` is '{min_prusti_version}'! \
                         Please update Prusti to version '{min_prusti_version}' or newer.",
                         env.get_prusti_version(),
                     ),

--- a/prusti-interface/src/specs/checker/version_checks.rs
+++ b/prusti-interface/src/specs/checker/version_checks.rs
@@ -21,8 +21,8 @@ impl<'tcx> SpecCheckerStrategy<'tcx> for MismatchedVersionsChecker {
             if env.compare_prusti_version(&min_prusti_version).is_lt() {
                 check_version.errors.push(PrustiError::incorrect(
                     format!(
-                        "Running Prusti version '{}' when the minimum version required by \
-                        `prusti-contracts`/`prusti-specs` is '{min_prusti_version}'! \
+                        "Running Prusti version '{}' when the minimum version required by the \
+                        `min_prusti_version` flag of the crate being compiled is '{min_prusti_version}'! \
                         Please update Prusti to version '{min_prusti_version}' or newer.",
                         env.get_prusti_version(),
                     ),

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -35,7 +35,8 @@ lazy_static! {
 
 fn get_prusti_version_info() -> String {
     format!(
-        "commit {} {}, built on {}",
+        "{}, commit {} {}, built on {}",
+        env!("CARGO_PKG_VERSION"),
         option_env!("COMMIT_HASH").unwrap_or("<unknown>"),
         option_env!("COMMIT_TIME").unwrap_or("<unknown>"),
         option_env!("BUILD_TIME").unwrap_or("<unknown>"),


### PR DESCRIPTION
I think it was not clear from where the minimum version requirement of prusti comes from. (Let me know if that's wrong.)