### PR TITLE
Small improvements

### DIFF
--- a/docs/dev-guide/src/development/setup.md
+++ b/docs/dev-guide/src/development/setup.md
@@ -22,7 +22,7 @@ The script will perform the following steps:
  2. Downloads and extracts the latest [Viper tools](#viper-tools).
  3. Sets up [the Rust toolchain](#rustup-setup).
 
-Steps 1 and 2 can be skipped by adding the `--rustup-only` argument to the command line. `--dry-run` can be used to prevent any shell commands from actually running, only printing them to the terminal.
+Step 1 can be skipped by adding the `--no-deps` argument to the command line. `--dry-run` can be used to prevent any shell commands from actually running, only printing them to the terminal.
 
 The `setup` step should be repeated if the Rust toolchain version changes, or if the native dependencies or Viper tools need to be updated.
 

--- a/prusti-common/src/vir/low_to_viper/domain.rs
+++ b/prusti-common/src/vir/low_to_viper/domain.rs
@@ -49,6 +49,15 @@ impl<'a, 'v> ToViper<'v, Vec<viper::NamedDomainAxiom<'v>>>
 impl<'a, 'v> ToViper<'v, viper::NamedDomainAxiom<'v>> for (&'a String, &'a DomainAxiomDecl) {
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::NamedDomainAxiom<'v> {
         let (domain_name, axiom) = self;
-        ast.named_domain_axiom(&axiom.name, axiom.body.to_viper(context, ast), domain_name)
+        if let Some(comment) = &axiom.comment {
+            ast.named_domain_axiom_with_comment(
+                &axiom.name,
+                axiom.body.to_viper(context, ast),
+                domain_name,
+                comment,
+            )
+        } else {
+            ast.named_domain_axiom(&axiom.name, axiom.body.to_viper(context, ast), domain_name)
+        }
     }
 }

--- a/prusti-common/src/vir/macros/polymorphic.rs
+++ b/prusti-common/src/vir/macros/polymorphic.rs
@@ -151,6 +151,11 @@ macro_rules! vir_expr {
             vir_expr!($body),
         )
     };
+
+    (local $($tokens: tt)+) => {
+        vir_local!($($tokens)+).into()
+    };
+
     ([ $e: expr ]) => { $e.clone() };
     (( $($tokens: tt)+ )) => { vir_expr!($($tokens)+) }
 }

--- a/prusti-common/src/vir/macros/polymorphic.rs
+++ b/prusti-common/src/vir/macros/polymorphic.rs
@@ -140,10 +140,14 @@ macro_rules! vir_expr {
         $crate::vir::polymorphic_vir::Expr::magic_wand(vir_expr!($lhs), vir_expr!($rhs), $borrow)
     };
 
-    (forall $($name: ident : $type: tt),+ :: {$($triggers: tt),*} $body: tt) => {
+    (forall $($name: ident : $type: tt),+ :: $({ $($triggers: tt),+ })+ :: $body: tt) => {
         $crate::vir::polymorphic_vir::Expr::forall(
             vec![$($crate::vir_local!($name: $type)),+],
-            vec![$($crate::vir::polymorphic_vir::Trigger::new(vec![vir_expr!($triggers)])),*],
+            vec![
+                $($crate::vir::polymorphic_vir::Trigger::new(vec![
+                    $(vir_expr!($triggers)),+
+                ])),*
+            ],
             vir_expr!($body),
         )
     };
@@ -160,14 +164,14 @@ mod tests {
         let expected = Expr::ForAll(ForAll {
             variables: vec![vir_local!(i: Int), vir_local!(j: Int)],
             triggers: vec![
+                Trigger::new(vec![vir_expr! { true }, vir_expr! { false }]),
                 Trigger::new(vec![vir_expr! { true }]),
-                Trigger::new(vec![vir_expr! { false }]),
             ],
             body: Box::new(vir_expr! { true }),
             position: Position::default(),
         });
 
-        let actual = vir_expr! { forall i: Int, j: Int :: {true, false} true };
+        let actual = vir_expr! { forall i: Int, j: Int :: {true, false} {true} :: true };
 
         assert_eq!(expected, actual);
     }

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -885,11 +885,20 @@ impl<'a, 'v> ToViper<'v, viper::DomainFunc<'v>> for &'a DomainFunc {
 
 impl<'a, 'v> ToViper<'v, viper::NamedDomainAxiom<'v>> for &'a DomainAxiom {
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::NamedDomainAxiom<'v> {
-        ast.named_domain_axiom(
-            &self.name,
-            self.expr.to_viper(context, ast),
-            &self.domain_name,
-        )
+        if let Some(comment) = &self.comment {
+            ast.named_domain_axiom_with_comment(
+                &self.name,
+                self.expr.to_viper(context, ast),
+                &self.domain_name,
+                comment,
+            )
+        } else {
+            ast.named_domain_axiom(
+                &self.name,
+                self.expr.to_viper(context, ast),
+                &self.domain_name,
+            )
+        }
     }
 }
 

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -1176,7 +1176,11 @@ fn block_to_viper<'a>(
     index: usize,
 ) -> viper::Stmt<'a> {
     let label = &basic_block_labels[index];
