### PR TITLE
Compile for macOS ARM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,9 +55,7 @@ jobs:
 
   # Build in release mode (but don't test) for macOS ARM
   # See: https://stackoverflow.com/a/66875783/2491528
-  # Blocked by: https://github.com/viperproject/prusti-dev/issues/1193
   build_macos_arm:
-    if: false
     runs-on: macos-latest
     steps:
       - name: Check out the repo
@@ -106,7 +104,7 @@ jobs:
       - name: Zip Prusti artifacts
         shell: bash
         run: |
-          for os in ubuntu-20.04 ubuntu-22.04 windows-latest macos-latest
+          for os in ubuntu-20.04 ubuntu-22.04 windows-latest macos-latest macos-arm
           do
             echo "Package Prusti artifact for $os"
             cd prusti-release-$os
@@ -168,7 +166,7 @@ jobs:
           asset_name: prusti-release-windows.zip
           asset_content_type: application/zip
 
-      - name: Upload release asset for MacOS
+      - name: Upload release asset for MacOS x86
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -176,4 +174,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./prusti-release-macos-latest/prusti.zip
           asset_name: prusti-release-macos.zip
+          asset_content_type: application/zip
+
+      - name: Upload release asset for MacOS ARM
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./prusti-release-macos-arm/prusti.zip
+          asset_name: prusti-release-macos-arm.zip
           asset_content_type: application/zip


### PR DESCRIPTION
Now that we no longer depend on `libssl1.1`, compiling for macOS ARM might work.

(Related to https://github.com/viperproject/prusti-dev/issues/1193)