### PR TITLE
Force nightly Rust toolchain in cargo-prusti

### DIFF
--- a/prusti-launch/src/bin/cargo-prusti.rs
+++ b/prusti-launch/src/bin/cargo-prusti.rs
@@ -44,6 +44,7 @@ where
     let cargo_target = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
     let cargo_target: PathBuf = [cargo_target, "verify".to_string()].into_iter().collect();
     let exit_status = Command::new(cargo_path)
+        .arg(&format!("+{}", launch::get_rust_toolchain_channel()))
         .arg(&command)
         .args(features)
         .args(args)

--- a/prusti-tests/tests/cargo_verify/failing_stable_toolchain/Cargo.toml
+++ b/prusti-tests/tests/cargo_verify/failing_stable_toolchain/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "failing_crate"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+prusti-contracts = { path = "prusti-contracts/prusti-contracts" } # The test suite will prepare a symbolic link for this
+
+# Declare that this crate is not part of a workspace
+[workspace]

--- a/prusti-tests/tests/cargo_verify/failing_stable_toolchain/Cargo.toml
+++ b/prusti-tests/tests/cargo_verify/failing_stable_toolchain/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "failing_crate"
+name = "failing_stable_toolchain"
 version = "0.1.0"
 edition = "2021"
 

--- a/prusti-tests/tests/cargo_verify/failing_stable_toolchain/output.stderr
+++ b/prusti-tests/tests/cargo_verify/failing_stable_toolchain/output.stderr
@@ -18,5 +18,4 @@ note: the failing assertion is here
 3 | #[requires(x > 123)]
   |            ^^^^^^^
 
-warning: `failing_stable_toolchain` (bin "failing_stable_toolchain") generated 1 warning
 error: could not compile `failing_stable_toolchain` due to previous error; 1 warning emitted

--- a/prusti-tests/tests/cargo_verify/failing_stable_toolchain/output.stderr
+++ b/prusti-tests/tests/cargo_verify/failing_stable_toolchain/output.stderr
@@ -1,0 +1,22 @@
+warning: unused variable: `unused`
+ --> src/main.rs:4:17
+  |
+4 | fn test(x: i32, unused: usize) {
+  |                 ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
+  |
+  = note: `#[warn(unused_variables)]` on by default
+
+error: [Prusti: verification error] precondition might not hold.
+ --> src/main.rs:9:5
+  |
+9 |     test(1, 0);
+  |     ^^^^^^^^^^
+  |
+note: the failing assertion is here
+ --> src/main.rs:3:12
+  |
+3 | #[requires(x > 123)]
+  |            ^^^^^^^
+
+warning: `failing_stable_toolchain` (bin "failing_stable_toolchain") generated 1 warning
+error: could not compile `failing_stable_toolchain` due to previous error; 1 warning emitted

--- a/prusti-tests/tests/cargo_verify/failing_stable_toolchain/rust-toolchain.toml
+++ b/prusti-tests/tests/cargo_verify/failing_stable_toolchain/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/prusti-tests/tests/cargo_verify/failing_stable_toolchain/src/main.rs
+++ b/prusti-tests/tests/cargo_verify/failing_stable_toolchain/src/main.rs
@@ -1,0 +1,10 @@
+use prusti_contracts::*;
+
+#[requires(x > 123)]
+fn test(x: i32, unused: usize) {
+    assert!(x > 123);
+}
+
+fn main() {
+    test(1, 0);
+}

--- a/prusti-tests/tests/cargotest.rs
+++ b/prusti-tests/tests/cargotest.rs
@@ -185,6 +185,11 @@ fn test_failing_crate() {
 }
 
 #[cargo_test]
+fn test_failing_stable_toolchain() {
+    test_local_project("failing_stable_toolchain");
+}
+
+#[cargo_test]
 fn test_library_contracts_test() {
     test_local_project("library_contracts_test");
 }


### PR DESCRIPTION
Procedural macros behave differently when compiled on stable compared to nightly ([documentation](https://docs.rs/proc-macro2/latest/proc_macro2/struct.Span.html#method.join)). This PR forces `cargo-prusti` to use the same nightly version that we use to compile Prusti.