### PR TITLE
Fix paths in artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,7 @@ jobs:
             echo "Package Prusti artifact for $os"
             cd prusti-release-$os
             mv target/release/* .
+            mv prusti-contracts/target/verify/release/* .
             rm -rf target
             zip -r prusti.zip *
             cd ..

--- a/prusti-launch/src/bin/prusti-rustc.rs
+++ b/prusti-launch/src/bin/prusti-rustc.rs
@@ -62,7 +62,12 @@ fn process(mut args: Vec<String>) -> Result<(), i32> {
     // should always be with `cargo` anyway (i.e. cargo_invoked == true)
     if !cargo_invoked {
         // Need to give references to standard prusti libraries
-        let target_dir = launch::get_prusti_contracts_dir(prusti_home);
+        let target_dir = launch::get_prusti_contracts_dir(&prusti_home).unwrap_or_else(|| {
+            panic!(
+                "Failed to find the path of the Prusti contracts from prusti home '{}'",
+                prusti_home.display()
+            )
+        });
         if target_dir.to_str().is_none() {
             panic!(
                 "Path to '{}' is not a valid utf-8 string!",

--- a/prusti-utils/src/launch/mod.rs
+++ b/prusti-utils/src/launch/mod.rs
@@ -33,10 +33,25 @@ pub fn get_current_executable_dir() -> PathBuf {
         .to_path_buf()
 }
 
-pub fn get_prusti_contracts_dir(exe_dir: PathBuf) -> PathBuf {
-    let mut prusti_dir = exe_dir.parent().unwrap().parent().unwrap().to_path_buf();
-    prusti_dir.extend(["prusti-contracts", "target", "verify", "release"]);
-    prusti_dir
+pub fn get_prusti_contracts_dir(exe_dir: &Path) -> Option<PathBuf> {
+    let a_prusti_contracts_file = format!("lib{}.rlib", PRUSTI_LIBS[0].replace('-', "_"));
+    let candidates = [
+        // Libraries in the Prusti artifact will show up here
+        exe_dir.to_path_buf(),
+        // Libraries when building Prusti will show up here
+        exe_dir
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("prusti-contracts")
+            .join("target")
+            .join("verify")
+            .join("release"),
+    ];
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join(&a_prusti_contracts_file).exists())
 }
 
 /// Append paths to the loader environment variable


### PR DESCRIPTION
The `prusti-contracts` discovery was not working with the structure of files used in the artifact.