### PR TITLE
Fix loop encoding when there are no user-defined invariants

### DIFF
--- a/prusti-interface/src/environment/loops.rs
+++ b/prusti-interface/src/environment/loops.rs
@@ -114,7 +114,9 @@ impl<'b, 'tcx> Visitor<'tcx> for AccessCollector<'b, 'tcx> {
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Copy) => PlaceAccessKind::Read,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Move) => PlaceAccessKind::Move,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Inspect) => PlaceAccessKind::Read,
-                NonMutatingUse(mir::visit::NonMutatingUseContext::AddressOf) => PlaceAccessKind::Read,
+                NonMutatingUse(mir::visit::NonMutatingUseContext::AddressOf) => {
+                    PlaceAccessKind::Read
+                }
                 NonMutatingUse(mir::visit::NonMutatingUseContext::SharedBorrow) => {
                     PlaceAccessKind::SharedBorrow
                 }

--- a/prusti-interface/src/environment/loops.rs
+++ b/prusti-interface/src/environment/loops.rs
@@ -246,6 +246,12 @@ pub struct ProcedureLoops {
     pub ordered_blocks: Vec<BasicBlockIndex>,
 }
 
+pub type ReadAndWriteLeaves<'tcx> = (
+    Vec<mir::Place<'tcx>>,
+    Vec<mir::Place<'tcx>>,
+    Vec<mir::Place<'tcx>>,
+);
+
 impl ProcedureLoops {
     pub fn new<'a, 'tcx: 'a>(mir: &'a mir::Body<'tcx>, real_edges: &RealEdges) -> ProcedureLoops {
         let dominators = mir.basic_blocks.dominators();
@@ -499,14 +505,7 @@ impl ProcedureLoops {
         loop_head: BasicBlockIndex,
         mir: &'a mir::Body<'tcx>,
         definitely_initalised_paths: Option<&PlaceSet<'tcx>>,
-    ) -> Result<
-        (
-            Vec<mir::Place<'tcx>>,
-            Vec<mir::Place<'tcx>>,
-            Vec<mir::Place<'tcx>>,
-        ),
-        LoopAnalysisError,
-    > {
+    ) -> Result<ReadAndWriteLeaves<'tcx>, LoopAnalysisError> {
         // 1.  Let ``A1`` be a set of pairs ``(p, t)`` where ``p`` is a prefix
         //     accessed in the loop body and ``t`` is the type of access (read,
         //     destructive read, …).

--- a/prusti-interface/src/environment/loops.rs
+++ b/prusti-interface/src/environment/loops.rs
@@ -114,6 +114,7 @@ impl<'b, 'tcx> Visitor<'tcx> for AccessCollector<'b, 'tcx> {
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Copy) => PlaceAccessKind::Read,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Move) => PlaceAccessKind::Move,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Inspect) => PlaceAccessKind::Read,
+                NonMutatingUse(mir::visit::NonMutatingUseContext::AddressOf) => PlaceAccessKind::Read,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::SharedBorrow) => {
                     PlaceAccessKind::SharedBorrow
                 }

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -32,7 +32,7 @@ mod traits;
 pub use self::{
     body::EnvBody,
     diagnostic::EnvDiagnostic,
-    loops::{PlaceAccess, PlaceAccessKind, ProcedureLoops},
+    loops::{LoopAnalysisError, PlaceAccess, PlaceAccessKind, ProcedureLoops},
     loops_utils::*,
     name::EnvName,
     procedure::{

--- a/prusti-tests/tests/verify/fail/issues/issue-1200-1.rs
+++ b/prusti-tests/tests/verify/fail/issues/issue-1200-1.rs
@@ -1,0 +1,38 @@
+use prusti_contracts::*;
+use std::cmp::min;
+
+/// Find a fft length larger that is at least `minimum_size` in length that is made up of a limited set of factors.
+/// The `once_factor` will be used exactly once, the multi factors may be used any number of times to reach the minimum.
+fn fast_fft_len(
+    minimum_len: usize,
+    once_factor: usize,
+    multi_factor1: usize,
+    multi_factor2: usize,
+) -> usize {
+    // Apply once factor
+    let mut product = once_factor;
+
+    // apply second factor until at or above minimum
+    while product < minimum_len {
+        product *= multi_factor2
+    }
+
+    // remove second factor one at a time then add enough first factor to reach minimum_size
+    // repeat while tracking lowest viable product
+    let mut best = product;
+    loop {
+        match product.cmp(&minimum_len) {
+            std::cmp::Ordering::Less => product *= multi_factor1,
+            std::cmp::Ordering::Equal => return product,
+            std::cmp::Ordering::Greater => {
+                best = min(best, product);
+                if product % multi_factor2 != 0 { //~ ERROR attempt to calculate the remainder with a divisor of zero
+                    return best;
+                }
+                product /= multi_factor2;
+            }
+        }
+    }
+}
+
+fn main(){}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-1200-2.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-1200-2.rs
@@ -1,0 +1,14 @@
+fn exit_loop_with_a_non_boolean_switch(
+    a: usize,
+    b: usize,
+) {
+    loop {
+        match a.cmp(&b) {
+            std::cmp::Ordering::Less => {},
+            std::cmp::Ordering::Equal => return,
+            std::cmp::Ordering::Greater => {}
+        }
+    }
+}
+
+fn main(){}


### PR DESCRIPTION
Fixes #1200.

When there are no user-defined loop invariants, Prusti was placing a `body_invariant!(true)` after the first exit block (MIR block with an edge that exits the loop). In doing so it was incorrectly assuming that such exit block is the evaluation of a boolean, but #1200 shows that it can actually be the evaluation of a `match`. This PR adds a further condition that checks the number of exit edges.