### PR TITLE
Make it possible to persist verification cache in prusti-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,9 +2091,12 @@ version = "0.2.0"
 dependencies = [
  "cargo-test-support",
  "compiletest_rs",
+ "env_logger",
+ "log",
  "prusti",
  "prusti-launch",
  "prusti-server",
+ "ureq",
 ]
 
 [[package]]

--- a/prusti-tests/Cargo.toml
+++ b/prusti-tests/Cargo.toml
@@ -10,6 +10,9 @@ prusti-server = { path = "../prusti-server" }
 prusti-launch = { path = "../prusti-launch" }
 prusti = { path = "../prusti" }
 cargo-test-support = { git = "https://github.com/rust-lang/cargo.git", rev = "17f8088" }
+ureq = "2.1"
+log = { version = "0.4", features = ["release_max_level_info"] }
+env_logger = "0.9"
 
 [package.metadata.rust-analyzer]
 # This crate uses #[feature(rustc_private)]

--- a/prusti-tests/tests/compiletest.rs
+++ b/prusti-tests/tests/compiletest.rs
@@ -10,9 +10,9 @@
 #![test_runner(test_runner)]
 
 use compiletest_rs::{common::Mode, run_tests, Config};
+use log::{error, info};
 use prusti_server::spawn_server_thread;
 use std::{env, path::PathBuf};
-use log::{info, error};
 
 fn find_prusti_rustc_path() -> PathBuf {
     let target_directory = if cfg!(debug_assertions) {
@@ -167,8 +167,8 @@ fn test_runner(_tests: &[&()]) {
     // Spawn server process as child (so it stays around until main function terminates)
     let server_address = spawn_server_thread();
     env::set_var("PRUSTI_SERVER_ADDRESS", server_address.to_string());
-    let save_verification_cache = || {
-        match ureq::post(&format!("http://{server_address}/save")).call() {
+    let save_verification_cache =
+        || match ureq::post(&format!("http://{server_address}/save")).call() {
             Ok(response) => {
                 info!("Saving verification cache: {}", response.status_text());
             }
@@ -176,8 +176,7 @@ fn test_runner(_tests: &[&()]) {
                 error!("Error while saving verification cache: {response:?}");
             }
             Err(err) => error!("Error while saving verification cache: {err}"),
-        }
-    };
+        };
 
     // Filter the tests to run
     let filter = env::args().nth(1);


### PR DESCRIPTION
Note: this PR does not actually persist the verification cache. To enable that, set `PRUSTI_CACHE_PATH` in your terminal.

This PR unblocks https://github.com/viperproject/prusti-dev/pull/856.