### PR TITLE
implement opt-in verification

### DIFF
--- a/docs/dev-guide/src/config/flags.md
+++ b/docs/dev-guide/src/config/flags.md
@@ -295,7 +295,7 @@ When enabled, verification is skipped for dependencies. Equivalent to enabling `
 > **Note:** applied to all dependency crates when running with `cargo prusti`.
 
 ## `OPT_IN_VERIFICATION`
-When enabled, verification is only applied to functions that have the `#[verified]` attribute applied and all functions that do not have the `#[verified]` attribute are assumed to be `#[trusted]`, by default.
+When enabled, Prusti will only try to verify the functions annotated with `#[verified]`. All other functions are assumed to be `#[trusted]`, by default. Functions annotated with both `#[trusted]` and `#[verified]` will not be verified.
 
 ## `ONLY_MEMORY_SAFETY`
 

--- a/docs/dev-guide/src/config/flags.md
+++ b/docs/dev-guide/src/config/flags.md
@@ -46,6 +46,7 @@
 | [`MIN_PRUSTI_VERSION`](#min_prusti_version) | `Option<String>` | `None` | A |
 | [`NO_VERIFY`](#no_verify) | `bool` | `false` | A |
 | [`NO_VERIFY_DEPS`](#no_verify_deps) | `bool` | `false` | B |
+| [`OPT_IN_VERIFICATION`](#opt_in_verification) | `bool` | `false` | A |
 | [`OPTIMIZATIONS`](#optimizations) | `Vec<String>` | "all" | A |
 | [`PRESERVE_SMT_TRACE_FILES`](#preserve_smt_trace_files) | `bool` | `false` | A |
 | [`PRINT_COLLECTED_VERIFICATION_ITEMS`](#print_collected_verification_items) | `bool` | `false` | A |
@@ -292,6 +293,9 @@ When enabled, verification is skipped altogether, though specs are still exporte
 When enabled, verification is skipped for dependencies. Equivalent to enabling `NO_VERIFY` for all dependencies. Remote dependencies from e.g. git/crates.io are already automatically `NO_VERIFY`.
 
 > **Note:** applied to all dependency crates when running with `cargo prusti`.
+
+## `OPT_IN_VERIFICATION`
+When enabled, verification is only applied to functions that have the `#[verified]` attribute applied and all functions that do not have the `#[verified]` attribute are assumed to be `#[trusted]`, by default.
 
 ## `ONLY_MEMORY_SAFETY`
 

--- a/prusti-contracts/prusti-contracts-proc-macros/src/lib.rs
+++ b/prusti-contracts/prusti-contracts-proc-macros/src/lib.rs
@@ -47,6 +47,12 @@ pub fn trusted(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
 }
 
 #[cfg(not(feature = "prusti"))]
+#[proc_macro_attribute]
+pub fn verified(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    tokens
+}
+
+#[cfg(not(feature = "prusti"))]
 #[proc_macro]
 pub fn body_invariant(_tokens: TokenStream) -> TokenStream {
     TokenStream::new()
@@ -163,6 +169,12 @@ pub fn pure(attr: TokenStream, tokens: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn trusted(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     prusti_specs::trusted(attr.into(), tokens.into()).into()
+}
+
+#[cfg(feature = "prusti")]
+#[proc_macro_attribute]
+pub fn verified(attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    rewrite_prusti_attributes(SpecAttributeKind::Verified, attr.into(), tokens.into()).into()
 }
 
 #[cfg(feature = "prusti")]

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -18,6 +18,9 @@ pub use prusti_contracts_proc_macros::pure;
 /// A macro for marking a function as trusted.
 pub use prusti_contracts_proc_macros::trusted;
 
+/// A macro for marking a function as opted into verification.
+pub use prusti_contracts_proc_macros::verified;
+
 /// A macro for type invariants.
 pub use prusti_contracts_proc_macros::invariant;
 

--- a/prusti-contracts/prusti-specs/src/spec_attribute_kind.rs
+++ b/prusti-contracts/prusti-specs/src/spec_attribute_kind.rs
@@ -17,6 +17,7 @@ pub enum SpecAttributeKind {
     RefineSpec = 9,
     Terminates = 10,
     PrintCounterexample = 11,
+    Verified = 12,
 }
 
 impl TryFrom<String> for SpecAttributeKind {
@@ -35,6 +36,7 @@ impl TryFrom<String> for SpecAttributeKind {
             "refine_spec" => Ok(SpecAttributeKind::RefineSpec),
             "model" => Ok(SpecAttributeKind::Model),
             "print_counterexample" => Ok(SpecAttributeKind::PrintCounterexample),
+            "verified" => Ok(SpecAttributeKind::Verified),
             _ => Err(name),
         }
     }

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     PrustiError,
 };
 use log::debug;
+use prusti_common::config::opt_in_verification;
 use prusti_rustc_interface::{
     ast::ast,
     errors::MultiSpan,
@@ -364,7 +365,8 @@ fn get_procedure_spec_ids(def_id: DefId, attrs: &[ast::Attribute]) -> Option<Pro
     );
 
     let pure = has_prusti_attr(attrs, "pure");
-    let trusted = has_prusti_attr(attrs, "trusted");
+    let trusted = has_prusti_attr(attrs, "trusted")
+        || (opt_in_verification() && !has_prusti_attr(attrs, "verified"));
     let abstract_predicate = has_abstract_predicate_attr(attrs);
 
     if abstract_predicate || pure || trusted || !spec_id_refs.is_empty() {

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -366,7 +366,7 @@ fn get_procedure_spec_ids(def_id: DefId, attrs: &[ast::Attribute]) -> Option<Pro
 
     let pure = has_prusti_attr(attrs, "pure");
     let trusted = has_prusti_attr(attrs, "trusted")
-        || (opt_in_verification() && !has_prusti_attr(attrs, "verified"));
+        || (config::opt_in_verification() && !has_prusti_attr(attrs, "verified"));
     let abstract_predicate = has_abstract_predicate_attr(attrs);
 
     if abstract_predicate || pure || trusted || !spec_id_refs.is_empty() {

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     PrustiError,
 };
 use log::debug;
-use prusti_common::config::opt_in_verification;
+use prusti_common::config;
 use prusti_rustc_interface::{
     ast::ast,
     errors::MultiSpan,

--- a/prusti-tests/tests/verify_overflow/fail/issues/issue-1187-2.rs
+++ b/prusti-tests/tests/verify_overflow/fail/issues/issue-1187-2.rs
@@ -1,0 +1,19 @@
+// compile-flags: -Popt_in_verification=true
+use prusti_contracts::*;
+
+fn main() {}
+
+fn i_am_not_verified() {
+    unreachable!();
+}
+
+#[verified]
+fn i_am_verified() {
+    assert!(1 == 2); //~ ERROR
+}
+
+#[verified]
+#[trusted]
+fn i_am_trusted() {
+    unreachable!();
+}

--- a/prusti-tests/tests/verify_overflow/fail/issues/issue-1187-3.rs
+++ b/prusti-tests/tests/verify_overflow/fail/issues/issue-1187-3.rs
@@ -1,0 +1,19 @@
+// compile-flags: -Popt_in_verification=false
+use prusti_contracts::*;
+
+fn main() {}
+
+fn i_am_not_verified() {
+    unreachable!(); //~ ERROR
+}
+
+#[verified]
+fn i_am_verified() {
+    assert!(1 == 2); //~ ERROR
+}
+
+#[verified]
+#[trusted]
+fn i_am_trusted() {
+    unreachable!();
+}

--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-1187-1.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-1187-1.rs
@@ -1,0 +1,25 @@
+// compile-flags: -Popt_in_verification=true
+use prusti_contracts::*;
+
+fn main() {}
+
+fn i_am_not_verified() {
+    unreachable!();
+}
+
+#[verified]
+fn i_am_verified() {
+    assert!(1 != 2);
+}
+
+#[verified]
+#[pure]
+fn i_am_pure() {
+    assert!(true);
+}
+
+#[verified]
+#[trusted]
+fn i_am_trusted() {
+    unreachable!();
+}

--- a/prusti-utils/src/config.rs
+++ b/prusti-utils/src/config.rs
@@ -107,6 +107,7 @@ lazy_static::lazy_static! {
         settings.set_default("allow_unreachable_unsupported_code", false).unwrap();
         settings.set_default("no_verify", false).unwrap();
         settings.set_default("no_verify_deps", false).unwrap();
+        settings.set_default("opt_in_verification", false).unwrap();
         settings.set_default("full_compilation", false).unwrap();
         settings.set_default("json_communication", false).unwrap();
         settings.set_default("optimizations", "all").unwrap();
@@ -979,6 +980,12 @@ pub fn set_no_verify(value: bool) {
 /// When enabled, verification is skipped for dependencies.
 pub fn no_verify_deps() -> bool {
     read_setting("no_verify_deps")
+}
+
+/// When enabled, verification is skipped for functions
+/// that do not have the `#[verified]` attribute.
+pub fn opt_in_verification() -> bool {
+    read_setting("opt_in_verification")
 }
 
 /// When enabled, compilation will continue and a binary will be generated


### PR DESCRIPTION
Adds `#[verified]` attribute and `opt_in_verification` configuration option plus tests and documentation, as discussed in #1187.

Closes #1187.