### PR TITLE
Use debug=1 instead of debug=true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ members = [
     "jni-gen/systest",
 ]
 
+[profile.dev]
+debug = 1
+
 [profile.release]
 # Enable after fixing https://github.com/viperproject/prusti-dev/issues/383
 # lto = true


### PR DESCRIPTION
This way the debug binaries are much smaller while still having stacktraces.

For example, on Ubuntu the `target/debug/prusti-driver` binary goes from 1.4 GB to "just" 300 MB. Most of the size was due to a 700 MB `.debug_pubtypes` section. There is a related rustc issue: https://github.com/rust-lang/rust/issues/48762.