### PR TITLE
Fix log bugs when `Prusti.toml` is provided

### DIFF
--- a/docs/dev-guide/src/config/flags.md
+++ b/docs/dev-guide/src/config/flags.md
@@ -39,7 +39,7 @@
 | [`INTERN_NAMES`](#intern_names) | `bool` | `true` | A |
 | [`JAVA_HOME`](#java_home) | `Option<String>` | `None` | A |
 | [`JSON_COMMUNICATION`](#json_communication) | `bool` | `false` | A |
-| [`LOG`](#log) | `Option<String>` | `None` | A |
+| [`LOG`](#log) | `String` | `""` | A |
 | [`LOG_DIR`](#log_dir) | `String` | `"log"` | A* |
 | [`LOG_STYLE`](#log_style) | `String` | `"auto"` | A |
 | [`LOG_SMT_WRAPPER_INTERACTION`](#log_smt_wrapper_interaction) | `bool` | `false` | A |

--- a/prusti-launch/src/bin/prusti-server.rs
+++ b/prusti-launch/src/bin/prusti-server.rs
@@ -32,6 +32,9 @@ fn process(args: Vec<String>) -> Result<(), i32> {
     let mut cmd = Command::new(&prusti_server_driver_path);
     cmd.args(args);
 
+    // Prevent shadowing of default log behavior.
+    cmd.env("DEFAULT_PRUSTI_LOG", "info");
+
     let libjvm_path =
         launch::find_libjvm(&java_home).expect("Failed to find JVM library. Check JAVA_HOME");
     launch::add_to_loader_path(vec![libjvm_path], &mut cmd);

--- a/prusti-server/Cargo.toml
+++ b/prusti-server/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 log = { version = "0.4", features = ["release_max_level_info"] }
 viper = { path = "../viper" }
 prusti-common = { path = "../prusti-common" }
+prusti-utils = { path = "../prusti-utils" }
 env_logger = "0.9"
 clap = { version = "3.2", features = ["derive"] }
 bincode = "1.0"

--- a/prusti-server/src/driver.rs
+++ b/prusti-server/src/driver.rs
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use clap::Parser;
+use prusti_utils::config;
 
 /// A verification server to handle Prusti verification requests.
 #[derive(Parser, Debug)]
@@ -17,7 +18,11 @@ struct Args {
 }
 
 fn main() {
-    env_logger::init_from_env(env_logger::Env::new().filter_or("PRUSTI_LOG", "info"));
+    env_logger::init_from_env(
+        env_logger::Env::new()
+            .filter_or("PRUSTI_LOG", config::log())
+            .write_style_or("PRUSTI_LOG_STYLE", config::log_style()),
+    );
 
     let args = Args::parse();
 

--- a/prusti-utils/src/config.rs
+++ b/prusti-utils/src/config.rs
@@ -82,6 +82,8 @@ lazy_static::lazy_static! {
         settings.set_default("encode_unsigned_num_constraint", false).unwrap();
         settings.set_default("encode_bitvectors", false).unwrap();
         settings.set_default("simplify_encoding", true).unwrap();
+        settings.set_default("log", "").unwrap();
+        settings.set_default("log_style", "auto").unwrap();
         settings.set_default("log_dir", "log").unwrap();
         settings.set_default("cache_path", "").unwrap();
         settings.set_default("dump_debug_info", false).unwrap();
@@ -416,6 +418,16 @@ pub fn dump_viper_program() -> bool {
 /// Filter for `fold`/`unfold` nodes when debug info is dumped.
 pub fn foldunfold_state_filter() -> String {
     read_setting("foldunfold_state_filter")
+}
+
+/// Set the log level of `env_logger`.
+pub fn log() -> String {
+    read_setting("log")
+}
+
+/// Set the log style when logging is enabled by `log`.
+pub fn log_style() -> String {
+    read_setting("log_style")
 }
 
 /// Path to directory in which log files and dumped output will be stored.

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -101,10 +101,12 @@ fn report_prusti_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
 
 /// Initialize Prusti and the Rust compiler loggers.
 fn init_loggers() {
-    let env = env_logger::Env::new()
-        .filter("PRUSTI_LOG")
-        .write_style("PRUSTI_LOG_STYLE");
-    env_logger::init_from_env(env);
+    env_logger::init_from_env(
+        env_logger::Env::new()
+            .filter_or("PRUSTI_LOG", config::log())
+            .write_style_or("PRUSTI_LOG_STYLE", config::log_style()),
+    );
+    
     prusti_rustc_interface::driver::init_rustc_env_logger();
 }
 

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -106,7 +106,7 @@ fn init_loggers() {
             .filter_or("PRUSTI_LOG", config::log())
             .write_style_or("PRUSTI_LOG_STYLE", config::log_style()),
     );
-    
+
     prusti_rustc_interface::driver::init_rustc_env_logger();
 }
 


### PR DESCRIPTION
This PR fixes #1218 and allows reading log-related configurations from `Prusti.toml`.