-    let mut stmts: Vec<viper::Stmt> = vec![ast.label(label, &[])];
+    let mut stmts: Vec<viper::Stmt> = vec![
+        // To put a bit of white space between blocks.
+        ast.comment(""),
+        ast.label(label, &[])
+    ];
     stmts.extend(block.stmts.to_viper(context, ast));
     stmts.push(successor_to_viper(
         context,

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -1179,7 +1179,7 @@ fn block_to_viper<'a>(
     let mut stmts: Vec<viper::Stmt> = vec![
         // To put a bit of white space between blocks.
         ast.comment(""),
-        ast.label(label, &[])
+        ast.label(label, &[]),
     ];
     stmts.extend(block.stmts.to_viper(context, ast));
     stmts.push(successor_to_viper(

--- a/prusti-viper/src/encoder/builtin_encoder.rs
+++ b/prusti-viper/src/encoder/builtin_encoder.rs
@@ -304,6 +304,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BuiltinEncoder<'p, 'v, 'tcx> {
                 vec![vir::Trigger::new(vec![function_app.clone()])],
                 function_app);
             let axiom = vir::DomainAxiom {
+                comment: None,
                 name: format!("{}$axiom", f.get_identifier()),
                 expr: body,
                 domain_name: domain_name.to_string(),

--- a/prusti-viper/src/encoder/builtin_encoder.rs
+++ b/prusti-viper/src/encoder/builtin_encoder.rs
@@ -7,6 +7,7 @@
 use prusti_common::{vir_local, vir_expr};
 use vir_crate::polymorphic::{self as vir};
 use vir_crate::common::identifier::WithIdentifier;
+use super::errors::EncodingResult;
 use super::high::builtin_functions::HighBuiltinFunctionEncoderInterface;
 use super::versioning;
 
@@ -50,9 +51,7 @@ pub enum BuiltinFunctionKind {
     },
 }
 
-// This code is currently dead, but we should start using it soon.
-#[allow(dead_code)]
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum BuiltinDomainKind {
     Nat,
     Primitive,
@@ -81,7 +80,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> BuiltinEncoder<'p, 'v, 'tcx> {
         }
     }
 
-    pub fn encode_builtin_method_def(&self, method: BuiltinMethodKind) -> vir::BodylessMethod {
+    pub fn encode_builtin_method_def(&self, method: BuiltinMethodKind) -> EncodingResult<vir::BodylessMethod> {
+        let method_name = self.encode_builtin_method_name(method);
         let return_type = match method {
             BuiltinMethodKind::HavocBool => vir::Type::Bool,
             BuiltinMethodKind::HavocInt => vir::Type::Int,
@@ -90,16 +90,16 @@ impl<'p, 'v: 'p, 'tcx: 'v> BuiltinEncoder<'p, 'v, 'tcx> {
             BuiltinMethodKind::HavocF64 => vir::Type::Float(vir::Float::F64),
             BuiltinMethodKind::HavocRef => vir::Type::typed_ref(""),
             BuiltinMethodKind::BumpMemVersion => {
-                return versioning::bump_mem_version_definition();
+                return Ok(versioning::bump_mem_version_definition());
             }
         };
-        vir::BodylessMethod {
-            name: self.encode_builtin_method_name(method),
+        Ok(vir::BodylessMethod {
+            name: method_name,
             formal_args: vec![],
             formal_returns: vec![vir_local!{ ret: {return_type} }],
             pres: vec![],
             posts: vec![],
-        }
+        })
     }
 
     pub fn encode_builtin_function_def(&self, function: BuiltinFunctionKind) -> vir::Function {
@@ -224,13 +224,19 @@ impl<'p, 'v: 'p, 'tcx: 'v> BuiltinEncoder<'p, 'v, 'tcx> {
         }
     }
 
-    // This code is currently dead, but we should start using it soon.
-    #[allow(dead_code)]
-    pub fn encode_builtin_domain(&self, kind: BuiltinDomainKind) -> vir::Domain {
-        match kind {
+    pub fn encode_builtin_domain(&self, kind: BuiltinDomainKind) -> EncodingResult<vir::Domain> {
+        Ok(match kind {
             BuiltinDomainKind::Nat => self.encode_nat_builtin_domain(),
             BuiltinDomainKind::Primitive => self.encode_primitive_builtin_domain(),
-        }
+        })
+    }
+
+    pub fn encode_builtin_domain_type(&self, kind: BuiltinDomainKind) -> EncodingResult<vir::Type> {
+        Ok(match kind {
+            BuiltinDomainKind::Nat | BuiltinDomainKind::Primitive => {
+                vir::Type::domain(self.encode_builtin_domain(kind)?.name)
+            }
+        })
     }
 
     fn encode_nat_builtin_domain(&self) -> vir::Domain {

--- a/prusti-viper/src/encoder/definition_collector.rs
+++ b/prusti-viper/src/encoder/definition_collector.rs
@@ -42,6 +42,8 @@ pub(super) fn collect_definitions(
         unfolded_predicates: Default::default(),
     };
     vir::utils::walk_methods(&methods, &mut unfolded_predicate_collector);
+    // Keep all domains around. An alternative is to make the collector walk over domain axioms.
+    let used_builtin_domains = encoder.get_encoded_builtin_domains().into_iter().collect();
     let mut collector = Collector {
         error_span,
         encoder,
@@ -51,6 +53,7 @@ pub(super) fn collect_definitions(
         used_predicates: Default::default(),
         used_fields: Default::default(),
         used_domains: Default::default(),
+        used_builtin_domains,
         used_snap_domain_functions: Default::default(),
         used_functions: Default::default(),
         checked_function_contracts: Default::default(),
@@ -77,6 +80,7 @@ struct Collector<'p, 'v: 'p, 'tcx: 'v> {
     new_unfolded_predicates: FxHashSet<vir::Type>,
     used_fields: FxHashSet<vir::Field>,
     used_domains: FxHashSet<String>,
+    used_builtin_domains: FxHashSet<vir::Domain>,
     used_snap_domain_functions: FxHashSet<vir::FunctionIdentifier>,
     /// The set of all functions that are mentioned in the method.
     used_functions: FxHashSet<vir::FunctionIdentifier>,
@@ -287,6 +291,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> Collector<'p, 'v, 'tcx> {
                 domains.push(mirror_domain);
             }
         }
+        domains.extend(self.used_builtin_domains.iter().cloned());
         domains.sort_by_cached_key(|domain| domain.name.clone());
         domains
     }

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -13,6 +13,7 @@ use crate::encoder::builtin_encoder::BuiltinMethodKind;
 use crate::encoder::errors::{ErrorManager, SpannedEncodingError, EncodingError};
 use crate::encoder::foldunfold;
 use crate::encoder::procedure_encoder::ProcedureEncoder;
+use crate::error_unsupported;
 use prusti_common::{vir_expr, vir_local};
 use prusti_common::config;
 use prusti_common::report::log;
@@ -316,7 +317,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
                     let mir_ct = mir::UnevaluatedConst::new(ct.def, ct.substs);
                     self.uneval_eval_intlike(mir_ct)
                 },
-                _ => return Err(EncodingError::unsupported(format!("unsupported const kind: {:?}", value))),
+                _ => error_unsupported!("unsupported const kind: {:?}", value),
             }
             mir::ConstantKind::Val(val, _) => val.try_to_scalar(),
             mir::ConstantKind::Unevaluated(ct, _) => self.uneval_eval_intlike(ct),
@@ -607,9 +608,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
                 })
             }
             _ => {
-                return Err(EncodingError::unsupported(
-                    format!("unsupported constant type {:?}", ty.kind())
-                ));
+                error_unsupported!("unsupported constant type {:?}", ty.kind());
             }
         };
         debug!("encode_const_expr {:?} --> {:?}", value, expr);

--- a/prusti-viper/src/encoder/errors/encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/encoding_error.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use prusti_rustc_interface::errors::MultiSpan;
-use log::trace;
+use log::{debug, error};
 use crate::encoder::errors::SpannedEncodingError;
 use crate::encoder::errors::EncodingErrorKind;
 use backtrace::Backtrace;
@@ -22,19 +22,25 @@ pub type EncodingResult<T> = Result<T, EncodingError>;
 impl EncodingError {
     /// Usage of an unsupported Rust feature (e.g. dereferencing raw pointers)
     pub fn unsupported<M: ToString>(message: M) -> Self {
-        trace!("Constructing unsupported error at:\n{:?}", Backtrace::new());
+        if cfg!(debug_assertions) {
+            debug!("Constructing unsupported error at:\n{:?}", Backtrace::new());
+        }
         EncodingError::Positionless(EncodingErrorKind::unsupported(message))
     }
 
     /// An incorrect usage of Prusti (e.g. call an impure function in a contract)
     pub fn incorrect<M: ToString>(message: M) -> Self {
-        trace!("Constructing incorrect error at:\n{:?}", Backtrace::new());
+        if cfg!(debug_assertions) {
+            debug!("Constructing incorrect error at:\n{:?}", Backtrace::new());
+        }
         EncodingError::Positionless(EncodingErrorKind::incorrect(message))
     }
 
     /// An internal error of Prusti (e.g. failure of the fold-unfold)
     pub fn internal<M: ToString>(message: M) -> Self {
-        trace!("Constructing internal error at:\n{:?}", Backtrace::new());
+        if cfg!(debug_assertions) {
+            error!("Constructing internal error at:\n{:?}", Backtrace::new());
+        }
         EncodingError::Positionless(EncodingErrorKind::internal(message))
     }
 

--- a/prusti-viper/src/encoder/errors/encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/encoding_error.rs
@@ -71,3 +71,33 @@ impl From<SpannedEncodingError> for EncodingError {
         EncodingError::Spanned(other)
     }
 }
+
+#[macro_export]
+macro_rules! error_internal {
+    ($message:expr) => {
+        return Err($crate::encoder::errors::EncodingError::internal($message))
+    };
+    ($($tokens:tt)+) => {
+        return Err($crate::encoder::errors::EncodingError::internal(format!($($tokens)+)))
+    };
+}
+
+#[macro_export]
+macro_rules! error_incorrect {
+    ($message:expr) => {
+        return Err($crate::encoder::errors::EncodingError::incorrect($message))
+    };
+    ($($tokens:tt)+) => {
+        return Err($crate::encoder::errors::EncodingError::incorrect(format!($($tokens)+)))
+    };
+}
+
+#[macro_export]
+macro_rules! error_unsupported {
+    ($message:expr) => {
+        return Err($crate::encoder::errors::EncodingError::unsupported($message))
+    };
+    ($($tokens:tt)+) => {
+        return Err($crate::encoder::errors::EncodingError::unsupported(format!($($tokens)+)))
+    };
+}

--- a/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use prusti_rustc_interface::errors::MultiSpan;
-use log::trace;
+use log::{debug, error};
 use prusti_interface::PrustiError;
 
 use crate::encoder::errors::EncodingErrorKind;
