### PR TITLE
Normalize field types

### DIFF
--- a/prusti-tests/tests/verify/pass/generic/associated-types.rs
+++ b/prusti-tests/tests/verify/pass/generic/associated-types.rs
@@ -1,0 +1,34 @@
+use prusti_contracts::*;
+
+trait Model {
+  type Kind;
+}
+
+struct MyModel {}
+
+impl Model for MyModel {
+  type Kind = bool;
+}
+
+struct Guard<M: Model> {
+  kind: M::Kind,
+}
+
+// <MyModel as Model>::Kind is the same type as bool,
+// but it need to be normalized to see that.
+fn test1(gd: Guard<MyModel>) -> bool {
+  gd.kind
+}
+
+// Snapshot types should also be normalized.
+#[pure]
+fn test2(gd: &Guard<MyModel>) -> bool {
+  gd.kind
+}
+
+// In this case, normalization fails, so it should
+// continue with the non-normalized type.
+fn test3<M: Model>(gd: Guard<M>) {}
+
+#[trusted]
+fn main() {}

--- a/prusti-viper/src/encoder/mir/types/encoder.rs
+++ b/prusti-viper/src/encoder/mir/types/encoder.rs
@@ -18,7 +18,10 @@ use prusti_common::config;
 use prusti_rustc_interface::{
     errors::MultiSpan,
     hir::def_id::DefId,
-    middle::{mir, ty},
+    middle::{
+        mir,
+        ty::{self, TypeVisitable},
+    },
 };
 use vir_crate::high::{self as vir, operations::ty::Typed};
 
@@ -703,6 +706,12 @@ fn encode_variant<'v, 'tcx: 'v>(
     for (field_index, field) in variant.fields.iter().enumerate() {
         let field_name = crate::encoder::encoder::encode_field_name(field.ident(tcx).as_str());
         let field_ty = field.ty(tcx, substs);
+        let field_ty = if config::unsafe_core_proof() && field_ty.has_erasable_regions() {
+            field_ty
+        } else {
+            tcx.try_normalize_erasing_regions(ty::ParamEnv::reveal_all(), field_ty)
+                .unwrap_or(field_ty)
+        };
         let field =
             vir::FieldDecl::new(field_name, field_index, encoder.encode_type_high(field_ty)?);
         fields.push(field);

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -717,6 +717,9 @@ impl SnapshotEncoder {
                 for field in adt_def.all_fields() {
                     // or adt_def.variants[0].fields ?
                     let field_ty = field.ty(tcx, substs);
+                    let field_ty = tcx
+                        .try_normalize_erasing_regions(ty::ParamEnv::reveal_all(), field_ty)
+                        .unwrap_or(field_ty);
                     fields.push(SnapshotField {
                         name: encode_field_name(&field.ident(tcx).to_string()),
                         access: self.snap_app(
@@ -762,6 +765,9 @@ impl SnapshotEncoder {
                     };
                     for field in &variant.fields {
                         let field_ty = field.ty(tcx, substs);
+                        let field_ty = tcx
+                            .try_normalize_erasing_regions(ty::ParamEnv::reveal_all(), field_ty)
+                            .unwrap_or(field_ty);
                         fields.push(SnapshotField {
                             name: encode_field_name(&field.ident(tcx).to_string()),
                             access: self.snap_app(


### PR DESCRIPTION
With associated types, you can have two types that are equal, but you can only see that after you normalize the types. See https://rustc-dev-guide.rust-lang.org/ty.html#comparing-types

I'm not sure if this is the right way or place to do normalization, but at least tests pass.

In the mir encoder, I can't use try_normalize_erasing_regions, because the unsafe core proof needs lifetime information.
Here is an example how the Normalize type op is used in the Rust compiler: https://github.com/rust-lang/rust/blob/19423b59440f464c6cbe6be442d447e37b50fe3c/compiler/rustc_borrowck/src/type_check/free_region_relations.rs#L247