### PR TITLE
Fix test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Build with cargo
         run: python x.py build --all
         env:
-          RUSTFLAGS: -Zinstrument-coverage
+          RUSTFLAGS: -Cinstrument-coverage
       - name: Run cargo tests, enabling debug dumps
         run: python x.py test --all
         env:
-          RUSTFLAGS: -Zinstrument-coverage
+          RUSTFLAGS: -Cinstrument-coverage
           PRUSTI_DUMP_DEBUG_INFO: true
           PRUSTI_DUMP_VIPER_PROGRAM: true
           PRUSTI_IGNORE_REGIONS: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ members = [
 [profile.dev]
 debug = 1
 
+[profile.test]
+debug = 1
+
 [profile.release]
 # Enable after fixing https://github.com/viperproject/prusti-dev/issues/383
 # lto = true


### PR DESCRIPTION
The test coverage runs are silently failing (since https://github.com/viperproject/prusti-dev/commit/0efcb86909662aaedfd33426125a23f4c8a1f4c1, it seems) because the github runner is apparently using more than 14 GB of disk. This PR tries to fix that.