@@ -57,7 +57,9 @@ impl SpannedEncodingError {
 
     /// Usage of an unsupported Rust feature (e.g. dereferencing raw pointers)
     pub fn unsupported<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
-        trace!("Constructing unsupported error at:\n{:?}", Backtrace::new());
+        if cfg!(debug_assertions) {
+            debug!("Constructing unsupported error at:\n{:?}", Backtrace::new());
+        }
         SpannedEncodingError::new(
             EncodingErrorKind::unsupported(message),
             span
@@ -66,7 +68,9 @@ impl SpannedEncodingError {
 
     /// An incorrect usage of Prusti (e.g. call an impure function in a contract)
     pub fn incorrect<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
-        trace!("Constructing incorrect error at:\n{:?}", Backtrace::new());
+        if cfg!(debug_assertions) {
+            debug!("Constructing incorrect error at:\n{:?}", Backtrace::new());
+        }
         SpannedEncodingError::new(
             EncodingErrorKind::incorrect(message),
             span
@@ -75,7 +79,9 @@ impl SpannedEncodingError {
 
     /// An internal error of Prusti (e.g. failure of the fold-unfold)
     pub fn internal<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
-        trace!("Constructing internal error at:\n{:?}", Backtrace::new());
+        if cfg!(debug_assertions) {
+            error!("Constructing internal error at:\n{:?}", Backtrace::new());
+        }
         SpannedEncodingError::new(
             EncodingErrorKind::internal(message),
             span

--- a/prusti-viper/src/encoder/high/types/fields.rs
+++ b/prusti-viper/src/encoder/high/types/fields.rs
@@ -1,6 +1,6 @@
 //! Helper functions for creating fields.
 
-use crate::encoder::errors::{EncodingError, EncodingResult};
+use crate::{encoder::errors::EncodingResult, error_internal, error_unsupported};
 use log::trace;
 
 use vir_crate::high as vir;
@@ -40,10 +40,7 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
         }
 
         vir::Type::Array(_) | vir::Type::Slice(_) => {
-            return Err(EncodingError::internal(format!(
-                "create_value_field should not be called for {}",
-                ty
-            )));
+            error_internal!("create_value_field should not be called for {}", ty);
         }
 
         vir::Type::Union(_)
@@ -51,10 +48,7 @@ pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl
         | vir::Type::Never
         | vir::Type::Str
         | vir::Type::Unsupported(_) => {
-            return Err(EncodingError::unsupported(format!(
-                "{} type is not supported",
-                ty
-            )));
+            error_unsupported!("{} type is not supported", ty);
         }
 
         vir::Type::MBool

--- a/prusti-viper/src/encoder/middle/core_proof/adts/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/adts/interface.rs
@@ -305,6 +305,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> AdtsInterface for Lowerer<'p, 'v, 'tcx> {
                     conjuncts.into_iter().conjoin(),
                 );
                 let axiom = vir_low::DomainAxiomDecl {
+                    comment: None,
                     name: format!("{}$bottom_up_injectivity_axiom", constructor_name),
                     body,
                 };
@@ -351,6 +352,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> AdtsInterface for Lowerer<'p, 'v, 'tcx> {
                 equality
             };
             let axiom = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: format!("{}$top_down_injectivity_axiom", constructor_name),
                 body: vir_low::Expression::forall(vec![value], triggers, forall_body),
             };

--- a/prusti-viper/src/encoder/middle/core_proof/compute_address/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/compute_address/interface.rs
@@ -77,6 +77,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
             )
         };
         Ok(vir_low::DomainAxiomDecl {
+            comment: None,
             name: format!(
                 "{}${}$compute_address_axiom",
                 ty.get_identifier(),
@@ -160,6 +161,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ComputeAddressInterface for Lowerer<'p, 'v, 'tcx> {
                             )
                         };
                         let axiom = vir_low::DomainAxiomDecl {
+                            comment: None,
                             name: format!(
                                 "{}${}$compute_address_axiom",
                                 ty.get_identifier(),
@@ -198,6 +200,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ComputeAddressInterface for Lowerer<'p, 'v, 'tcx> {
                         )
                     };
                     let axiom = vir_low::DomainAxiomDecl {
+                        comment: None,
                         name: format!("{}$compute_address_axiom", ty.get_identifier(),),
                         body,
                     };
@@ -235,6 +238,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ComputeAddressInterface for Lowerer<'p, 'v, 'tcx> {
             )
         };
         let axiom = vir_low::DomainAxiomDecl {
+            comment: None,
             name: format!(
                 "root${}$compute_address_axiom",
                 self.compute_address_state.encoded_roots.len()

--- a/prusti-viper/src/encoder/middle/core_proof/lifetimes/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lifetimes/interface.rs
@@ -226,6 +226,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> LifetimesInterface for Lowerer<'p, 'v, 'tcx> {
             Default::default(),
         )?;
         let axiom = vir_low::DomainAxiomDecl {
+            comment: None,
             name: "included_in_itself$".to_string(),
             body: QuantifierHelpers::forall(
                 vec![lft],
@@ -263,6 +264,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> LifetimesInterface for Lowerer<'p, 'v, 'tcx> {
             };
 
             let axiom = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: "included_intersect$1".to_string(),
                 body: QuantifierHelpers::forall(
                     vec![lft_1, lft_2],
@@ -292,6 +294,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> LifetimesInterface for Lowerer<'p, 'v, 'tcx> {
                 ) == (lft_2 in lft_1)
             };
             let axiom = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: "included_intersect$2".to_string(),
                 body: QuantifierHelpers::forall(
                     vec![lft_1, lft_2],
@@ -318,6 +321,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> LifetimesInterface for Lowerer<'p, 'v, 'tcx> {
                 [intersect] == lft
             };
             let axiom = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: "intersect_singleton$".to_string(),
                 body: QuantifierHelpers::forall(
                     vec![lft],

--- a/prusti-viper/src/encoder/middle/core_proof/lowerer/functions/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/lowerer/functions/interface.rs
@@ -139,6 +139,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                     },
                 );
                 let axiom = vir_low::DomainAxiomDecl {
+                    comment: None,
                     name: format!("{}$definitional_axiom", function_name),
                     body: axiom_body,
                 };

--- a/prusti-viper/src/encoder/middle/core_proof/places/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/places/interface.rs
@@ -151,6 +151,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PlacesInterface for Lowerer<'p, 'v, 'tcx> {
                 },
             );
             let axiom = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: format!("index_place$${}$$injectivity_axiom", ty.get_identifier()),
                 body,
             };

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/builtin_functions/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/builtin_functions/interface.rs
@@ -88,6 +88,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
                 },
             );
             let axiom = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: format!("{}$sequence_repeat_constructor_definition", domain_name),
                 body,
             };

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/validity/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/validity/interface.rs
@@ -162,6 +162,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValidityInterface for Lowerer<'p, 'v, 'tcx> {
         let valid_constructor = self.encode_snapshot_valid_call(domain_name, constructor_call)?;
         if parameters.is_empty() {
             let axiom = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: format!(
                     "{}$validity_axiom_bottom_up_alternative_no_parameters",
                     domain_name
@@ -210,6 +211,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValidityInterface for Lowerer<'p, 'v, 'tcx> {
                 },
             );
             let axiom_top_down = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: format!(
                     "{}${}$validity_axiom_top_down_alternative",
                     domain_name, variant_name
@@ -232,6 +234,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValidityInterface for Lowerer<'p, 'v, 'tcx> {
         // The axiom that allows proving that the data structure is
         // valid if we know that its fields are valid.
         let axiom_bottom_up = vir_low::DomainAxiomDecl {
+            comment: None,
             name: format!(
                 "{}${}$validity_axiom_bottom_up_alternative",
                 domain_name, variant_name
@@ -293,6 +296,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValidityInterface for Lowerer<'p, 'v, 'tcx> {
                 },
             );
             let axiom_top_down = vir_low::DomainAxiomDecl {
+                comment: None,
                 name: format!("{}$validity_axiom_top_down_enum", domain_name),
                 body: axiom_top_down_body,
             };
@@ -345,6 +349,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValidityInterface for Lowerer<'p, 'v, 'tcx> {
         // The axiom that allows proving that the data structure is
         // valid if we know that its fields are valid.
         let validity_axiom_bottom_up = vir_low::DomainAxiomDecl {
+            comment: None,
             name: format!(
                 "{}${}$validity_axiom_bottom_up_enum_variant",
                 domain_name, variant_name
@@ -365,6 +370,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValidityInterface for Lowerer<'p, 'v, 'tcx> {
         };
         // The axiom that defines the discriminant of the variant.
         let dicsriminant_axiom = vir_low::DomainAxiomDecl {
+            comment: None,
             name: format!("{}${}$discriminant_axiom", domain_name, variant_name),
             body: discriminant_axiom_body,
         };
@@ -416,6 +422,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> SnapshotValidityInterface for Lowerer<'p, 'v, 'tcx> {
             },
         );
         let axiom_top_down = vir_low::DomainAxiomDecl {
+            comment: None,
             // We use ty identifier to distinguish sequences from arrays.
             name: format!(
                 "{}${}$validity_axiom_top_down_sequence",

--- a/prusti-viper/src/encoder/middle/core_proof/types/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/types/interface.rs
@@ -241,6 +241,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
             expr! { [parameters_validity.into_iter().conjoin()] ==> ([op_constructor_call] == [constructor_call_op]) },
         );
         let axiom = vir_low::DomainAxiomDecl {
+            comment: None,
             name: format!("{}$simplification_axiom", variant),
             body,
         };
@@ -273,6 +274,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> Private for Lowerer<'p, 'v, 'tcx> {
             expr! { [destructor] == [evaluation_result] },
         );
         let axiom = vir_low::DomainAxiomDecl {
+            comment: None,
             name: format!("{}$eval_axiom", variant),
             body,
         };
@@ -470,6 +472,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> TypesInterface for Lowerer<'p, 'v, 'tcx> {
                     expr! { [op_constructor_call] == [constructor_call_op] },
                 );
                 let axiom = vir_low::DomainAxiomDecl {
+                    comment: None,
                     name: format!("{}$simplification_axiom", variant_name),
                     body,
                 };

--- a/prusti-viper/src/encoder/mir/casts/interface.rs
+++ b/prusti-viper/src/encoder/mir/casts/interface.rs
@@ -2,7 +2,7 @@ use log::{debug, trace};
 use prusti_rustc_interface::middle::ty;
 use vir_crate::high::{self as vir_high};
 
