### PR TITLE
Frontend improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "prusti-specs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/docs/user-guide/src/syntax.md
+++ b/docs/user-guide/src/syntax.md
@@ -6,6 +6,8 @@ Prusti specifications are a superset of Rust boolean expressions. They must be d
 | --- | --- |
 | [`old(...)`](#old-expressions) | Value of expression in a previous state |
 | [`... ==> ...`](#implications) | Implication |
+| [`... <== ...`](#implications) | Implication |
+| [`... <==> ...`](#implications) | Biconditional |
 | [`... === ...`](#snapshot-equality) | Snapshot equality |
 | [`... !== ...`](#snapshot-equality) | Snapshot inequality |
 | [`forall(...)`](#quantifiers) | Universal quantifier |
@@ -36,13 +38,24 @@ Implications express a [relationship](https://en.wikipedia.org/wiki/Material_con
 pub fn is_empty(&self) -> bool;
 ```
 
-There is no syntax for logical equivalences ("if and only if"), because this coincides with `==`:
+There is syntax for a right-to-left implication:
 
 ```rust,noplaypen
 #[pure]
-#[ensures(result == (self.len() == 0))]
+#[ensures(self.len() == 0 <== result)]
+#[ensures(self.len() > 0 <== !result)]
 pub fn is_empty(&self) -> bool;
 ```
+
+As well as a biconditional ("if and only if"):
+
+```rust,noplaypen
+#[pure]
+#[ensures(self.len() == 0 <==> result)]
+pub fn is_empty(&self) -> bool;
+```
+
+Semantically, a biconditional is equivalent to a Boolean `==`. However, it has lower precedence than the `==` operator.
 
 ## Snapshot Equality
 

--- a/docs/user-guide/src/syntax.md
+++ b/docs/user-guide/src/syntax.md
@@ -7,6 +7,7 @@ Prusti specifications are a superset of Rust boolean expressions. They must be d
 | [`old(...)`](#old-expressions) | Value of expression in a previous state |
 | [`... ==> ...`](#implications) | Implication |
 | [`... === ...`](#snapshot-equality) | Snapshot equality |
+| [`... !== ...`](#snapshot-equality) | Snapshot inequality |
 | [`forall(...)`](#quantifiers) | Universal quantifier |
 | [`exists(...)`](#quantifiers) | Existential quantifier |
 | [<code>... &#x7C;= ...</code>](#specification-entailments) | Specification entailment |
@@ -66,6 +67,8 @@ fn main() {
     foo(X { a: 1 }, X { a: 1 });
 }
 ```
+
+Snapshot *in*equality is expressed using the `!==` operator.
 
 ## Quantifiers
 

--- a/docs/user-guide/src/verify/assert_assume.md
+++ b/docs/user-guide/src/verify/assert_assume.md
@@ -31,6 +31,10 @@ assert!(map.insert(5));
 prusti_assert!(map.insert(5)); // error
 ```
 
+`prusti_assert_eq!` and `prusti_assert_ne!` are the Prusti counterparts to
+`assert_eq!` and `assert_ne!`, but the check is made for
+[snapshot equality](../syntax.md#snapshot-equality), resp. snapshot inequality.
+
 ## Assumptions
 
 The `prusti_assume!` macro instructs Prusti to assume that a certain property

--- a/prusti-contracts/prusti-contracts-proc-macros/Cargo.toml
+++ b/prusti-contracts/prusti-contracts-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-contracts-proc-macros"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -15,7 +15,7 @@ categories = ["development-tools", "development-tools::testing"]
 proc-macro = true
 
 [dependencies]
-prusti-specs = { path = "../prusti-specs", version = "0.1.3", optional = true }
+prusti-specs = { path = "../prusti-specs", version = "0.1.4", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 
 [features]

--- a/prusti-contracts/prusti-contracts/Cargo.toml
+++ b/prusti-contracts/prusti-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-contracts"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -12,7 +12,7 @@ keywords = ["prusti", "contracts", "verification", "formal", "specifications"]
 categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
-prusti-contracts-proc-macros = { path = "../prusti-contracts-proc-macros", version = "0.1.3" }
+prusti-contracts-proc-macros = { path = "../prusti-contracts-proc-macros", version = "0.1.4" }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -82,6 +82,16 @@ mod private {
         };
     }
 
+    #[macro_export]
+    macro_rules! prusti_assert_eq {
+        ($left:expr, $right:expr $(,)?) => {};
+    }
+
+    #[macro_export]
+    macro_rules! prusti_assert_ne {
+        ($left:expr, $right:expr $(,)?) => {};
+    }
+
     /// A sequence type
     #[non_exhaustive]
     #[derive(PartialEq, Eq, Copy, Clone)]
@@ -154,6 +164,20 @@ mod private {
     }
 
     __int_dummy_trait_impls__!(Add add, Sub sub, Mul mul, Div div, Rem rem);
+
+    #[macro_export]
+    macro_rules! prusti_assert_eq {
+        ($left:expr, $right:expr $(,)?) => {
+            $crate::prusti_assert!($crate::snapshot_equality($left, $right))
+        };
+    }
+
+    #[macro_export]
+    macro_rules! prusti_assert_ne {
+        ($left:expr, $right:expr $(,)?) => {
+            $crate::prusti_assert!(!$crate::snapshot_equality($left, $right))
+        };
+    }
 
     impl Neg for Int {
         type Output = Self;

--- a/prusti-contracts/prusti-specs/Cargo.toml
+++ b/prusti-contracts/prusti-specs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-specs"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/prusti-contracts/prusti-specs/src/predicate.rs
+++ b/prusti-contracts/prusti-specs/src/predicate.rs
@@ -5,7 +5,7 @@ use crate::{
     rewriter, SpecificationId, SPECS_VERSION,
 };
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, quote_spanned};
+use quote::{quote_spanned, ToTokens};
 use syn::{parse::Parse, parse_quote_spanned, spanned::Spanned};
 
 #[derive(Debug)]
@@ -91,9 +91,9 @@ fn parse_predicate_internal(
         syn::ReturnType::Default => {
             return Err(syn::Error::new(
                 input.fn_sig.span(),
-                "`predicate!` must specify an output type"
+                "`predicate!` must specify an output type",
             ));
-        },
+        }
         syn::ReturnType::Type(_, box typ) => typ.to_token_stream(),
     };
 
@@ -104,8 +104,12 @@ fn parse_predicate_internal(
         if in_spec_refinement {
             let patched_function: syn::ImplItemMethod =
                 patch_predicate_macro_body(&input, span, spec_id);
-            let spec_function =
-                generate_spec_function(input.body.unwrap(), return_type, spec_id, &patched_function)?;
+            let spec_function = generate_spec_function(
+                input.body.unwrap(),
+                return_type,
+                spec_id,
+                &patched_function,
+            )?;
 
             Ok(ParsedPredicate::Impl(PredicateWithBody {
                 spec_function,
@@ -113,8 +117,12 @@ fn parse_predicate_internal(
             }))
         } else {
             let patched_function: syn::ItemFn = patch_predicate_macro_body(&input, span, spec_id);
-            let spec_function =
-                generate_spec_function(input.body.unwrap(), return_type, spec_id, &patched_function)?;
+            let spec_function = generate_spec_function(
+                input.body.unwrap(),
+                return_type,
+                spec_id,
+                &patched_function,
+            )?;
 
             Ok(ParsedPredicate::FreeStanding(PredicateWithBody {
                 spec_function,

--- a/prusti-contracts/prusti-specs/src/predicate.rs
+++ b/prusti-contracts/prusti-specs/src/predicate.rs
@@ -5,7 +5,7 @@ use crate::{
     rewriter, SpecificationId, SPECS_VERSION,
 };
 use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
+use quote::{ToTokens, quote_spanned};
 use syn::{parse::Parse, parse_quote_spanned, spanned::Spanned};
 
 #[derive(Debug)]
@@ -177,8 +177,9 @@ impl syn::parse::Parse for PredicateFnInput {
         } else {
             let brace_content;
             let _brace_token = syn::braced!(brace_content in input);
-            let parsed_body = brace_content.parse()?;
-            Some(parsed_body)
+            let parsed_body: TokenStream = brace_content.parse()?;
+            // add the braces back to allow function-like syntax
+            Some(quote_spanned!(parsed_body.span()=> { #parsed_body }))
         };
 
         Ok(PredicateFnInput {

--- a/prusti-contracts/prusti-specs/src/rewriter.rs
+++ b/prusti-contracts/prusti-specs/src/rewriter.rs
@@ -117,10 +117,7 @@ impl AstRewriter {
                 quote_spanned! {item_span => Int},
                 quote_spanned! {item_span => Int::new(0) + },
             ),
-            SpecItemType::Predicate(return_type) => (
-                return_type.clone(),
-                TokenStream::new(),
-            ),
+            SpecItemType::Predicate(return_type) => (return_type.clone(), TokenStream::new()),
             _ => (
                 quote_spanned! {item_span => bool},
                 quote_spanned! {item_span => !!},

--- a/prusti-contracts/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/preparser.rs
@@ -923,7 +923,7 @@ impl PrustiBinaryOp {
     /// will bind to expr first, as 4 > 3.
     ///
     /// Associativity is likewise defined by making sure that each side of the
-    /// binding power is different. (4, 3) is left associative, (3, 4) is right
+    /// binding power is different. (4, 3) is right associative, (3, 4) is left
     /// associative.
     fn binding_power(&self) -> (u8, u8) {
         // TODO: should <== and ==> have the same binding power? === and !==?

--- a/prusti-contracts/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/preparser.rs
@@ -884,7 +884,10 @@ impl PrustiToken {
     }
 
     fn parse_op4(p1: &Punct, p2: &Punct, p3: &Punct, p4: &Punct) -> Option<Self> {
-        let span = join_spans(join_spans(join_spans(p1.span(), p2.span()), p3.span()), p4.span());
+        let span = join_spans(
+            join_spans(join_spans(p1.span(), p2.span()), p3.span()),
+            p4.span(),
+        );
         Some(Self::BinOp(
             span,
             if operator4("<==>", p1, p2, p3, p4) {
@@ -945,7 +948,7 @@ impl PrustiBinaryOp {
             Self::Iff => {
                 let joined_span = join_spans(lhs.span(), rhs.span());
                 quote_spanned! { joined_span => #lhs == #rhs }
-            },
+            }
             // implication is desugared into this form to avoid evaluation
             // order issues: `f(a, b)` makes Rust evaluate both `a` and `b`
             // before the `f` call

--- a/prusti-contracts/prusti-std/Cargo.toml
+++ b/prusti-contracts/prusti-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-std"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -12,7 +12,7 @@ keywords = ["prusti", "contracts", "verification", "formal", "specifications"]
 categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
-prusti-contracts = { path = "../prusti-contracts", version = "0.1.3" }
+prusti-contracts = { path = "../prusti-contracts", version = "0.1.4" }
 
 # Forward "prusti" flag
 [features]

--- a/prusti-tests/tests/parse/pass/issues/issue-1297.rs
+++ b/prusti-tests/tests/parse/pass/issues/issue-1297.rs
@@ -6,3 +6,5 @@ predicate! {
         y > x
     }
 }
+
+fn main() {}

--- a/prusti-tests/tests/parse/pass/issues/issue-1297.rs
+++ b/prusti-tests/tests/parse/pass/issues/issue-1297.rs
@@ -1,0 +1,8 @@
+use prusti_contracts::*;
+
+predicate! {
+    fn foo(x: i64) -> bool {
+        let y = x + 1;
+        y > x
+    }
+}

--- a/prusti-tests/tests/parse/pass/issues/issue-1299.rs
+++ b/prusti-tests/tests/parse/pass/issues/issue-1299.rs
@@ -1,0 +1,16 @@
+use prusti_contracts::*;
+
+#[ensures((x == 5 || x == 7) == (result == 1))]
+fn a(x: u64) -> u64 {
+    if x == 5 || x == 7 { 1 } else { 0 }
+}
+
+#[ensures(x == 5 || x == 7 <==> result == 1)]
+fn b(x: u64) -> u64 {
+    if x == 5 || x == 7 { 1 } else { 0 }
+}
+
+#[ensures(result == 1 <== x == 0)]
+fn c(x: u64) -> u64 {
+    if x == 0 { 1 } else { 0 }
+}

--- a/prusti-tests/tests/parse/pass/issues/issue-1299.rs
+++ b/prusti-tests/tests/parse/pass/issues/issue-1299.rs
@@ -14,3 +14,5 @@ fn b(x: u64) -> u64 {
 fn c(x: u64) -> u64 {
     if x == 0 { 1 } else { 0 }
 }
+
+fn main() {}

--- a/prusti-tests/tests/parse/ui/composite.stdout
+++ b/prusti-tests/tests/parse/ui/composite.stdout
@@ -139,7 +139,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test10_$(NUM_UUID)() -> bool {
     !!(((true) &&
-                            (forall((),
+                            (::prusti_contracts::forall((),
                                     #[prusti::spec_only] |a: i32| -> bool
                                         { ((a == 5): bool) }))): bool)
 }
@@ -151,7 +151,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test12_$(NUM_UUID)() -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 { ((a == 5): bool) })): bool)
 }
@@ -164,7 +164,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test13_$(NUM_UUID)() -> bool {
     !!((!(true) ||
-                            (!(forall((),
+                            (!(::prusti_contracts::forall((),
                                                 #[prusti::spec_only] |a: i32, b: i32| -> bool
                                                     { ((a == 5): bool) })) || (true))): bool)
 }
@@ -177,7 +177,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test14_$(NUM_UUID)() -> bool {
     !!((!(true) ||
-                            (forall((),
+                            (::prusti_contracts::forall((),
                                     #[prusti::spec_only] |a: i32| -> bool
                                         { ((a == 5): bool) }))): bool)
 }
@@ -189,7 +189,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test15_$(NUM_UUID)() -> bool {
-    !!((!(forall((),
+    !!((!(::prusti_contracts::forall((),
                                         #[prusti::spec_only] |a: i32| -> bool { ((a == 5): bool) }))
                             || (true)): bool)
 }
@@ -201,11 +201,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test16_$(NUM_UUID)() -> bool {
-    !!((!(forall((),
+    !!((!(::prusti_contracts::forall((),
                                         #[prusti::spec_only] |b: i32| -> bool
                                             { ((b == 10): bool) })) ||
                             (!(true) ||
-                                    (forall((),
+                                    (::prusti_contracts::forall((),
                                             #[prusti::spec_only] |a: u32, b: u32| -> bool
                                                 { ((a == 5): bool) })))): bool)
 }
@@ -218,7 +218,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test17_$(NUM_UUID)() -> bool {
     !!(((true) &&
-                            (exists((),
+                            (::prusti_contracts::exists((),
                                     #[prusti::spec_only] |a: i32| -> bool
                                         { ((a == 5): bool) }))): bool)
 }
@@ -230,7 +230,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test19_$(NUM_UUID)() -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 { ((a == 5): bool) })): bool)
 }
@@ -243,7 +243,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test20_$(NUM_UUID)() -> bool {
     !!((!(true) ||
-                            (!(exists((),
+                            (!(::prusti_contracts::exists((),
                                                 #[prusti::spec_only] |a: i32, b: i32| -> bool
                                                     { ((a == 5): bool) })) || (true))): bool)
 }
@@ -256,7 +256,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test21_$(NUM_UUID)() -> bool {
     !!((!(true) ||
-                            (exists((),
+                            (::prusti_contracts::exists((),
                                     #[prusti::spec_only] |a: i32| -> bool
                                         { ((a == 5): bool) }))): bool)
 }
@@ -268,7 +268,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test22_$(NUM_UUID)() -> bool {
-    !!((!(exists((),
+    !!((!(::prusti_contracts::exists((),
                                         #[prusti::spec_only] |a: i32| -> bool { ((a == 5): bool) }))
                             || (true)): bool)
 }
@@ -280,11 +280,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test23_$(NUM_UUID)() -> bool {
-    !!((!(exists((),
+    !!((!(::prusti_contracts::exists((),
                                         #[prusti::spec_only] |b: i32| -> bool
                                             { ((b == 10): bool) })) ||
                             (!(true) ||
-                                    (exists((),
+                                    (::prusti_contracts::exists((),
                                             #[prusti::spec_only] |a: u32, b: u32| -> bool
                                                 { ((a == 5): bool) })))): bool)
 }
@@ -306,10 +306,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test25_$(NUM_UUID)() -> bool {
-    !!(((forall((),
+    !!(((::prusti_contracts::forall((),
                                     #[prusti::spec_only] |a: i32| -> bool { ((a == 5): bool) }))
                             ||
-                            (forall((),
+                            (::prusti_contracts::forall((),
                                     #[prusti::spec_only] |a: i32| -> bool
                                         { ((a == 5): bool) }))): bool)
 }
@@ -321,10 +321,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test26_$(NUM_UUID)() -> bool {
-    !!(((exists((),
+    !!(((::prusti_contracts::exists((),
                                     #[prusti::spec_only] |a: i32| -> bool { ((a == 5): bool) }))
                             ||
-                            (exists((),
+                            (::prusti_contracts::exists((),
                                     #[prusti::spec_only] |a: i32| -> bool
                                         { ((a == 5): bool) }))): bool)
 }

--- a/prusti-tests/tests/parse/ui/exists.stdout
+++ b/prusti-tests/tests/parse/ui/exists.stdout
@@ -25,7 +25,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 { (((a + a == a + a)): bool) })): bool)
 }
@@ -37,7 +37,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |a: i32, b: i32| -> bool
                                 {
                                     ((((a + b == a + b) && (true)) == (a + b == a + b)): bool)
@@ -51,7 +51,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |a: i32, b: i32| -> bool
                                 { ((!(a + b == a + b) || (a + b == a + b)): bool) })): bool)
 }
@@ -63,7 +63,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((exists(((#[prusti::spec_only] |a: i32| (1),
+    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32| (1),
                                     #[prusti::spec_only] |a: i32| ((2 == 2) && (true))),),
                             #[prusti::spec_only] |a: i32| -> bool
                                 { ((a + a == a + a): bool) })): bool)
@@ -76,8 +76,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((exists(((#[prusti::spec_only] |a: i32, b: i32| (1),
-                                    #[prusti::spec_only] |a: i32, b: i32| (2)),
+    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: i32|
+                                        (1), #[prusti::spec_only] |a: i32, b: i32| (2)),
                                 (#[prusti::spec_only] |a: i32, b: i32| (1),)),
                             #[prusti::spec_only] |a: i32, b: i32| -> bool
                                 { ((a + b == a + b): bool) })): bool)
@@ -90,8 +90,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((exists(((#[prusti::spec_only] |a: i32, b: i32| (1),
-                                    #[prusti::spec_only] |a: i32, b: i32| (2),
+    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: i32|
+                                        (1), #[prusti::spec_only] |a: i32, b: i32| (2),
                                     #[prusti::spec_only] |a: i32, b: i32| (3)),
                                 (#[prusti::spec_only] |a: i32, b: i32| (1),
                                     #[prusti::spec_only] |a: i32, b: i32| (2)),

--- a/prusti-tests/tests/parse/ui/forall.stdout
+++ b/prusti-tests/tests/parse/ui/forall.stdout
@@ -25,7 +25,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 { (((a + a == a + a)): bool) })): bool)
 }
@@ -37,7 +37,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |a: i32, b: i32| -> bool
                                 {
                                     ((((a + b == a + b) && (true)) == (a + b == a + b)): bool)
@@ -51,7 +51,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |a: i32, b: i32| -> bool
                                 { ((!(a + b == a + b) || (a + b == a + b)): bool) })): bool)
 }
@@ -63,7 +63,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((forall(((#[prusti::spec_only] |a: i32| (1),
+    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32| (1),
                                     #[prusti::spec_only] |a: i32| ((2 == 2) && (true))),),
                             #[prusti::spec_only] |a: i32| -> bool
                                 { ((a + a == a + a): bool) })): bool)
@@ -76,8 +76,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((forall(((#[prusti::spec_only] |a: i32, b: i32| (1),
-                                    #[prusti::spec_only] |a: i32, b: i32| (2)),
+    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: i32|
+                                        (1), #[prusti::spec_only] |a: i32, b: i32| (2)),
                                 (#[prusti::spec_only] |a: i32, b: i32| (1),)),
                             #[prusti::spec_only] |a: i32, b: i32| -> bool
                                 { ((a + b == a + b): bool) })): bool)
@@ -90,8 +90,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((forall(((#[prusti::spec_only] |a: i32, b: i32| (1),
-                                    #[prusti::spec_only] |a: i32, b: i32| (2),
+    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: i32|
+                                        (1), #[prusti::spec_only] |a: i32, b: i32| (2),
                                     #[prusti::spec_only] |a: i32, b: i32| (3)),
                                 (#[prusti::spec_only] |a: i32, b: i32| (1),
                                     #[prusti::spec_only] |a: i32, b: i32| (2)),

--- a/prusti-tests/tests/parse/ui/predicate_fail-2.stderr
+++ b/prusti-tests/tests/parse/ui/predicate_fail-2.stderr
@@ -1,16 +1,16 @@
-error: `predicate!` can only be used on function definitions. it supports no attributes.
+error: `predicate!` can only be used on function definitions; it supports no attributes
   --> $DIR/predicate_fail-2.rs:18:5
    |
 18 |     static FOO: usize = 0;
    |     ^^^^^^
 
-error: `predicate!` can only be used on function definitions. it supports no attributes.
+error: `predicate!` can only be used on function definitions; it supports no attributes
   --> $DIR/predicate_fail-2.rs:24:5
    |
 24 |     #[pure]
    |     ^
 
-error: `predicate!` can only be used on function definitions. it supports no attributes.
+error: `predicate!` can only be used on function definitions; it supports no attributes
   --> $DIR/predicate_fail-2.rs:33:5
    |
 33 |     #[trusted]

--- a/prusti-tests/tests/parse/ui/predicates-visibility.stdout
+++ b/prusti-tests/tests/parse/ui/predicates-visibility.stdout
@@ -27,7 +27,7 @@ mod foo {
     fn prusti_pred_item_pred1_$(NUM_UUID)(a: bool)
         -> bool {
         (({
-                        forall((),
+                        ::prusti_contracts::forall((),
                             #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
                     }): bool)
     }

--- a/prusti-tests/tests/parse/ui/predicates-visibility.stdout
+++ b/prusti-tests/tests/parse/ui/predicates-visibility.stdout
@@ -26,9 +26,10 @@ mod foo {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pred_item_pred1_$(NUM_UUID)(a: bool)
         -> bool {
-        !!((forall((),
-                                #[prusti::spec_only] |b: bool| -> bool
-                                    { ((a == b): bool) })): bool)
+        (({
+                        forall((),
+                            #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
+                    }): bool)
     }
     #[allow(unused_must_use, unused_variables, dead_code)]
     #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]

--- a/prusti-tests/tests/parse/ui/predicates.stdout
+++ b/prusti-tests/tests/parse/ui/predicates.stdout
@@ -27,9 +27,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_pred1_$(NUM_UUID)(a: bool) -> bool {
-    !!((forall((),
-                            #[prusti::spec_only] |b: bool| -> bool
-                                { ((a == b): bool) })): bool)
+    (({
+                    forall((),
+                        #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
+                }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
@@ -54,9 +55,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_pred2_$(NUM_UUID)(a: bool) -> bool {
-    !!((exists((),
-                            #[prusti::spec_only] |b: bool| -> bool
-                                { ((a == b): bool) })): bool)
+    (({
+                    exists((),
+                        #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
+                }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
@@ -82,9 +84,11 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_forall_implication_$(NUM_UUID)()
     -> bool {
-    !!((forall((),
-                            #[prusti::spec_only] |x: usize| -> bool
-                                { ((!((x != 0)) || (x * 2 != 0)): bool) })): bool)
+    (({
+                    forall((),
+                        #[prusti::spec_only] |x: usize| -> bool
+                            { ((!((x != 0)) || (x * 2 != 0)): bool) })
+                }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
@@ -100,9 +104,11 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_exists_implication_$(NUM_UUID)()
     -> bool {
-    !!((exists((),
-                            #[prusti::spec_only] |x: usize| -> bool
-                                { ((!((x != 0)) || (x * 2 != 0)): bool) })): bool)
+    (({
+                    exists((),
+                        #[prusti::spec_only] |x: usize| -> bool
+                            { ((!((x != 0)) || (x * 2 != 0)): bool) })
+                }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]

--- a/prusti-tests/tests/parse/ui/predicates.stdout
+++ b/prusti-tests/tests/parse/ui/predicates.stdout
@@ -28,7 +28,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_pred1_$(NUM_UUID)(a: bool) -> bool {
     (({
-                    forall((),
+                    ::prusti_contracts::forall((),
                         #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
                 }): bool)
 }
@@ -56,7 +56,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_pred2_$(NUM_UUID)(a: bool) -> bool {
     (({
-                    exists((),
+                    ::prusti_contracts::exists((),
                         #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
                 }): bool)
 }
@@ -85,7 +85,7 @@ non_snake_case)]
 fn prusti_pred_item_forall_implication_$(NUM_UUID)()
     -> bool {
     (({
-                    forall((),
+                    ::prusti_contracts::forall((),
                         #[prusti::spec_only] |x: usize| -> bool
                             { ((!((x != 0)) || (x * 2 != 0)): bool) })
                 }): bool)
@@ -105,7 +105,7 @@ non_snake_case)]
 fn prusti_pred_item_exists_implication_$(NUM_UUID)()
     -> bool {
     (({
-                    exists((),
+                    ::prusti_contracts::exists((),
                         #[prusti::spec_only] |x: usize| -> bool
                             { ((!((x != 0)) || (x * 2 != 0)): bool) })
                 }): bool)

--- a/prusti-tests/tests/typecheck/ui/forall_encode_typeck.stdout
+++ b/prusti-tests/tests/typecheck/ui/forall_encode_typeck.stdout
@@ -21,8 +21,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((forall(((#[prusti::spec_only] |a: i32, b: u32| (a == a),
-                                    #[prusti::spec_only] |a: i32, b: u32| (a == a)),
+    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: u32|
+                                        (a == a), #[prusti::spec_only] |a: i32, b: u32| (a == a)),
                                 (#[prusti::spec_only] |a: i32, b: u32| (true),)),
                             #[prusti::spec_only] |a: i32, b: u32| -> bool
                                 { ((a == a): bool) })): bool)
@@ -35,8 +35,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((exists(((#[prusti::spec_only] |a: i32, b: u32| (a == a),
-                                    #[prusti::spec_only] |a: i32, b: u32| (a == a)),
+    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: u32|
+                                        (a == a), #[prusti::spec_only] |a: i32, b: u32| (a == a)),
                                 (#[prusti::spec_only] |a: i32, b: u32| (true),)),
                             #[prusti::spec_only] |a: i32, b: u32| -> bool
                                 { ((a == a): bool) })): bool)

--- a/prusti-tests/tests/typecheck/ui/forall_triggers.stdout
+++ b/prusti-tests/tests/typecheck/ui/forall_triggers.stdout
@@ -27,7 +27,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((forall(((#[prusti::spec_only] |a: i32| (a == a),),),
+    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
+                                        (a == a),),),
                             #[prusti::spec_only] |a: i32| -> bool { ((true): bool) })):
                     bool)
 }
@@ -39,10 +40,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((forall(((#[prusti::spec_only] |a: i32| ((a == a) && (true)),),),
+    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
+                                        ((a == a) && (true)),),),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((forall((),
+                                    ((::prusti_contracts::forall((),
                                                     #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
                                             bool)
                                 })): bool)
@@ -55,10 +57,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((forall(((#[prusti::spec_only] |a: i32| (a == a),),),
+    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
+                                        (a == a),),),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((forall(((#[prusti::spec_only] |b: i32| (a == a),),),
+                                    ((::prusti_contracts::forall(((#[prusti::spec_only] |b: i32|
+                                                                (a == a),),),
                                                     #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
                                             bool)
                                 })): bool)
@@ -71,10 +75,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((forall(((#[prusti::spec_only] |a: i32| ((a == a) && (true)),),),
+    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
+                                        ((a == a) && (true)),),),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((forall(((#[prusti::spec_only] |b: i32| (a == b),),),
+                                    ((::prusti_contracts::forall(((#[prusti::spec_only] |b: i32|
+                                                                (a == b),),),
                                                     #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
                                             bool)
                                 })): bool)
@@ -87,7 +93,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((exists(((#[prusti::spec_only] |a: i32| (a == a),),),
+    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
+                                        (a == a),),),
                             #[prusti::spec_only] |a: i32| -> bool { ((true): bool) })):
                     bool)
 }
@@ -99,10 +106,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((exists(((#[prusti::spec_only] |a: i32| ((a == a) && (true)),),),
+    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
+                                        ((a == a) && (true)),),),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((exists((),
+                                    ((::prusti_contracts::exists((),
                                                     #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
                                             bool)
                                 })): bool)
@@ -115,10 +123,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test7_$(NUM_UUID)() -> bool {
-    !!((exists(((#[prusti::spec_only] |a: i32| (a == a),),),
+    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
+                                        (a == a),),),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((exists(((#[prusti::spec_only] |b: i32| (a == a),),),
+                                    ((::prusti_contracts::exists(((#[prusti::spec_only] |b: i32|
+                                                                (a == a),),),
                                                     #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
                                             bool)
                                 })): bool)
@@ -131,10 +141,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test8_$(NUM_UUID)() -> bool {
-    !!((exists(((#[prusti::spec_only] |a: i32| ((a == a) && (true)),),),
+    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
+                                        ((a == a) && (true)),),),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((exists(((#[prusti::spec_only] |b: i32| (a == b),),),
+                                    ((::prusti_contracts::exists(((#[prusti::spec_only] |b: i32|
+                                                                (a == b),),),
                                                     #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
                                             bool)
                                 })): bool)

--- a/prusti-tests/tests/typecheck/ui/nested_forall.stdout
+++ b/prusti-tests/tests/typecheck/ui/nested_forall.stdout
@@ -26,10 +26,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((forall((),
+                                    ((::prusti_contracts::forall((),
                                                     #[prusti::spec_only] |a: i32| -> bool
                                                         { ((a == a): bool) })): bool)
                                 })): bool)
@@ -42,10 +42,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((forall((),
+                                    ((::prusti_contracts::forall((),
                                                     #[prusti::spec_only] |b: i32| -> bool
                                                         { ((!(a == a) || (b == b)): bool) })): bool)
                                 })): bool)
@@ -58,13 +58,13 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((forall((),
+                                    ((::prusti_contracts::forall((),
                                                     #[prusti::spec_only] |b: i32| -> bool
                                                         {
-                                                            ((forall((),
+                                                            ((::prusti_contracts::forall((),
                                                                             #[prusti::spec_only] |c: i32| -> bool
                                                                                 { (((a == a) && (b == b)): bool) })): bool)
                                                         })): bool)
@@ -78,10 +78,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((exists((),
+                                    ((::prusti_contracts::exists((),
                                                     #[prusti::spec_only] |a: i32| -> bool
                                                         { ((a == a): bool) })): bool)
                                 })): bool)
@@ -94,10 +94,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((exists((),
+                                    ((::prusti_contracts::exists((),
                                                     #[prusti::spec_only] |b: i32| -> bool
                                                         { ((!(a == a) || (b == b)): bool) })): bool)
                                 })): bool)
@@ -110,13 +110,13 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |a: i32| -> bool
                                 {
-                                    ((exists((),
+                                    ((::prusti_contracts::exists((),
                                                     #[prusti::spec_only] |b: i32| -> bool
                                                         {
-                                                            ((exists((),
+                                                            ((::prusti_contracts::exists((),
                                                                             #[prusti::spec_only] |c: i32| -> bool
                                                                                 { (((a == a) && (b == b)): bool) })): bool)
                                                         })): bool)

--- a/prusti-tests/tests/verify/pass/pure-fn/non-bool-predicate.rs
+++ b/prusti-tests/tests/verify/pass/pure-fn/non-bool-predicate.rs
@@ -1,0 +1,11 @@
+use prusti_contracts::*;
+
+predicate! {
+    fn foo(x: usize) -> usize {
+        x + 1
+    }
+}
+
+fn main() {
+    prusti_assert!(foo(2) == 3);
+}

--- a/prusti-tests/tests/verify/ui/forall_verify.stderr
+++ b/prusti-tests/tests/verify/ui/forall_verify.stderr
@@ -1,8 +1,8 @@
 error: [Prusti: verification error] postcondition might not hold.
-  --> $DIR/forall_verify.rs:18:27
+  --> $DIR/forall_verify.rs:18:11
    |
 18 | #[ensures(forall(|x: i32| identity(x) == x + 1))]
-   |                           ^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the error originates here
   --> $DIR/forall_verify.rs:19:1

--- a/prusti-tests/tests/verify/ui/forall_verify.stdout
+++ b/prusti-tests/tests/verify/ui/forall_verify.stdout
@@ -34,7 +34,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test1_$(NUM_UUID)(result: ())
     -> bool {
-    !!((forall((), #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })):
+    !!((::prusti_contracts::forall((),
+                            #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })):
                     bool)
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
@@ -46,7 +47,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test2_$(NUM_UUID)(result: ())
     -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |x: i32| -> bool
                                 { ((identity(x) == x): bool) })): bool)
 }
@@ -59,7 +60,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test3_$(NUM_UUID)(result: ())
     -> bool {
-    !!((forall((),
+    !!((::prusti_contracts::forall((),
                             #[prusti::spec_only] |x: i32| -> bool
                                 { ((identity(x) == x + 1): bool) })): bool)
 }
@@ -72,7 +73,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test4_$(NUM_UUID)(result: ())
     -> bool {
-    !!((exists((), #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })):
+    !!((::prusti_contracts::exists((),
+                            #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })):
                     bool)
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
@@ -92,7 +94,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test5_$(NUM_UUID)(result: ())
     -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |x: i32| -> bool
                                 { ((identity(x) == x): bool) })): bool)
 }
@@ -106,7 +108,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test6_$(NUM_UUID)(result: ())
     -> bool {
-    !!((exists((),
+    !!((::prusti_contracts::exists((),
                             #[prusti::spec_only] |x: i32| -> bool
                                 { ((identity(x) == x + 1): bool) })): bool)
 }

--- a/prusti-tests/tests/verify/ui/predicate.stdout
+++ b/prusti-tests/tests/verify/ui/predicate.stdout
@@ -35,8 +35,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_true_p1_$(NUM_UUID)() -> bool {
-    !!((forall((), #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })):
-                    bool)
+    (({
+                    forall((),
+                        #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })
+                }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
@@ -51,8 +53,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_true_p2_$(NUM_UUID)() -> bool {
-    !!((exists((), #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })):
-                    bool)
+    (({
+                    exists((),
+                        #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })
+                }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
@@ -68,9 +72,11 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_forall_identity_$(NUM_UUID)()
     -> bool {
-    !!((forall((),
-                            #[prusti::spec_only] |x: i32| -> bool
-                                { ((identity(x) == x): bool) })): bool)
+    (({
+                    forall((),
+                        #[prusti::spec_only] |x: i32| -> bool
+                            { ((identity(x) == x): bool) })
+                }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
@@ -86,9 +92,11 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_exists_identity_$(NUM_UUID)()
     -> bool {
-    !!((exists(((#[prusti::spec_only] |x: i32| (identity(x)),),),
-                            #[prusti::spec_only] |x: i32| -> bool
-                                { ((identity(x) == x): bool) })): bool)
+    (({
+                    exists(((#[prusti::spec_only] |x: i32| (identity(x)),),),
+                        #[prusti::spec_only] |x: i32| -> bool
+                            { ((identity(x) == x): bool) })
+                }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
@@ -143,7 +151,7 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_false_p_$(NUM_UUID)() -> bool {
-    !!((false): bool)
+    (({ false }): bool)
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]

--- a/prusti-tests/tests/verify/ui/predicate.stdout
+++ b/prusti-tests/tests/verify/ui/predicate.stdout
@@ -36,7 +36,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_true_p1_$(NUM_UUID)() -> bool {
     (({
-                    forall((),
+                    ::prusti_contracts::forall((),
                         #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })
                 }): bool)
 }
@@ -54,7 +54,7 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_true_p2_$(NUM_UUID)() -> bool {
     (({
-                    exists((),
+                    ::prusti_contracts::exists((),
                         #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })
                 }): bool)
 }
@@ -73,7 +73,7 @@ non_snake_case)]
 fn prusti_pred_item_forall_identity_$(NUM_UUID)()
     -> bool {
     (({
-                    forall((),
+                    ::prusti_contracts::forall((),
                         #[prusti::spec_only] |x: i32| -> bool
                             { ((identity(x) == x): bool) })
                 }): bool)
@@ -93,7 +93,8 @@ non_snake_case)]
 fn prusti_pred_item_exists_identity_$(NUM_UUID)()
     -> bool {
     (({
-                    exists(((#[prusti::spec_only] |x: i32| (identity(x)),),),
+                    ::prusti_contracts::exists(((#[prusti::spec_only] |x: i32|
+                                    (identity(x)),),),
                         #[prusti::spec_only] |x: i32| -> bool
                             { ((identity(x) == x): bool) })
                 }): bool)

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
@@ -749,7 +749,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                         // We are encoding a trigger, so all panic branches must be stripped.
                         states[target].clone()
                     }
-                    PureEncodingContext::Assertion if matches!(self.mir.return_ty().kind(), ty::TyKind::Bool) => {
+                    PureEncodingContext::Assertion
+                        if matches!(self.mir.return_ty().kind(), ty::TyKind::Bool) =>
+                    {
                         // We are encoding an assertion, so all failures should be equivalent to false.
                         // Predicates are also encoded as assertions, but non-Boolean predicates should
                         // use the other arm.

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
@@ -211,19 +211,22 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
             .map(|local| self.encode_local((*local).into()).map(|l| l.into()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let predicate_body_encoded = self.encoder.encode_assertion(
-            predicate_body,
-            None,
-            &encoded_args,
-            None,
-            true,
-            self.parent_def_id,
-            self.substs,
-        )?;
-        self.encoder.error_manager().set_error(
-            predicate_body_encoded.pos(),
-            ErrorCtxt::PureFunctionDefinition,
-        );
+        let predicate_body_encoded = self
+            .encoder
+            .encode_assertion(
+                predicate_body,
+                None,
+                &encoded_args,
+                None,
+                true,
+                self.parent_def_id,
+                self.substs,
+            )?
+            .set_default_pos(self.encoder.error_manager().register_error(
+                self.span,
+                ErrorCtxt::PureFunctionDefinition,
+                *predicate_body,
+            ));
 
         self.encode_function_given_body(Some(predicate_body_encoded))
     }


### PR DESCRIPTION
Some changes to specs:

- `prusti_assert_eq!` and `prusti_assert_ne!` added as `macro_rules`, desugaring to a snapshot (in)equality check. Closes #1283. Error messages are a bit noisy because of the `macro_rules` implementation. We probably want macros that affect the backtrace we report in the long term anyway.
- `!==` is snapshot inequality, to avoid having to write `!(a === b)`.
- Fixed spans for implications, now includes the LHS and RHS, not only the `==>` operator.
- Fixed spans for quantifiers, now includes the `forall`/`exists` keyword.
- `<==` and `<==>` are now supported, closes #1299.
- Predicates can have multiple statements like regular functions, closes #1297.
- Predicates can return any `Copy` type, not just Booleans.