### PR TITLE
Run test-test crates with ubuntu-22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -291,7 +291,7 @@ jobs:
   # Test cargo-prusti on a collection of crates.
   test-crates:
     needs: [fmt-check, clippy-check, check-deps, smir-check, quick-tests]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         shard_index: [0, 1, 2, 3]


### PR DESCRIPTION
If the failures of `test-crates` are due to the missing libssl1.1 library, this should fix it in the short-term. Let's see.

(Removing the dependency on libssl1.1 seems better for the long-term, I agree.)