-use crate::encoder::errors::{EncodingError, EncodingResult};
+use crate::{encoder::errors::EncodingResult, error_unsupported};
 
 pub(crate) trait CastsEncoderInterface<'tcx> {
     fn encode_int_cast_high(
@@ -75,10 +75,7 @@ impl<'v, 'tcx: 'v> CastsEncoderInterface<'tcx> for super::super::super::Encoder<
                 number.into()
             }
             kind => {
-                return Err(EncodingError::unsupported(format!(
-                    "unsupported integer cast: {:?}",
-                    kind
-                )));
+                error_unsupported!("unsupported integer cast: {:?}", kind);
             }
         };
         debug!("encode_int_cast {:?} as {:?} --> {:?}", value, ty, expr);

--- a/prusti-viper/src/encoder/mir/constants/interface.rs
+++ b/prusti-viper/src/encoder/mir/constants/interface.rs
@@ -2,9 +2,9 @@ use log::debug;
 use prusti_rustc_interface::middle::{mir, ty};
 use vir_crate::high::{self as vir_high};
 
-use crate::encoder::{
-    errors::{EncodingError, EncodingResult},
-    mir::types::MirTypeEncoderInterface,
+use crate::{
+    encoder::{errors::EncodingResult, mir::types::MirTypeEncoderInterface},
+    error_unsupported,
 };
 
 pub(crate) trait ConstantsEncoderInterface<'tcx> {
@@ -67,10 +67,7 @@ impl<'v, 'tcx: 'v> ConstantsEncoderInterface<'tcx> for super::super::super::Enco
                 vir_high::Expression::constructor_no_pos(ty, Vec::new())
             }
             _ => {
-                return Err(EncodingError::unsupported(format!(
-                    "unsupported constant type {:?}",
-                    mir_type.kind()
-                )));
+                error_unsupported!("unsupported constant type {:?}", mir_type.kind());
             }
         };
         debug!("encode_const_expr {:?} --> {:?}", constant.literal, expr);

--- a/prusti-viper/src/encoder/mir/contracts/interface.rs
+++ b/prusti-viper/src/encoder/mir/contracts/interface.rs
@@ -2,10 +2,11 @@ use super::{
     borrows::BorrowInfoCollectingVisitor,
     contracts::{ProcedureContract, ProcedureContractGeneric, ProcedureContractMirDef},
 };
-use crate::encoder::{
-    errors::{EncodingError, EncodingResult},
-    mir::specifications::SpecificationsInterface,
-    places, Encoder,
+use crate::{
+    encoder::{
+        errors::EncodingResult, mir::specifications::SpecificationsInterface, places, Encoder,
+    },
+    error_unsupported,
 };
 use log::trace;
 use prusti_interface::specs::typed;
@@ -146,9 +147,7 @@ fn get_procedure_contract<'p, 'v: 'p, 'tcx: 'v>(
         // FIXME: Replace with FakeMirEncoder.
         let fn_sig: FnSig = env.query.get_fn_sig(proc_def_id, substs).skip_binder();
         if fn_sig.c_variadic {
-            return Err(EncodingError::unsupported(
-                "variadic functions are not supported",
-            ));
+            error_unsupported!("variadic functions are not supported");
         }
         args_ty = (0usize..fn_sig.inputs().len())
             .map(|i| (mir::Local::from_usize(i + 1), fn_sig.inputs()[i]))

--- a/prusti-viper/src/encoder/mir/places/interface.rs
+++ b/prusti-viper/src/encoder/mir/places/interface.rs
@@ -1,10 +1,12 @@
-use crate::encoder::{
-    errors::{
-        EncodingError, EncodingResult, ErrorCtxt, SpannedEncodingError, SpannedEncodingResult,
-        WithSpan,
+use crate::{
+    encoder::{
+        errors::{
+            EncodingResult, ErrorCtxt, SpannedEncodingError, SpannedEncodingResult, WithSpan,
+        },
+        high::pure_functions::HighPureFunctionEncoderInterface,
+        mir::{constants::ConstantsEncoderInterface, types::MirTypeEncoderInterface},
     },
-    high::pure_functions::HighPureFunctionEncoderInterface,
-    mir::{constants::ConstantsEncoderInterface, types::MirTypeEncoderInterface},
+    error_internal, error_unsupported,
 };
 use log::debug;
 use prusti_common::config;
@@ -306,15 +308,10 @@ impl<'v, 'tcx: 'v> PlacesEncoderInterface<'tcx> for super::super::super::Encoder
             mir::BinOp::BitOr if is_bool => vir_high::Expression::or(left, right),
             mir::BinOp::BitXor if is_bool => vir_high::Expression::xor(left, right),
             mir::BinOp::BitAnd | mir::BinOp::BitOr | mir::BinOp::BitXor => {
-                return Err(EncodingError::unsupported(
-                    "bitwise operations on non-boolean types are not supported",
-                ))
+                error_unsupported!("bitwise operations on non-boolean types are not supported");
             }
             unsupported_op => {
-                return Err(EncodingError::unsupported(format!(
-                    "operation '{:?}' is not supported",
-                    unsupported_op
-                )))
+                error_unsupported!("operation '{:?}' is not supported", unsupported_op);
             }
         })
     }
