### PR TITLE
Fix fold-unfold for old expression in after_expiry

### DIFF
--- a/prusti-tests/tests/verify/pass/fold-unfold/after_expiry_old.rs
+++ b/prusti-tests/tests/verify/pass/fold-unfold/after_expiry_old.rs
@@ -1,0 +1,27 @@
+use prusti_contracts::*;
+
+struct Inner(i32);
+
+struct Outer {
+  value: Inner,
+}
+
+#[pure]
+#[trusted]
+fn condition(v: &Outer) -> bool {
+  unimplemented!()
+}
+
+#[trusted]
+#[ensures(*result === *old(&v.value))]
+#[after_expiry(old(condition(&v)))]
+fn deref_mut(v: &mut Outer) -> &mut Inner {
+  &mut v.value
+}
+
+fn test(g: &mut Outer) {
+  deref_mut(g);
+}
+
+#[trusted]
+fn main () {}


### PR DESCRIPTION
When collecting old expressions in fold/unfold, also collect old expressions inside ReborrowingDAGs.

Without the fix, old expressions in after_expiry are not considered when generating fold/unfold statements, and the test produces this error:
`cannot generate fold-unfold Viper statements. A pure expression needs to fold Pred(_3.val_ref, write), but Viper doesn't support 'folding .. in ..' expressions.`