@@ -384,18 +381,17 @@ impl<'v, 'tcx: 'v> PlacesEncoderInterface<'tcx> for super::super::super::Encoder
                     ),
 
                     _ => {
-                        return Err(EncodingError::unsupported(format!(
+                        error_unsupported!(
                             "overflow checks are unsupported for operation '{:?}' on type '{:?}'",
-                            op, ty,
-                        )));
+                            op,
+                            ty,
+                        );
                     }
                 },
 
                 mir::BinOp::Shl | mir::BinOp::Shr => {
                     if !config::encode_bitvectors() {
-                        return Err(EncodingError::unsupported(
-                            "overflow checks on a shift operation are unsupported",
-                        ));
+                        error_unsupported!("overflow checks on a shift operation are unsupported");
                     }
                     let size: u32 = match ty {
                         vir_high::Type::Int(vir_high::ty::Int::U8) => 8,
@@ -404,9 +400,7 @@ impl<'v, 'tcx: 'v> PlacesEncoderInterface<'tcx> for super::super::super::Encoder
                         vir_high::Type::Int(vir_high::ty::Int::U64) => 64,
                         vir_high::Type::Int(vir_high::ty::Int::U128) => 128,
                         vir_high::Type::Int(vir_high::ty::Int::Usize) => {
-                            return Err(EncodingError::unsupported(
-                                "unknown size of usize for the overflow check",
-                            ));
+                            error_unsupported!("unknown size of usize for the overflow check");
                         }
                         vir_high::Type::Int(vir_high::ty::Int::I8) => 8,
                         vir_high::Type::Int(vir_high::ty::Int::I16) => 16,
@@ -414,15 +408,13 @@ impl<'v, 'tcx: 'v> PlacesEncoderInterface<'tcx> for super::super::super::Encoder
                         vir_high::Type::Int(vir_high::ty::Int::I64) => 64,
                         vir_high::Type::Int(vir_high::ty::Int::I128) => 128,
                         vir_high::Type::Int(vir_high::ty::Int::Isize) => {
-                            return Err(EncodingError::unsupported(
-                                "unknown size of isize for the overflow check",
-                            ));
+                            error_unsupported!("unknown size of isize for the overflow check");
                         }
                         _ => {
-                            return Err(EncodingError::unsupported(format!(
+                            error_unsupported!(
                                 "overflow checks are unsupported for operation '{:?}' on type '{:?}'",
                                 op, ty,
-                            )));
+                            );
                         }
                     };
                     vir_high::Expression::or(
@@ -432,10 +424,7 @@ impl<'v, 'tcx: 'v> PlacesEncoderInterface<'tcx> for super::super::super::Encoder
                 }
 
                 _ => {
-                    return Err(EncodingError::internal(format!(
-                        "unexpected overflow check on {:?}",
-                        op
-                    )))
+                    error_internal!("unexpected overflow check on {:?}", op);
                 }
             })
         }

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
@@ -825,7 +825,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
             }
 
             mir::StatementKind::Assign(box (lhs, ref rhs)) => {
-                let (encoded_lhs, ty, _) = self.encode_place(lhs).unwrap();
+                let (encoded_lhs, ty, _) = self.encode_place(lhs).with_span(span)?;
                 trace!("Encoding assignment to LHS {:?}", encoded_lhs);
 
                 if !state.uses_place(&encoded_lhs) {

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -4,16 +4,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::encoder::{
-    errors::{EncodingError, EncodingResult, SpannedEncodingResult, WithSpan},
-    high::types::HighTypeEncoderInterface,
-    mir::{
-        pure::{specifications::utils::extract_closure_from_ty, PureFunctionEncoderInterface},
-        types::MirTypeEncoderInterface,
+use crate::{
+    encoder::{
+        errors::{EncodingError, EncodingResult, SpannedEncodingResult, WithSpan},
+        high::types::HighTypeEncoderInterface,
+        mir::{
+            pure::{specifications::utils::extract_closure_from_ty, PureFunctionEncoderInterface},
+            types::MirTypeEncoderInterface,
+        },
+        mir_encoder::{MirEncoder, PlaceEncoder},
+        snapshot::interface::SnapshotEncoderInterface,
+        Encoder,
     },
-    mir_encoder::{MirEncoder, PlaceEncoder},
-    snapshot::interface::SnapshotEncoderInterface,
-    Encoder,
+    error_incorrect,
 };
 use prusti_common::config;
 use prusti_rustc_interface::{
@@ -356,9 +359,7 @@ fn check_trigger_set(
         .any(|var| !found_bounded_vars.contains(var))
     {
         // TODO: mention (+ span) the missing qvars in the error
-        return Err(EncodingError::incorrect(
-            "a trigger set must mention all bound variables",
-        ));
+        error_incorrect!("a trigger set must mention all bound variables");
     }
     Ok(())
 }

--- a/prusti-viper/src/encoder/mir/sequences/encoder.rs
+++ b/prusti-viper/src/encoder/mir/sequences/encoder.rs
@@ -1,8 +1,7 @@
 use super::interface::EncodedSequenceTypes;
-use crate::encoder::{
-    errors::{EncodingError, EncodingResult},
-    high::types::HighTypeEncoderInterface,
-    Encoder,
+use crate::{
+    encoder::{errors::EncodingResult, high::types::HighTypeEncoderInterface, Encoder},
+    error_unsupported,
 };
 use prusti_rustc_interface::middle::ty;
 
@@ -24,9 +23,7 @@ pub(super) fn encode_sequence_types<'p, 'v: 'p, 'tcx: 'v>(
         }
         ty::TyKind::Slice(elem_ty) => (*elem_ty, None),
         ty::TyKind::Str => {
-            return Err(EncodingError::unsupported(
-                "Encoding of Str slice type".to_string(),
-            ))
+            error_unsupported!("Encoding of Str slice type");
         }
         _ => unreachable!(),
     };

--- a/prusti-viper/src/encoder/mir/type_invariants/interface.rs
+++ b/prusti-viper/src/encoder/mir/type_invariants/interface.rs
@@ -1,5 +1,6 @@
 use super::encoder::{encode_invariant_def, encode_invariant_stub, needs_invariant_func};
 use crate::encoder::errors::EncodingResult;
+use prusti_common::config;
 use prusti_rustc_interface::middle::ty;
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
@@ -25,7 +26,7 @@ impl<'v, 'tcx: 'v> TypeInvariantEncoderInterface<'tcx> for super::super::super::
         ty: ty::Ty<'tcx>,
         encoded_arg: vir::Expr,
     ) -> EncodingResult<vir::Expr> {
-        if !prusti_common::config::enable_type_invariants() {
+        if !config::enable_type_invariants() {
             return Ok(true.into());
         }
 

--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -10,7 +10,7 @@ use crate::encoder::errors::{
 };
 use crate::encoder::Encoder;
 use crate::encoder::snapshot::interface::SnapshotEncoderInterface;
-use crate::utils;
+use crate::{utils, error_internal, error_unsupported};
 use prusti_common::vir_expr;
 use vir_crate::{polymorphic as vir};
 use prusti_common::config;
@@ -124,15 +124,13 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                             num
                         } else {
                             if num_variants != 1 {
-                                return Err(EncodingError::internal(
-                                    format!(
-                                        "tried to encode a projection that accesses the field {} \
-                                        of a variant without first downcasting its enumeration \
-                                        {:?}",
-                                        field.index(),
-                                        base_ty,
-                                    )
-                                ));
+                                error_internal!(
+                                    "tried to encode a projection that accesses the field {} \
+                                    of a variant without first downcasting its enumeration \
+                                    {:?}",
+                                    field.index(),
+                                    base_ty,
+                                );
                             }
                             0
                         };
@@ -146,9 +144,7 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                         let field = &variant_def.fields[field.index()];
                         let field_ty = *proj_field_ty;
                         if utils::is_reference(field_ty) {
-                            return Err(EncodingError::unsupported(
-                                "access to reference-typed fields is not supported",
-                            ));
+                            error_unsupported!("access to reference-typed fields is not supported");
                         }
                         let encoded_field = self
                             .encoder()
@@ -177,13 +173,11 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                     }
 
                     ty::TyKind::Generator(..) => {
-                        return Err(EncodingError::unsupported("generator fields are not supported"));
+                        error_unsupported!("generator fields are not supported");
                     }
 
                     x => {
-                        return Err(EncodingError::internal(
-                            format!("{} has no fields", utils::ty_to_string(x))
-                        ));
+                        error_internal!("{} has no fields", utils::ty_to_string(x));
                     }
                 }
             }
@@ -194,9 +188,9 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                         let (e, ty, v) = self.encode_deref(e, base_ty)?;
                         (PlaceEncoding::Expr(e), ty, v)
                     }
-                    Err(_) => return Err(EncodingError::unsupported(
+                    Err(_) => error_unsupported!(
                         "mixed dereferencing and array indexing projections are not supported"
-                    )),
+                    ),
                 }
             }
 
@@ -239,9 +233,9 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                                 );
                                 vir_expr! { [ slice_len ] - [ vir::Expr::from(offset) ] }
                             }
-                            _ => return Err(EncodingError::unsupported(
-                                format!("pattern matching on the end of '{:?} is not supported", base_ty),
-                            ))
+                            _ => error_unsupported!(
+                                "pattern matching on the end of '{:?} is not supported", base_ty,
+                            )
                         }
                     }
                     _ => unreachable!(),
@@ -271,15 +265,13 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                             None,
                         )
                     },
-                    _ => return Err(EncodingError::unsupported(
-                        format!("index on unsupported type '{:?}'", base_ty)
-                    )),
+                    _ => error_unsupported!("index on unsupported type '{:?}'", base_ty),
                 }
             }
 
-            mir::ProjectionElem::Subslice { .. } => return Err(EncodingError::unsupported(
+            mir::ProjectionElem::Subslice { .. } => error_unsupported!(
                 "slice patterns are not supported",
-            )),
+            ),
         })
     }
 
@@ -315,9 +307,7 @@ pub trait PlaceEncoder<'v, 'tcx: 'v> {
                 (access, base_ty.boxed_ty(), None)
             }
             ref x => {
-                return Err(EncodingError::internal(
-                    format!("Type {:?} can not be dereferenced", x)
-                ));
+                error_internal!("Type {:?} can not be dereferenced", x);
             }
         })
     }
@@ -521,15 +511,17 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
             mir::BinOp::BitAnd |
             mir::BinOp::BitOr |
             mir::BinOp::BitXor if !config::encode_bitvectors() => {
-                return Err(EncodingError::unsupported(
-                    "bitwise operations on non-boolean types are experimental and disabled by default; use `encode_bitvectors` to enable"
-                ))
+                error_unsupported!(
+                    "bitwise operations on non-boolean types are experimental and disabled by \
+                    default; use `encode_bitvectors` to enable"
+                );
             }
             unsupported_op if !config::encode_bitvectors() => {
-                return Err(EncodingError::unsupported(format!(
-                    "support for operation '{:?}' is experimental and disabled by default; use `encode_bitvectors` to enable",
+                error_unsupported!(
+                    "support for operation '{:?}' is experimental and disabled by default; use \
+                    `encode_bitvectors` to enable it",
                     unsupported_op
-                )))
+                );
             }
             mir::BinOp::BitAnd => vir::Expr::bin_op(vir::BinaryOpKind::BitAnd, left, right),
             mir::BinOp::BitOr => vir::Expr::bin_op(vir::BinaryOpKind::BitOr, left, right),
@@ -540,10 +532,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
             mir::BinOp::Shr if is_signed => vir::Expr::bin_op(vir::BinaryOpKind::AShr, left, right),
             mir::BinOp::Shr => vir::Expr::bin_op(vir::BinaryOpKind::LShr, left, right),
             mir::BinOp::Offset => {
-                return Err(EncodingError::unsupported(format!(
-                    "operation '{:?}' is not supported",
-                    op
-                )))
+                error_unsupported!("operation '{:?}' is not supported", op);
             }
         })
     }
@@ -630,11 +619,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
                         vir::Expr::gt_cmp(result, std::f64::MAX.into()),
                     ),
                     _ => {
-                        return Err(EncodingError::unsupported(format!(
+                        error_unsupported!(
                             "overflow checks are unsupported for operation '{:?}' on type '{:?}'",
                             op,
                             ty,
-                        )));
+                        );
                     }
                 },
 
@@ -646,9 +635,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
                         ty::TyKind::Uint(ty::UintTy::U64) => 64,
                         ty::TyKind::Uint(ty::UintTy::U128) => 128,
                         ty::TyKind::Uint(ty::UintTy::Usize) => {
-                            return Err(EncodingError::unsupported(
-                                "unknown size of usize for the overflow check",
-                            ));
+                            error_unsupported!("unknown size of usize for the overflow check");
                         }
                         ty::TyKind::Int(ty::IntTy::I8) => 8,
                         ty::TyKind::Int(ty::IntTy::I16) => 16,
@@ -656,15 +643,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> MirEncoder<'p, 'v, 'tcx> {
                         ty::TyKind::Int(ty::IntTy::I64) => 64,
                         ty::TyKind::Int(ty::IntTy::I128) => 128,
                         ty::TyKind::Int(ty::IntTy::Isize) => {
-                            return Err(EncodingError::unsupported(
-                                "unknown size of isize for the overflow check",
-                            ));
+                            error_unsupported!("unknown size of isize for the overflow check");
                         },
                         _ => {
-                            return Err(EncodingError::unsupported(format!(
+                            error_unsupported!(
                                 "overflow checks are unsupported for operation '{:?}' on type '{:?}'",
                                 op, ty,
-                            )));
+                            );
                         }
                     };
                     vir::Expr::or(

--- a/prusti-viper/src/encoder/mirror_function_encoder.rs
+++ b/prusti-viper/src/encoder/mirror_function_encoder.rs
@@ -239,6 +239,7 @@ fn encode_definitional_axiom(
     let pre_conds_and_valid = vir::Expr::and(pre_conds, valids_anded);
     let axiom_body = vir::Expr::implies(pre_conds_and_valid, rhs);
     let definitional_axiom = vir::DomainAxiom {
+        comment: None,
         name: format!("{}$axiom", function.get_identifier()),
         expr: vir::Expr::forall(domain_function.formal_args.clone(), triggers.clone(), axiom_body),
         domain_name: mirror_function_domain.name.clone(),
@@ -269,6 +270,7 @@ fn encode_nat_axiom(
     let function_call_without_succ = vir::Expr::domain_func_app(domain_function, args_without_succ);
     let axiom_body = vir::Expr::eq_cmp(function_call_without_succ, function_call_with_succ);
     let axiom = vir::DomainAxiom {
+        comment: None,
         name: format!("{}$nat_axiom", function.get_identifier()),
         expr: vir::Expr::forall(formal_args, triggers.clone(), axiom_body),
         domain_name: mirror_function_domain.name.clone(),

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5672,7 +5672,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         let lookup_array_i_old = sequence_types.encode_lookup_pure_call(self.encoder, old(encoded_array.clone()), i_var, lookup_ret_ty.clone());
         let lookup_same_as_old = vir_expr!{ [lookup_array_i] == [old(lookup_array_i)] };
         let forall_body = vir_expr!{ [idx_conditions] ==> [lookup_same_as_old] };
-        let all_others_unchanged = vir_expr!{ forall i: Int :: { [lookup_array_i_old] } [ forall_body ] };
+        let all_others_unchanged = vir_expr!{ forall i: Int :: { [lookup_array_i_old] } :: [ forall_body ] };
 
         stmts.push(vir_stmt!{ inhale [ all_others_unchanged ]});
 
@@ -6299,7 +6299,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         stmts.push(vir::Stmt::Inhale( vir::Inhale {
             expr: vir_expr! {
                 forall i: Int ::
-                { [array_lookup_call], [slice_lookup_call] }
+                { [array_lookup_call] } { [slice_lookup_call] } ::
                 ([indices] ==> ([array_lookup_call] == [slice_lookup_call])) }
         }));
 
@@ -6402,7 +6402,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         stmts.push(vir::Stmt::Inhale( vir::Inhale {
             expr: vir_expr! {
                 forall i: Int ::
-                { [lookup_pure_call] }
+                { [lookup_pure_call] } ::
                 ([indices] ==> ([lookup_pure_call] == [inhaled_operand])) }
         }));
 
@@ -6951,7 +6951,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         );
         let lookup_same_as_old = vir_expr!{ [lookup_array_i] == [old(lookup_array_i.clone())] };
         let forall_body = vir_expr!{ [idx_conditions] ==> [lookup_same_as_old] };
-        let all_others_unchanged = vir_expr!{ forall i: Int :: { [lookup_array_i] } [ forall_body ] };
+        let all_others_unchanged = vir_expr!{ forall i: Int :: { [lookup_array_i] } :: [ forall_body ] };
         let indexed_lookup_pure = sequence_types.encode_lookup_pure_call(
             self.encoder,
             encoded_base_expr.clone(),

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -880,7 +880,7 @@ impl SnapshotEncoder {
 
                     let indices = vir_expr! { ([Expr::from(0usize)] <= [i]) && ([i] < [Expr::from(array_types.sequence_len.unwrap())]) };
 
-                    vir_expr! { forall i: Int :: { [read_call], [lookup_call] } ([indices] ==> ([read_call] == [lookup_call])) }
+                    vir_expr! { forall i: Int :: { [read_call] } { [lookup_call] } :: ([indices] ==> ([read_call] == [lookup_call])) }
                 };
 
                 let snap_func = vir::Function {
@@ -1120,7 +1120,7 @@ impl SnapshotEncoder {
 
                     let indices = vir_expr! { ([Expr::from(0)] <= [i]) && ([i] < [slice_len]) };
 
-                    vir_expr! { forall i: Int :: { [read_call], [lookup_call] } ([indices] ==> ([read_call] == [lookup_call])) }
+                    vir_expr! { forall i: Int :: { [read_call] } { [lookup_call] } :: ([indices] ==> ([read_call] == [lookup_call])) }
                 };
 
                 let snap_len = len.apply(vec![result_expr]);
@@ -1256,7 +1256,7 @@ impl SnapshotEncoder {
                     vir::DomainAxiom {
                         comment: None,
                         name: format!("{}$len_of_seq", predicate_type.name()),
-                        expr: vir_expr! { forall data: {seq_type} :: { [len_call], [seq_len] } ([len_call] == [seq_len]) },
+                        expr: vir_expr! { forall data: {seq_type} :: { [len_call] } { [seq_len] } :: ([len_call] == [seq_len]) },
                         domain_name: domain_name.clone(),
                     }
                 };
@@ -1268,7 +1268,7 @@ impl SnapshotEncoder {
                     vir::DomainAxiom {
                         comment: None,
                         name: format!("{}$len_positive", predicate_type.name()),
-                        expr: vir_expr! { forall slice: {slice_snap_ty.clone()} :: { [len_call] } ([len_call] >= [Expr::from(0)]) },
+                        expr: vir_expr! { forall slice: {slice_snap_ty.clone()} :: { [len_call] } :: ([len_call] >= [Expr::from(0)]) },
                         domain_name: domain_name.clone(),
                     }
                 };
@@ -1292,7 +1292,7 @@ impl SnapshotEncoder {
                     vir::DomainAxiom {
                         comment: None,
                         name: format!("{}$len_upper_bound", predicate_type.name()),
-                        expr: vir_expr! { forall slice: {slice_snap_ty.clone()} :: { [len_call] } [upper_bound] },
+                        expr: vir_expr! { forall slice: {slice_snap_ty.clone()} :: { [len_call] } :: [upper_bound] },
                         domain_name: domain_name.clone(),
                     }
                 };

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -910,6 +910,7 @@ impl SnapshotEncoder {
                     let uncons_call = uncons.apply(vec![cons_call.clone()]);
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$injectivity", domain_name),
                         expr: Expr::forall(
                             vec![arg.clone()],
@@ -926,6 +927,7 @@ impl SnapshotEncoder {
                     let cons_call = cons.apply(vec![uncons_call.clone()]);
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$surjectivity", domain_name),
                         expr: Expr::forall(
                             vec![arg.clone()],
@@ -944,6 +946,7 @@ impl SnapshotEncoder {
                     let rhs_call = cons.apply(vec![rhs_arg.clone().into()]);
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$extensionality", domain_name),
                         expr: Expr::forall(
                             vec![lhs_arg.clone(), rhs_arg.clone()],
@@ -971,6 +974,7 @@ impl SnapshotEncoder {
                         position: vir::Position::default(),
                     });
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$read_indices", predicate_type.name()),
                         expr: Expr::forall(
                             vec![data, idx],
@@ -1009,6 +1013,7 @@ impl SnapshotEncoder {
                         let read_call = read.apply(vec![self_expr, idx.clone().into()]);
 
                         vir::DomainAxiom {
+                            comment: None,
                             name: format!("{}$valid", domain_name),
                             expr: Expr::forall(
                                 vec![self_local, idx],
@@ -1159,6 +1164,7 @@ impl SnapshotEncoder {
                     let uncons_call = uncons.apply(vec![cons_call.clone()]);
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$injectivity", domain_name),
                         expr: Expr::forall(
                             vec![arg.clone()],
@@ -1175,6 +1181,7 @@ impl SnapshotEncoder {
                     let cons_call = cons.apply(vec![uncons_call.clone()]);
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$surjectivity", domain_name),
                         expr: Expr::forall(
                             vec![arg.clone()],
@@ -1193,6 +1200,7 @@ impl SnapshotEncoder {
                     let rhs_call = cons.apply(vec![rhs_arg.clone().into()]);
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$extensionality", domain_name),
                         expr: Expr::forall(
                             vec![lhs_arg.clone(), rhs_arg.clone()],
@@ -1222,6 +1230,7 @@ impl SnapshotEncoder {
                     });
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$read_indices", predicate_type.name()),
                         expr: Expr::forall(
                             vec![data.clone(), idx],
@@ -1245,6 +1254,7 @@ impl SnapshotEncoder {
                     });
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$len_of_seq", predicate_type.name()),
                         expr: vir_expr! { forall data: {seq_type} :: { [len_call], [seq_len] } ([len_call] == [seq_len]) },
                         domain_name: domain_name.clone(),
@@ -1256,6 +1266,7 @@ impl SnapshotEncoder {
                         len.apply(vec![vir_local! { slice: {slice_snap_ty.clone()} }.into()]);
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$len_positive", predicate_type.name()),
                         expr: vir_expr! { forall slice: {slice_snap_ty.clone()} :: { [len_call] } ([len_call] >= [Expr::from(0)]) },
                         domain_name: domain_name.clone(),
@@ -1279,6 +1290,7 @@ impl SnapshotEncoder {
                     };
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}$len_upper_bound", predicate_type.name()),
                         expr: vir_expr! { forall slice: {slice_snap_ty.clone()} :: { [len_call] } [upper_bound] },
                         domain_name: domain_name.clone(),
@@ -1313,6 +1325,7 @@ impl SnapshotEncoder {
                         let read_call = read.apply(vec![self_expr, idx.clone().into()]);
 
                         vir::DomainAxiom {
+                            comment: None,
                             name: format!("{}$valid", domain_name),
                             expr: Expr::forall(
                                 vec![self_local, idx],
@@ -1656,6 +1669,7 @@ impl SnapshotEncoder {
             domain_axioms.push({
                 let disc_call = discriminant_func.apply(vec![arg_dom_expr]);
                 vir::DomainAxiom {
+                    comment: None,
                     name: format!("{}$discriminant_range", domain_name),
                     expr: Expr::forall(
                         vec![arg_dom_local],
@@ -1757,6 +1771,7 @@ impl SnapshotEncoder {
                     .conjoin();
 
                 domain_axioms.push(vir::DomainAxiom {
+                    comment: None,
                     name: format!("{}${}$injectivity", domain_name, variant_idx),
                     expr: forall_or_body(
                         forall_vars,
@@ -1773,6 +1788,7 @@ impl SnapshotEncoder {
                     let args = encode_prefixed_args("");
                     let call = encode_constructor_call(&args);
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}${}$discriminant_axiom", domain_name, variant_idx),
                         expr: forall_or_body(
                             args.to_vec(),
@@ -1809,6 +1825,7 @@ impl SnapshotEncoder {
                     let field_of_cons = field_access_func.apply(vec![call.clone()]);
 
                     vir::DomainAxiom {
+                        comment: None,
                         name: format!("{}${}$field${}$axiom", domain_name, variant_idx, field.name),
                         expr: forall_or_body(
                             args.clone(),
@@ -1834,6 +1851,7 @@ impl SnapshotEncoder {
                         let field_of_self = field_access_func.apply(vec![self_expr.clone()]);
 
                         vir::DomainAxiom {
+                            comment: None,
                             name: format!(
                                 "{}${}$field${}$valid",
                                 domain_name, variant_idx, field.name

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -4,15 +4,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::encoder::{
-    encoder::encode_field_name,
-    errors::{EncodingError, EncodingResult},
-    foldunfold,
-    high::types::HighTypeEncoderInterface,
-    mir::{sequences::MirSequencesEncoderInterface, types::MirTypeEncoderInterface},
-    snapshot::{decls::Snapshot, patcher::SnapshotPatcher},
-    utils::range_extract,
-    Encoder,
+use crate::{
+    encoder::{
+        encoder::encode_field_name,
+        errors::{EncodingError, EncodingResult},
+        foldunfold,
+        high::types::HighTypeEncoderInterface,
+        mir::{sequences::MirSequencesEncoderInterface, types::MirTypeEncoderInterface},
+        snapshot::{decls::Snapshot, patcher::SnapshotPatcher},
+        utils::range_extract,
+        Encoder,
+    },
+    error_internal,
 };
 use log::debug;
 use prusti_common::{vir_expr, vir_local};
@@ -492,10 +495,7 @@ impl SnapshotEncoder {
             if let Snapshot::Array { read, .. } = self.encode_snapshot(encoder, array_ty)? {
                 read
             } else {
-                return Err(EncodingError::internal(format!(
-                    "called encode_array_idx on non-array-type {:?}",
-                    array_ty
-                )));
+                error_internal!("called encode_array_idx on non-array-type {:?}", array_ty);
             };
 
         Ok(read_func.apply(vec![array, idx]))
@@ -513,10 +513,7 @@ impl SnapshotEncoder {
             if let Snapshot::Slice { read, .. } = self.encode_snapshot(encoder, slice_ty)? {
                 read
             } else {
-                return Err(EncodingError::internal(format!(
-                    "called encode_slice_idx on non-slice-type {:?}",
-                    slice_ty
-                )));
+                error_internal!("called encode_slice_idx on non-slice-type {:?}", slice_ty);
             };
 
         Ok(read_func.apply(vec![slice, idx]))
@@ -532,10 +529,7 @@ impl SnapshotEncoder {
             if let Snapshot::Slice { len, .. } = self.encode_snapshot(encoder, slice_ty)? {
                 len
             } else {
-                return Err(EncodingError::internal(format!(
-                    "called encode_slice_len on non-slice-type {:?}",
-                    slice_ty
-                )));
+                error_internal!("called encode_slice_len on non-slice-type {:?}", slice_ty);
             };
 
         Ok(len_func.apply(vec![slice]))
@@ -558,10 +552,7 @@ impl SnapshotEncoder {
                 {
                     cons
                 } else {
-                    return Err(EncodingError::internal(format!(
-                        "called encode_slicing on non-slice-type {:?}",
-                        slice_ty
-                    )));
+                    error_internal!("called encode_slicing on non-slice-type {:?}", slice_ty);
                 };
 
                 Ok(slice_cons.apply(vec![self.apply_function(&slice_helper, vec![base, lo, hi])]))
@@ -777,10 +768,7 @@ impl SnapshotEncoder {
                         }
                         vir::Predicate::Struct(..) => (arg_expr.clone(), None),
                         _ => {
-                            return Err(EncodingError::internal(format!(
-                                "invalid Predicate for ADT: {}",
-                                predicate
-                            )))
+                            error_internal!("invalid Predicate for ADT: {}", predicate);
                         }
                     };
                     for field in &variant.fields {

--- a/viper/src/ast_factory/program.rs
+++ b/viper/src/ast_factory/program.rs
@@ -184,4 +184,24 @@ impl<'a> AstFactory<'a> {
             ));
         NamedDomainAxiom::new(obj)
     }
+
+    pub fn named_domain_axiom_with_comment(
+        &self,
+        name: &str,
+        expr: Expr,
+        domain_name: &str,
+        comment: &str,
+    ) -> NamedDomainAxiom<'a> {
+        let obj = self
+            .jni
+            .unwrap_result(ast::NamedDomainAxiom::with(self.env).new(
+                self.jni.new_string(name),
+                expr.to_jobject(),
+                self.no_position().to_jobject(),
+                self.simple_info(&[comment]),
+                self.jni.new_string(domain_name),
+                self.no_trafos(),
+            ));
+        NamedDomainAxiom::new(obj)
+    }
 }

--- a/vir/README.md
+++ b/vir/README.md
@@ -9,3 +9,8 @@ The build script will use `vir-gen` to copy the definitions of `defs/` into `gen
 * `#[derive_helpers]` derives constructors of enum variants.
 * `#[derive_visitors]` derives visitors.
 * `derive_lower!` derives visitors converting from one VIR to another.
+
+The transformations between VIR layers are:
+* `high` --(type unifications)--> `typed` --(fold-unfold generation)--> `middle` --> `low`
+* `polymorphic` --(monomorphization)--> `legacy`
+

--- a/vir/defs/low/domain/mod.rs
+++ b/vir/defs/low/domain/mod.rs
@@ -42,6 +42,7 @@ pub struct DomainFunctionDecl {
 
 #[display(fmt = "axiom {} {{\n  {}\n}}", name, body)]
 pub struct DomainAxiomDecl {
+    pub comment: Option<String>,
     pub name: String,
     pub body: Expression,
 }

--- a/vir/defs/polymorphic/ast/domain.rs
+++ b/vir/defs/polymorphic/ast/domain.rs
@@ -66,8 +66,45 @@ pub struct DomainFunc {
 }
 
 impl DomainFunc {
+    pub fn new(
+        domain_name: impl ToString,
+        fn_name: impl ToString,
+        args: Vec<LocalVar>,
+        return_type: Type,
+    ) -> Self {
+        Self {
+            name: fn_name.to_string(),
+            type_arguments: vec![],
+            formal_args: args,
+            return_type,
+            unique: false,
+            domain_name: domain_name.to_string(),
+        }
+    }
+
     pub fn apply(&self, args: Vec<Expr>) -> Expr {
         Expr::domain_func_app(self.clone(), args)
+    }
+
+    pub fn apply0(&self) -> Expr {
+        self.apply(vec![])
+    }
+
+    pub fn apply1(&self, arg1: impl Into<Expr>) -> Expr {
+        self.apply(vec![arg1.into()])
+    }
+
+    pub fn apply2(&self, arg1: impl Into<Expr>, arg2: impl Into<Expr>) -> Expr {
+        self.apply(vec![arg1.into(), arg2.into()])
+    }
+
+    pub fn apply3(
+        &self,
+        arg1: impl Into<Expr>,
+        arg2: impl Into<Expr>,
+        arg3: impl Into<Expr>,
+    ) -> Expr {
+        self.apply(vec![arg1.into(), arg2.into(), arg3.into()])
     }
 }
 

--- a/vir/defs/polymorphic/ast/domain.rs
+++ b/vir/defs/polymorphic/ast/domain.rs
@@ -107,6 +107,7 @@ impl WithIdentifier for DomainFunc {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DomainAxiom {
+    pub comment: Option<String>,
     pub name: String,
     pub expr: Expr,
     pub domain_name: String,
@@ -114,6 +115,14 @@ pub struct DomainAxiom {
 
 impl fmt::Display for DomainAxiom {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "axiom {} {{ {} }}", self.name, self.expr)
+        if let Some(comment) = &self.comment {
+            writeln!(
+                f,
+                "/* {} */ axiom {} {{ {} }}",
+                comment, self.name, self.expr
+            )
+        } else {
+            writeln!(f, "axiom {} {{ {} }}", self.name, self.expr)
+        }
     }
 }

--- a/vir/defs/polymorphic/ast/stmt.rs
+++ b/vir/defs/polymorphic/ast/stmt.rs
@@ -457,6 +457,10 @@ impl Stmt {
         Stmt::Inhale(Inhale { expr })
     }
 
+    pub fn exhale(expr: Expr, position: Position) -> Self {
+        Stmt::Exhale(Exhale { expr, position })
+    }
+
     pub fn package_magic_wand(
         lhs: Expr,
         rhs: Expr,

--- a/vir/src/converter/polymorphic_to_legacy.rs
+++ b/vir/src/converter/polymorphic_to_legacy.rs
@@ -185,6 +185,7 @@ impl From<polymorphic::DomainFunc> for legacy::DomainFunc {
 impl From<polymorphic::DomainAxiom> for legacy::DomainAxiom {
     fn from(domain_axiom: polymorphic::DomainAxiom) -> legacy::DomainAxiom {
         legacy::DomainAxiom {
+            comment: domain_axiom.comment,
             name: domain_axiom.name,
             expr: domain_axiom.expr.into(),
             domain_name: domain_axiom.domain_name,

--- a/vir/src/converter/type_substitution.rs
+++ b/vir/src/converter/type_substitution.rs
@@ -2914,6 +2914,7 @@ mod tests {
         let position = Position::new(1, 2, 3);
 
         let source = DomainAxiom {
+            comment: None,
             name: String::from("da"),
             expr: Expr::Local(Local {
                 variable: LocalVar {
@@ -2926,6 +2927,7 @@ mod tests {
         };
 
         let expected = DomainAxiom {
+            comment: None,
             name: String::from("da"),
             expr: Expr::Local(Local {
                 variable: LocalVar {
@@ -2985,6 +2987,7 @@ mod tests {
             ],
             axioms: vec![
                 DomainAxiom {
+                    comment: None,
                     name: String::from("da1"),
                     expr: Expr::Local(Local {
                         variable: LocalVar {
@@ -2996,6 +2999,7 @@ mod tests {
                     domain_name: String::from("dn3"),
                 },
                 DomainAxiom {
+                    comment: None,
                     name: String::from("da2"),
                     expr: Expr::Local(Local {
                         variable: LocalVar {
@@ -3050,6 +3054,7 @@ mod tests {
             ],
             axioms: vec![
                 DomainAxiom {
+                    comment: None,
                     name: String::from("da1"),
                     expr: Expr::Local(Local {
                         variable: LocalVar {
@@ -3061,6 +3066,7 @@ mod tests {
                     domain_name: String::from("dn3"),
                 },
                 DomainAxiom {
+                    comment: None,
                     name: String::from("da2"),
                     expr: Expr::Local(Local {
                         variable: LocalVar {

--- a/vir/src/legacy/ast/domain.rs
+++ b/vir/src/legacy/ast/domain.rs
@@ -91,6 +91,7 @@ impl WithIdentifier for DomainFunc {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DomainAxiom {
+    pub comment: Option<String>,
     pub name: String,
     pub expr: Expr,
     pub domain_name: String,
@@ -98,6 +99,14 @@ pub struct DomainAxiom {
 
 impl fmt::Display for DomainAxiom {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "axiom {} {{ {} }}", self.name, self.expr)
+        if let Some(comment) = &self.comment {
+            writeln!(
+                f,
+                "/* {} */ axiom {} {{ {} }}",
+                comment, self.name, self.expr
+            )
+        } else {
+            writeln!(f, "axiom {} {{ {} }}", self.name, self.expr)
+        }
     }
 }

--- a/x.py
+++ b/x.py
@@ -99,13 +99,14 @@ def viper_version():
         return file.read().strip()
 
 
-def setup_ubuntu():
+def setup_ubuntu(install_deps: bool):
     """Install the dependencies on Ubuntu."""
     # Install dependencies.
-    shell('sudo apt-get update')
-    shell('sudo apt-get install -y '
-          'build-essential pkg-config '
-          'curl gcc libssl-dev')
+    if install_deps:
+        shell('sudo apt-get update')
+        shell('sudo apt-get install -y '
+            'build-essential pkg-config '
+            'curl gcc libssl-dev unzip')
     # Download Viper.
     shell(
         'curl https://github.com/viperproject/viper-ide/releases/'
@@ -167,26 +168,25 @@ def setup_rustup():
 
 def setup(args):
     """Install the dependencies."""
-    rustup_only = False
+    install_deps = True
     if len(args) == 1 and args[0] == '--dry-run':
         global dry_run
         dry_run = True
-    elif len(args) == 1 and args[0] == '--rustup-only':
-        rustup_only = True
+    elif len(args) == 1 and args[0] == '--no-deps':
+        install_deps = False
     elif args:
         error("unexpected arguments: {}", args)
-    if not rustup_only:
-        if sys.platform in ("linux", "linux2"):
-            if 'Ubuntu' in platform.version():
-                setup_ubuntu()
-            else:
-                setup_linux()
-        elif sys.platform == "darwin":
-            setup_mac()
-        elif sys.platform == "win32":
-            setup_win()
+    if sys.platform in ("linux", "linux2"):
+        if 'Ubuntu' in platform.version():
+            setup_ubuntu(install_deps)
         else:
-            error("unsupported platform: {}", sys.platform)
+            setup_linux()
+    elif sys.platform == "darwin":
+        setup_mac()
+    elif sys.platform == "win32":
+        setup_win()
+    else:
+        error("unsupported platform: {}", sys.platform)
     setup_rustup()
 
 


### PR DESCRIPTION
This PR contains several small refactorings:
* Add generation of builtin domains in the encoder
* Add convenient methods to VIR poly
    * E.g. `Expr::exhale(..)`
* Add syntax for locals in `vir_expr!`
* Add description of VIR transformations to a README
* Replace `--rustup-only` with `--no-deps` in `x.py`
* Fix encoding of triggers
    * `vir_expr!(forall ... :: { A, B } :: ...)` now translates to `forall ... :: { A, B } ...` in Viper, no longer `forall ... :: { A } { B } ...`.
* Add optional comment field to the domain axioms.
* Add macro to return encoding errors
    * Super useful. `error_internal/unsupported/incorrect!(...)` desugars to `return Err(EncodingError::...(format!(...), ...));`
* Add empty line between the Viper encoding of CFG blocks
* Show stacktrace of encoding errors 
    * Only in debug mode, since it's slow. Very useful for debugging.
