### PR TITLE
Enable tracing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "tracing 0.1.0",
 ]
 
 [[package]]
@@ -1230,7 +1231,7 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -1363,7 +1364,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tower-service",
- "tracing",
+ "tracing 0.1.37",
  "want",
 ]
 
@@ -1514,6 +1515,7 @@ dependencies = [
  "log",
  "rustc-hash",
  "tempfile",
+ "tracing 0.1.0",
 ]
 
 [[package]]
@@ -1539,6 +1541,12 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "json5"
@@ -1650,6 +1658,15 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
  "value-bag",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2074,6 +2091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-tracing"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2120,9 @@ dependencies = [
  "prusti-interface",
  "prusti-rustc-interface",
  "prusti-viper",
+ "tracing 0.1.0",
+ "tracing-chrome",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2107,6 +2136,7 @@ dependencies = [
  "prusti-utils",
  "rustc-hash",
  "serde",
+ "tracing 0.1.0",
  "uuid",
  "viper",
  "vir",
@@ -2137,6 +2167,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "serde",
+ "tracing 0.1.0",
  "version-compare",
  "vir",
 ]
@@ -2171,6 +2202,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "tokio",
+ "tracing 0.1.0",
  "url",
  "viper",
  "warp",
@@ -2247,6 +2279,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "tracing 0.1.0",
  "viper",
  "vir",
 ]
@@ -2308,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2354,6 +2387,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -2597,12 +2633,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2635,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2648,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2728,6 +2763,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,6 +2810,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smt-log-analyzer"
@@ -2960,6 +3010,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,7 +3097,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -3070,6 +3130,14 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
+version = "0.1.0"
+dependencies = [
+ "proc-macro-tracing",
+ "tracing 0.1.37",
+]
+
+[[package]]
+name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
@@ -3077,7 +3145,31 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865016457701971958e047b9f61add5bba70d7a7b084a13c9e54f9bb4f19d3a6"
+dependencies = [
+ "crossbeam-channel",
+ "json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3087,6 +3179,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing 0.1.37",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3227,6 +3349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "value-bag"
 version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,6 +3398,7 @@ dependencies = [
  "serde",
  "smt-log-analyzer",
  "tokio",
+ "tracing 0.1.0",
  "uuid",
  "viper-sys",
 ]
@@ -3305,6 +3434,7 @@ dependencies = [
  "serde",
  "syn",
  "thiserror",
+ "tracing 0.1.0",
  "uuid",
  "vir-gen",
  "walkdir",
@@ -3376,7 +3506,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tower-service",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "prusti-tests",
     "prusti-common",
     "prusti-utils",
+    "tracing",
     "prusti-interface",
     "prusti-viper",
     "prusti-server",

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = "0.10"
 syn = { version = "1.0", features = [ "full", "parsing" ] }
 derive_more = "0.99"
 prusti-rustc-interface = { path = "../prusti-rustc-interface" }
+tracing = { path = "../tracing" }
 
 [dev-dependencies]
 compiletest_rs = "0.9"

--- a/analysis/src/domains/definitely_accessible/state.rs
+++ b/analysis/src/domains/definitely_accessible/state.rs
@@ -80,6 +80,7 @@ impl fmt::Debug for DefinitelyAccessibleState<'_> {
 
 impl<'mir, 'tcx: 'mir> PointwiseState<'mir, 'tcx, DefinitelyAccessibleState<'tcx>> {
     /// Make a best-effort at injecting statements to check the analysis state.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn generate_test_program(&self, tcx: TyCtxt<'tcx>, source_map: &SourceMap) -> String {
         let mir_span = self.mir.span;
         let source_file = source_map.lookup_source_file(mir_span.data().lo);

--- a/analysis/src/domains/maybe_borrowed/analysis.rs
+++ b/analysis/src/domains/maybe_borrowed/analysis.rs
@@ -28,6 +28,7 @@ impl<'mir, 'tcx: 'mir> MaybeBorrowedAnalysis<'mir, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn run_analysis(
         &self,
     ) -> AnalysisResult<PointwiseState<'mir, 'tcx, MaybeBorrowedState<'tcx>>> {

--- a/analysis/src/mir_utils.rs
+++ b/analysis/src/mir_utils.rs
@@ -7,7 +7,6 @@
 //! Various helper functions for working with `mir` types.
 //! copied from prusti-interface/utils
 
-use log::trace;
 use prusti_rustc_interface::{
     data_structures::fx::FxHashSet,
     infer::infer::TyCtxtInferExt,
@@ -233,6 +232,7 @@ pub fn expand_one_level<'tcx>(
 /// `{x.g, x.h, x.f.f, x.f.h, x.f.g.f, x.f.g.g, x.f.g.h}` and
 /// subtracting `{x.f.g.h}` from it, which results into `{x.g, x.h,
 /// x.f.f, x.f.h, x.f.g.f, x.f.g.g}`.
+#[tracing::instrument(level = "trace", skip(mir, tcx), ret)]
 pub(crate) fn expand<'tcx>(
     mir: &mir::Body<'tcx>,
     tcx: TyCtxt<'tcx>,
@@ -243,23 +243,12 @@ pub(crate) fn expand<'tcx>(
         is_prefix(subtrahend, minuend),
         "The minuend must be the prefix of the subtrahend."
     );
-    trace!(
-        "[enter] expand minuend={:?} subtrahend={:?}",
-        minuend,
-        subtrahend
-    );
     let mut place_set = Vec::new();
     while minuend.projection.len() < subtrahend.projection.len() {
         let (new_minuend, places) = expand_one_level(mir, tcx, minuend, subtrahend);
         minuend = new_minuend;
         place_set.extend(places);
     }
-    trace!(
-        "[exit] expand minuend={:?} subtrahend={:?} place_set={:?}",
-        minuend,
-        subtrahend,
-        place_set
-    );
     place_set
 }
 

--- a/docs/dev-guide/src/config/flags.md
+++ b/docs/dev-guide/src/config/flags.md
@@ -42,6 +42,7 @@
 | [`LOG_DIR`](#log_dir) | `String` | `"log"` | A* |
 | [`LOG_STYLE`](#log_style) | `String` | `"auto"` | A |
 | [`LOG_SMT_WRAPPER_INTERACTION`](#log_smt_wrapper_interaction) | `bool` | `false` | A |
+| [`LOG_TRACING`](#log_tracing) | `bool` | `true` | A |
 | [`MAX_LOG_FILE_NAME_LENGTH`](#max_log_file_name_length) | `usize` | `60` | A |
 | [`MIN_PRUSTI_VERSION`](#min_prusti_version) | `Option<String>` | `None` | A |
 | [`NO_VERIFY`](#no_verify) | `bool` | `false` | A |
@@ -257,7 +258,8 @@ When enabled, communication with the server will be encoded as JSON instead of t
 
 Log level and filters. See [`env_logger` documentation](https://docs.rs/env_logger/0.7.1/env_logger/index.html#enabling-logging).
 
-For example, `PRUSTI_LOG=prusti_viper=trace` enables trace logging for the prusti-viper crate.
+For example, `PRUSTI_LOG=prusti_viper=trace` enables trace logging for the prusti-viper crate, or `PRUSTI_LOG=debug` enables lighter logging everywhere. When using `trace` it is recommended to disable `jni` messages with e.g. `PRUSTI_LOG=trace,jni=warn`.
+A useful explanation of this can be found in the [rustc docs](https://rustc-dev-guide.rust-lang.org/tracing.html) (we set `PRUSTI_LOG` rather than `RUSTC_LOG`).
 Debug and trace logs are not available in release builds.
 
 ## `LOG_DIR`
@@ -268,13 +270,18 @@ Path to directory in which log files and dumped output will be stored.
 
 ## `LOG_STYLE`
 
-Log style. See [`env_logger` documentation](https://docs.rs/env_logger/0.7.1/env_logger/index.html#disabling-colors).
+Log style. See [`env_logger` documentation](https://docs.rs/env_logger/0.7.1/env_logger/index.html#disabling-colors). Has no effect when `LOG_TRACING=true`.
 
 ## `LOG_SMT_WRAPPER_INTERACTION`
 
 When enabled, logs all SMT wrapper interaction to a file.
 
 > **Note:** Requires `USE_SMT_WRAPPER` to be `true`.
+
+## `LOG_TRACING`
+
+When enabled, logs are outputted using the [`tracing_chrome` crate](https://docs.rs/tracing-chrome/0.7.0/tracing_chrome/) rather than as std output with the `env_logger`.
+You can find the file at `$LOG_DIR/trace.json` which can be opened in [ui.perfetto.dev](https://ui.perfetto.dev/). The file is only generated if [`LOG`](#log) is set.
 
 ## `MAX_LOG_FILE_NAME_LENGTH`
 

--- a/docs/dev-guide/src/pipeline/summary.md
+++ b/docs/dev-guide/src/pipeline/summary.md
@@ -24,3 +24,9 @@ This chapter summarizes the steps that take place when the user runs Prusti on a
     - (With Prusti server only) Send verification results back to the client.
 5. [Reporting stage](report.md)
     - The Prusti client reports compilation and verification errors.
+
+Prusti supports tracing which can be useful to get an idea of the most important functions in stages 3 to 5. To enable this, set the [`log`](../config/flags.md#log) flag, for example:
+
+> `./x.py run --bin prusti-rustc -- --edition=2021 prusti-tests/**/nfm22/bst_generics.rs -Plog=debug`
+
+Prusti then generates a `log/trace.json` file which can be opened in [ui.perfetto.dev](https://ui.perfetto.dev/) to visualize the trace.

--- a/jni-gen/Cargo.toml
+++ b/jni-gen/Cargo.toml
@@ -13,3 +13,4 @@ error-chain = "0.12.0"
 jni = { version = "0.20", features = ["invocation"] }
 tempfile = "3"
 rustc-hash = "1.1.0"
+tracing = { path = "../tracing" }

--- a/jni-gen/src/wrapper_generator.rs
+++ b/jni-gen/src/wrapper_generator.rs
@@ -45,9 +45,8 @@ impl WrapperGenerator {
         self
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn generate(&mut self, out_dir: &Path) -> LocalResult<()> {
-        debug!("Generate JNI wrappers in '{}'", out_dir.display());
-
         let classpath_separator = if cfg!(windows) { ";" } else { ":" };
 
         let jvm_args = InitArgsBuilder::new()

--- a/prusti-common/Cargo.toml
+++ b/prusti-common/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4.0"
 uuid = { version = "1.0", features = ["v4"] }
 rustc-hash = "1.1.0"
+tracing = { path = "../tracing" }

--- a/prusti-common/src/vir/fixes/ghost_vars.rs
+++ b/prusti-common/src/vir/fixes/ghost_vars.rs
@@ -17,6 +17,7 @@ use std::mem;
 /// creating the encoding. Therefore, we fix this with an additional
 /// pass that renames all variables declared inside package statements
 /// so that they are unique.
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn fix_ghost_vars(mut method: cfg::CfgMethod) -> cfg::CfgMethod {
     let mut fixer = GhostVarFixer {
         package_stmt_count: 0,

--- a/prusti-common/src/vir/optimizations/functions/inliner.rs
+++ b/prusti-common/src/vir/optimizations/functions/inliner.rs
@@ -7,7 +7,6 @@
 //! Inliner of pure functions.
 
 use crate::vir::polymorphic_vir::{ast, cfg};
-use log::trace;
 use rustc_hash::FxHashMap;
 use std::mem;
 
@@ -33,11 +32,11 @@ use std::mem;
 /// And then inline them on call sites.
 ///
 /// The optimization is performed until a fix-point.
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn inline_constant_functions(
     mut methods: Vec<cfg::CfgMethod>,
     mut functions: Vec<ast::Function>,
 ) -> (Vec<cfg::CfgMethod>, Vec<ast::Function>) {
-    trace!("[enter] purify_constant_functions");
     let mut non_pure_functions = Vec::new();
     let mut pure_function_map = FxHashMap::default();
     let mut changed = true;
@@ -63,8 +62,8 @@ pub fn inline_constant_functions(
 
 /// Try converting the function to pure by removing permissions from the
 /// precondition. Returns true if successful.
+#[tracing::instrument(level = "trace", skip_all, fields(name = %function.name))]
 fn try_purify(function: &mut ast::Function) -> Option<ast::Expr> {
-    trace!("[enter] try_purify(name={})", function.name);
     if function.has_constant_body()
         && function.pres.iter().all(|cond| cond.is_only_permissions())
         && function.posts.is_empty()

--- a/prusti-common/src/vir/optimizations/functions/simplifier.rs
+++ b/prusti-common/src/vir/optimizations/functions/simplifier.rs
@@ -7,7 +7,6 @@
 //! Function simplifier that simplifies expressions.
 
 use crate::vir::polymorphic_vir::ast::{self, ExprFolder};
-use log::trace;
 
 pub trait Simplifier {
     /// Simplify by doing constant evaluation.
@@ -18,11 +17,10 @@ pub trait Simplifier {
 impl Simplifier for ast::Function {
     /// Simplify functions in a way that tries to work-around regressions caused by
     /// <https://github.com/viperproject/silicon/issues/387>
+    #[tracing::instrument(level = "debug", skip(self), fields(self = %self), ret(Display))]
     fn simplify(mut self) -> Self {
-        trace!("[enter] simplify = {}", self);
         let new_body = self.body.map(|b| b.simplify());
         self.body = new_body;
-        trace!("[exit] simplify = {}", self);
         self
     }
 }
@@ -38,9 +36,9 @@ impl Simplifier for ast::Expr {
 struct ExprSimplifier {}
 
 impl ExprSimplifier {
+    #[tracing::instrument(level = "debug", skip(e), fields(e = %e), ret(Display))]
     fn apply_rules(e: ast::Expr) -> ast::Expr {
-        trace!("[enter] apply_rules={}", e);
-        let result = match e {
+        match e {
             ast::Expr::UnaryOp(ast::UnaryOp {
                 op_kind: ast::UnaryOpKind::Not,
                 argument:
@@ -186,9 +184,7 @@ impl ExprSimplifier {
                 position: pos,
             }),
             r => r,
-        };
-        trace!("[exit] apply_rules={}", result);
-        result
+        }
     }
 }
 

--- a/prusti-common/src/vir/optimizations/methods/mod.rs
+++ b/prusti-common/src/vir/optimizations/methods/mod.rs
@@ -24,6 +24,7 @@ use self::{
 };
 
 #[allow(clippy::let_and_return)]
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn optimize_method_encoding(
     cfg: CfgMethod,
     source_file_name: &str,

--- a/prusti-common/src/vir/optimizations/methods/quantifier_fixer.rs
+++ b/prusti-common/src/vir/optimizations/methods/quantifier_fixer.rs
@@ -84,6 +84,7 @@ impl vir::ExprFolder for Optimizer {
     fn fold_magic_wand(&mut self, magic_wand: vir::MagicWand) -> vir::Expr {
         vir::Expr::MagicWand(magic_wand)
     }
+    #[tracing::instrument(level = "debug", skip(self))]
     fn fold_forall(
         &mut self,
         vir::ForAll {
@@ -93,7 +94,6 @@ impl vir::ExprFolder for Optimizer {
             position,
         }: vir::ForAll,
     ) -> vir::Expr {
-        debug!("original body: {}", body);
         let folded_body = self.fold_boxed(body);
         debug!("Folded body: {}", folded_body);
         let old_counter = self.counter;
@@ -303,6 +303,7 @@ struct UnfoldingExtractor {
 }
 
 impl vir::ExprFolder for UnfoldingExtractor {
+    #[tracing::instrument(level = "debug", skip(self))]
     fn fold_forall(
         &mut self,
         vir::ForAll {
@@ -316,7 +317,6 @@ impl vir::ExprFolder for UnfoldingExtractor {
             self.unfoldings.is_empty(),
             "Nested quantifiers are not supported."
         );
-        debug!("original body: {}", body);
 
         self.in_quantifier = true;
         let replaced_body = self.fold_boxed(body);

--- a/prusti-common/src/vir/optimizations/methods/unfolding_fixer.rs
+++ b/prusti-common/src/vir/optimizations/methods/unfolding_fixer.rs
@@ -76,6 +76,7 @@ impl vir::StmtFolder for Optimizer {
 }
 
 impl vir::ExprFolder for Optimizer {
+    #[tracing::instrument(level = "debug", skip(self, unfolding))]
     fn fold_unfolding(&mut self, unfolding: vir::Unfolding) -> vir::Expr {
         let is_nested_duplicate = self
             .stack

--- a/prusti-common/src/vir/optimizations/mod.rs
+++ b/prusti-common/src/vir/optimizations/mod.rs
@@ -57,6 +57,7 @@ fn log_methods(
     }
 }
 
+#[tracing::instrument(level = "debug", skip(p))]
 pub fn optimize_program(p: Program, source_file_name: &str) -> Program {
     let mut program = p;
     let optimizations = config::optimizations();

--- a/prusti-common/src/vir/optimizations/predicates/delete_unused_predicates.rs
+++ b/prusti-common/src/vir/optimizations/predicates/delete_unused_predicates.rs
@@ -104,6 +104,7 @@ fn visit_predicate(
 }
 
 /// Delete all unused predicates and eliminate bodies of predicates that are never folded or unfolded
+#[tracing::instrument(level = "debug", skip(methods, functions, predicates))]
 pub fn delete_unused_predicates(
     methods: &[CfgMethod],
     functions: &[Function],

--- a/prusti-common/src/vir/optimizations/purification/mod.rs
+++ b/prusti-common/src/vir/optimizations/purification/mod.rs
@@ -6,6 +6,7 @@ use rustc_hash::FxHashSet;
 use std::collections::BTreeSet;
 
 /// This purifies local variables in a method body
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn purify_methods(
     mut methods: Vec<cfg::CfgMethod>,
     predicates: &[ast::Predicate],
@@ -36,6 +37,7 @@ fn translate_type(typ: &Type) -> Type {
 
 static SUPPORTED_TYPES: &[&str] = &["bool", "i32", "isize", "usize", "u32"];
 
+#[tracing::instrument(level = "debug", skip(method, predicates))]
 fn purify_method(method: &mut cfg::CfgMethod, predicates: &[ast::Predicate]) {
     let mut candidates = FxHashSet::default();
     for var in &method.local_vars {
@@ -116,6 +118,7 @@ impl PurifiableVariableCollector {
 }
 
 impl ast::ExprWalker for PurifiableVariableCollector {
+    #[tracing::instrument(level = "debug", skip(self, variable))]
     fn walk_local(&mut self, ast::Local { variable, .. }: &ast::Local) {
         if self.vars.remove(&variable.name) {
             debug!("Will not purify the variable {:?} ", variable)

--- a/prusti-common/src/vir/program_normalization.rs
+++ b/prusti-common/src/vir/program_normalization.rs
@@ -16,6 +16,7 @@ pub enum NormalizationInfo {
 
 impl NormalizationInfo {
     /// Normalize a vir::legacy program. Do nothing for vir::low programs.
+    #[tracing::instrument(level = "debug", skip(program))]
     pub fn normalize_program(program: &mut Program) -> Self {
         match program {
             Program::Low(_) => {
@@ -81,6 +82,7 @@ impl NormalizationInfo {
     }
 
     /// Denormalize the verification result.
+    #[tracing::instrument(level = "debug", skip(self, program))]
     pub fn denormalize_program(&self, program: &mut Program) {
         match program {
             Program::Low(_) => debug!("No denormalization is done for vir::low programs."),

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -14,12 +14,13 @@ use crate::{
         Program,
     },
 };
-use log::{info, trace};
+use log::info;
 use rustc_hash::FxHashMap;
 use viper::{self, AstFactory};
 use vir::common::identifier::WithIdentifier;
 
 impl<'v> ToViper<'v, viper::Program<'v>> for Program {
+    #[tracing::instrument(name = "Program::to_viper", level = "debug", skip_all)]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Program<'v> {
         let mut domains = self.domains.to_viper(context, ast);
         domains.extend(self.backend_types.to_viper(context, ast));
@@ -88,13 +89,10 @@ impl<'v> ToViper<'v, viper::Program<'v>> for Program {
 }
 
 impl<'v> ToViper<'v, viper::Position<'v>> for Position {
+    #[tracing::instrument(name = "Position::to_viper", level = "trace", skip_all, fields(
+        line = %self.line(), column = %self.column(), id = %self.id()
+    ))]
     fn to_viper(&self, _context: Context, ast: &AstFactory<'v>) -> viper::Position<'v> {
-        trace!(
-            "Generating Viper position: line {} column {} id {}",
-            self.line(),
-            self.column(),
-            self.id()
-        );
         ast.identifier_position(self.line(), self.column(), self.id().to_string())
     }
 }
@@ -161,8 +159,8 @@ impl<'v> ToViper<'v, viper::Field<'v>> for Field {
 }
 
 impl<'v> ToViper<'v, viper::Stmt<'v>> for Stmt {
+    #[tracing::instrument(name = "Stmt::to_viper", level = "trace", skip(context, ast))]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Stmt<'v> {
-        trace!("Generating Viper statement: {}", self);
         match self {
             Stmt::Comment(ref comment) => ast.comment(comment),
             Stmt::Label(ref label) => ast.label(label, &[]),
@@ -358,6 +356,7 @@ impl<'v> ToViper<'v, viper::Expr<'v>> for PermAmount {
 }
 
 impl<'v> ToViper<'v, viper::Expr<'v>> for Expr {
+    #[tracing::instrument(name = "Expr::to_viper", level = "trace", skip(context, ast))]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Expr<'v> {
         let expr = match self {
             Expr::Local(ref local_var, ref pos) => (local_var, pos).to_viper(context, ast),
@@ -805,6 +804,7 @@ impl<'v, 'a, 'b> ToViper<'v, viper::Expr<'v>> for (&'a Const, &'b Position) {
 }
 
 impl<'v> ToViper<'v, viper::Predicate<'v>> for Predicate {
+    #[tracing::instrument(name = "Predicate::to_viper", level = "debug", skip_all)]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Predicate<'v> {
         match self {
             Predicate::Struct(p) => p.to_viper(context, ast),
@@ -817,6 +817,11 @@ impl<'v> ToViper<'v, viper::Predicate<'v>> for Predicate {
 }
 
 impl<'v> ToViper<'v, viper::Predicate<'v>> for StructPredicate {
+    #[tracing::instrument(
+        name = "StructPredicate::to_viper",
+        level = "trace",
+        skip(context, ast)
+    )]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Predicate<'v> {
         ast.predicate(
             &self.name,
@@ -827,6 +832,7 @@ impl<'v> ToViper<'v, viper::Predicate<'v>> for StructPredicate {
 }
 
 impl<'v> ToViper<'v, viper::Predicate<'v>> for EnumPredicate {
+    #[tracing::instrument(name = "EnumPredicate::to_viper", level = "trace", skip(context, ast))]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Predicate<'v> {
         ast.predicate(
             &self.name,
@@ -837,6 +843,7 @@ impl<'v> ToViper<'v, viper::Predicate<'v>> for EnumPredicate {
 }
 
 impl<'a, 'v> ToViper<'v, viper::Method<'v>> for &'a BodylessMethod {
+    #[tracing::instrument(name = "BodylessMethod::to_viper", level = "trace", skip(context, ast))]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Method<'v> {
         ast.method(
             &self.name,
@@ -850,6 +857,7 @@ impl<'a, 'v> ToViper<'v, viper::Method<'v>> for &'a BodylessMethod {
 }
 
 impl<'a, 'v> ToViper<'v, viper::Function<'v>> for &'a Function {
+    #[tracing::instrument(name = "Function::to_viper", level = "debug", skip_all)]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Function<'v> {
         ast.function(
             &self.get_identifier(),
@@ -864,6 +872,7 @@ impl<'a, 'v> ToViper<'v, viper::Function<'v>> for &'a Function {
 }
 
 impl<'a, 'v> ToViper<'v, viper::Domain<'v>> for &'a Domain {
+    #[tracing::instrument(name = "Domain::to_viper", level = "debug", skip_all)]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Domain<'v> {
         ast.domain(
             &self.name,
@@ -875,6 +884,7 @@ impl<'a, 'v> ToViper<'v, viper::Domain<'v>> for &'a Domain {
 }
 
 impl<'a, 'v> ToViper<'v, viper::DomainFunc<'v>> for &'a DomainFunc {
+    #[tracing::instrument(name = "DomainFunc::to_viper", level = "trace", skip(context, ast))]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::DomainFunc<'v> {
         ast.domain_func(
             &self.get_identifier(),
@@ -887,6 +897,7 @@ impl<'a, 'v> ToViper<'v, viper::DomainFunc<'v>> for &'a DomainFunc {
 }
 
 impl<'a, 'v> ToViper<'v, viper::NamedDomainAxiom<'v>> for &'a DomainAxiom {
+    #[tracing::instrument(name = "DomainAxiom::to_viper", level = "trace", skip(context, ast))]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::NamedDomainAxiom<'v> {
         if let Some(comment) = &self.comment {
             ast.named_domain_axiom_with_comment(
@@ -1018,6 +1029,7 @@ impl<'v> ToViper<'v, Vec<viper::Predicate<'v>>> for Vec<Predicate> {
 }
 
 impl<'a, 'v> ToViper<'v, viper::Method<'v>> for &'a CfgMethod {
+    #[tracing::instrument(name = "CfgMethod::to_viper", level = "debug", skip_all)]
     fn to_viper(&self, context: Context, ast: &AstFactory<'v>) -> viper::Method<'v> {
         let mut blocks_ast: Vec<viper::Stmt> = vec![];
         let mut declarations: Vec<viper::Declaration> = vec![];

--- a/prusti-interface/Cargo.toml
+++ b/prusti-interface/Cargo.toml
@@ -17,6 +17,7 @@ analysis = { path = "../analysis" }
 prusti-specs = { path = "../prusti-contracts/prusti-specs" }
 prusti-common = { path = "../prusti-common" }
 prusti-rustc-interface = { path = "../prusti-rustc-interface" }
+tracing = { path = "../tracing" }
 log = { version = "0.4", features = ["release_max_level_info"] }
 lazy_static = "1.4.0"
 csv = "1"

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -1,4 +1,3 @@
-use log::trace;
 use prusti_common::config;
 use prusti_rustc_interface::{
     macros::{TyDecodable, TyEncodable},
@@ -277,11 +276,11 @@ impl<'tcx> EnvBody<'tcx> {
         self.try_get_local_mir_borrowck_facts(def_id).unwrap()
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn try_get_local_mir_borrowck_facts(
         &self,
         def_id: LocalDefId,
     ) -> Option<Rc<BorrowckFacts>> {
-        trace!("try_get_local_mir_borrowck_facts: {:?}", def_id);
         self.local_impure_fns
             .borrow()
             .get(&def_id)

--- a/prusti-interface/src/environment/borrowck/regions.rs
+++ b/prusti-interface/src/environment/borrowck/regions.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::environment::borrowck::facts;
-use log::{debug, trace};
+use log::debug;
 use prusti_rustc_interface::{
     data_structures::fx::FxHashMap,
     middle::{mir, ty},
@@ -93,6 +93,7 @@ fn extract_region_id(region: &ty::RegionKind) -> facts::Region {
     }
 }
 
+#[tracing::instrument(level = "trace", skip(place_regions))]
 fn extract_region(place_regions: &mut PlaceRegions, local: mir::Local, ty: ty::Ty<'_>) {
     match ty.kind() {
         ty::TyKind::Ref(region, _, _) => {
@@ -128,16 +129,13 @@ fn extract_region(place_regions: &mut PlaceRegions, local: mir::Local, ty: ty::T
     }
 }
 
+#[tracing::instrument(level = "debug", skip(body))]
 pub fn load_place_regions(body: &mir::Body<'_>) -> io::Result<PlaceRegions> {
-    trace!("[enter] load_place_regions()");
     let mut place_regions = PlaceRegions::new();
-
     for (local, local_decl) in body.local_decls.iter_enumerated() {
         let ty = local_decl.ty;
         debug!("local: {:?} {:?}", local, ty);
         extract_region(&mut place_regions, local, ty);
     }
-
-    trace!("[exit] load_place_regions");
     Ok(place_regions)
 }

--- a/prusti-interface/src/environment/collect_closure_defs_visitor.rs
+++ b/prusti-interface/src/environment/collect_closure_defs_visitor.rs
@@ -38,6 +38,7 @@ impl<'env, 'tcx> Visitor<'tcx> for CollectClosureDefsVisitor<'env, 'tcx> {
         self.map
     }
 
+    #[tracing::instrument(level = "trace", skip(self, expr))]
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
         if let hir::ExprKind::Closure { .. } = expr.kind {
             if !has_spec_only_attr(self.env.query.get_local_attributes(expr.hir_id)) {

--- a/prusti-interface/src/environment/collect_prusti_spec_visitor.rs
+++ b/prusti-interface/src/environment/collect_prusti_spec_visitor.rs
@@ -55,6 +55,7 @@ impl<'tcx> CollectPrustiSpecVisitor<'tcx> {
 }
 
 impl<'tcx> Visitor<'tcx> for CollectPrustiSpecVisitor<'tcx> {
+    #[tracing::instrument(level = "trace", skip(self, item))]
     fn visit_item(&mut self, item: &hir::Item) {
         let attrs = self.env_query.get_local_attributes(item.owner_id.def_id);
         if has_spec_only_attr(attrs) || has_extern_spec_attr(attrs) {
@@ -80,6 +81,7 @@ impl<'tcx> Visitor<'tcx> for CollectPrustiSpecVisitor<'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(self, trait_item))]
     fn visit_trait_item(&mut self, trait_item: &hir::TraitItem) {
         let attrs = self
             .env_query
@@ -108,6 +110,7 @@ impl<'tcx> Visitor<'tcx> for CollectPrustiSpecVisitor<'tcx> {
         self.procedures.push(def_id);
     }
 
+    #[tracing::instrument(level = "trace", skip(self, impl_item))]
     fn visit_impl_item(&mut self, impl_item: &hir::ImplItem) {
         let attrs = self
             .env_query

--- a/prusti-interface/src/environment/dump_borrowck_info.rs
+++ b/prusti-interface/src/environment/dump_borrowck_info.rs
@@ -8,14 +8,9 @@ use super::Environment;
 
 use crate::data::ProcedureDefId;
 
-use log::trace;
-
+#[tracing::instrument(level = "debug", skip(env, procedures))]
 pub fn dump_borrowck_info(env: &Environment<'_>, procedures: &[ProcedureDefId]) {
-    trace!("[dump_borrowck_info] enter");
-
     for def_id in procedures {
         crate::environment::mir_dump::dump_mir_info(env, *def_id);
     }
-
-    trace!("[dump_borrowck_info] exit");
 }

--- a/prusti-interface/src/environment/loops.rs
+++ b/prusti-interface/src/environment/loops.rs
@@ -23,6 +23,7 @@ pub enum LoopAnalysisError {
 }
 
 /// Walk up the CFG graph an collect all basic blocks that belong to the loop body.
+#[tracing::instrument(level = "debug", skip(real_edges, body))]
 fn collect_loop_body(
     head: BasicBlockIndex,
     back_edge_source: BasicBlockIndex,
@@ -96,6 +97,7 @@ struct AccessCollector<'b, 'tcx> {
 }
 
 impl<'b, 'tcx> Visitor<'tcx> for AccessCollector<'b, 'tcx> {
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_place(
         &mut self,
         place: &mir::Place<'tcx>,
@@ -253,6 +255,7 @@ pub type ReadAndWriteLeaves<'tcx> = (
 );
 
 impl ProcedureLoops {
+    #[tracing::instrument(name = "ProcedureLoops::new", level = "trace", skip(mir, real_edges))]
     pub fn new<'a, 'tcx: 'a>(mir: &'a mir::Body<'tcx>, real_edges: &RealEdges) -> ProcedureLoops {
         let dominators = mir.basic_blocks.dominators();
 
@@ -500,6 +503,7 @@ impl ProcedureLoops {
 
     /// If `definitely_initalised_paths` is not `None`, returns only leaves that are
     /// definitely initialised.
+    #[tracing::instrument(level = "debug", skip(self, mir, definitely_initalised_paths))]
     pub fn compute_read_and_write_leaves<'a, 'tcx: 'a>(
         &self,
         loop_head: BasicBlockIndex,

--- a/prusti-interface/src/environment/mir_analyses/initialization.rs
+++ b/prusti-interface/src/environment/mir_analyses/initialization.rs
@@ -63,6 +63,7 @@ impl<T> AnalysisResult<T> {
 /// The result of the definitely initialized analysis.
 pub type DefinitelyInitializedAnalysisResult<'tcx> = AnalysisResult<PlaceSet<'tcx>>;
 
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn compute_definitely_initialized<'a, 'tcx: 'a>(
     def_id: DefId,
     body: &'a mir::Body<'tcx>,

--- a/prusti-interface/src/environment/mir_body/patch/compiler.rs
+++ b/prusti-interface/src/environment/mir_body/patch/compiler.rs
@@ -114,6 +114,7 @@ impl<'tcx> MirPatch<'tcx> {
         Local::new(index)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn new_block(&mut self, data: BasicBlockData<'tcx>) -> BasicBlock {
         let block = BasicBlock::new(self.patch_map.len());
         debug!("MirPatch: new_block: {:?}: {:?}", block, data);
@@ -122,14 +123,14 @@ impl<'tcx> MirPatch<'tcx> {
         block
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn patch_terminator(&mut self, block: BasicBlock, new: TerminatorKind<'tcx>) {
         assert!(self.patch_map[block].is_none());
-        debug!("MirPatch: patch_terminator({:?}, {:?})", block, new);
         self.patch_map[block] = Some(new);
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn add_statement(&mut self, loc: Location, stmt: StatementKind<'tcx>) {
-        debug!("MirPatch: add_statement({:?}, {:?})", loc, stmt);
         self.new_statements.push((loc, stmt));
     }
 
@@ -137,6 +138,7 @@ impl<'tcx> MirPatch<'tcx> {
         self.add_statement(loc, StatementKind::Assign(Box::new((place, rv))));
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn apply(self, body: &mut Body<'tcx>) {
         debug!(
             "MirPatch: {:?} new temps, starting from index {}: {:?}",

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -88,6 +88,7 @@ impl<'tcx> Environment<'tcx> {
     }
 
     /// Get ids of Rust procedures that are annotated with a Prusti specification
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn get_annotated_procedures_and_types(&self) -> (Vec<ProcedureDefId>, Vec<ty::Ty<'tcx>>) {
         let mut visitor = CollectPrustiSpecVisitor::new(self);
         visitor.visit_all_item_likes();

--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -38,8 +38,8 @@ pub struct Procedure<'tcx> {
 impl<'tcx> Procedure<'tcx> {
     /// Builds an implementation of the Procedure interface, given a typing context and the
     /// identifier of a procedure
+    #[tracing::instrument(name = "Procedure::new", level = "debug", skip(env))]
     pub fn new(env: &Environment<'tcx>, proc_def_id: ProcedureDefId) -> Self {
-        trace!("Encoding procedure {proc_def_id:?}");
         let mir = env
             .body
             .get_impure_fn_body_identity(proc_def_id.expect_local());
@@ -309,6 +309,7 @@ struct BasicBlockNode {
     predecessors: FxHashSet<BasicBlock>,
 }
 
+#[tracing::instrument(level = "debug", skip_all)]
 fn _blocks_definitely_leading_to<'a>(
     bb_graph: &'a FxHashMap<BasicBlock, BasicBlockNode>,
     target: BasicBlock,
@@ -345,6 +346,7 @@ fn blocks_dominated_by(mir: &Body, dominator: BasicBlock) -> FxHashSet<BasicBloc
     blocks
 }
 
+#[tracing::instrument(level = "trace", skip_all)]
 fn get_nonspec_basic_blocks(
     env_query: EnvQuery,
     bb_graph: FxHashMap<BasicBlock, BasicBlockNode>,

--- a/prusti-interface/src/environment/query.rs
+++ b/prusti-interface/src/environment/query.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::data::ProcedureDefId;
 use log::debug;
 use prusti_rustc_interface::{
@@ -126,7 +128,11 @@ impl<'tcx> EnvQuery<'tcx> {
 
     /// If the given DefId describes an item belonging to a trait, returns the DefId
     /// of the trait that the trait item belongs to; otherwise, returns None.
-    pub fn get_trait_of_item(self, def_id: impl IntoParam<ProcedureDefId>) -> Option<DefId> {
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn get_trait_of_item(
+        self,
+        def_id: impl IntoParam<ProcedureDefId> + Debug,
+    ) -> Option<DefId> {
         self.tcx.trait_of_item(def_id.into_param())
     }
 
@@ -263,9 +269,10 @@ impl<'tcx> EnvQuery<'tcx> {
 
     /// Given some procedure `proc_def_id` which is called, this method returns the actual method which will be executed when `proc_def_id` is defined on a trait.
     /// Returns `None` if this method can not be found or the provided `proc_def_id` is no trait item.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn find_impl_of_trait_method_call(
         self,
-        proc_def_id: impl IntoParam<ProcedureDefId>,
+        proc_def_id: impl IntoParam<ProcedureDefId> + Debug,
         substs: SubstsRef<'tcx>,
     ) -> Option<ProcedureDefId> {
         // TODO(tymap): remove this method?
@@ -415,13 +422,12 @@ impl<'tcx> EnvQuery<'tcx> {
     /// The `param_env` should be passed as a `ProcedureDefId` which is
     /// then used to calculate the param env; i.e. the set of
     /// where-clauses that are in scope at this particular point.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn evaluate_predicate(
         self,
         predicate: ty::Predicate<'tcx>,
-        param_env: impl IntoParamTcx<'tcx, ParamEnv<'tcx>>,
+        param_env: impl IntoParamTcx<'tcx, ParamEnv<'tcx>> + Debug,
     ) -> bool {
-        debug!("Evaluating predicate {:?}", predicate);
-
         let obligation = Obligation::new(
             self.tcx,
             ObligationCause::dummy(),
@@ -441,10 +447,11 @@ impl<'tcx> EnvQuery<'tcx> {
     /// The `param_env` should be passed as a `ProcedureDefId` which is
     /// then used to calculate the param env; i.e. the set of
     /// where-clauses that are in scope at this particular point.
-    pub fn resolve_assoc_types<T: ty::TypeFoldable<'tcx> + std::fmt::Debug + Copy>(
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub fn resolve_assoc_types<T: ty::TypeFoldable<'tcx> + Debug + Copy>(
         self,
         normalizable: T,
-        param_env: impl IntoParamTcx<'tcx, ParamEnv<'tcx>>,
+        param_env: impl IntoParamTcx<'tcx, ParamEnv<'tcx>> + Debug,
     ) -> T {
         let param_env = param_env.into_param(self.tcx);
         let norm_res = self

--- a/prusti-interface/src/specs/checker/mod.rs
+++ b/prusti-interface/src/specs/checker/mod.rs
@@ -36,6 +36,7 @@ impl<'tcx> SpecChecker<'tcx> {
     }
 
     /// Executes all checks and emits errors
+    #[tracing::instrument(name = "SpecChecker::check", level = "debug", skip(self, env))]
     pub fn check(&self, env: &Environment<'tcx>) {
         for check in self.checks.iter() {
             let errors = check.check(env);

--- a/prusti-interface/src/specs/checker/predicate_checks.rs
+++ b/prusti-interface/src/specs/checker/predicate_checks.rs
@@ -17,6 +17,11 @@ use prusti_rustc_interface::{
 pub struct IllegalPredicateUsagesChecker;
 
 impl<'tcx> SpecCheckerStrategy<'tcx> for IllegalPredicateUsagesChecker {
+    #[tracing::instrument(
+        name = "IllegalPredicateUsagesChecker::check",
+        level = "debug",
+        skip(self, env)
+    )]
     fn check(&self, env: &Environment<'tcx>) -> Vec<PrustiError> {
         let collected_predicates = self.collect_predicates(env.query);
         debug!("Predicate funcs: {:?}", collected_predicates.predicates);

--- a/prusti-interface/src/specs/checker/type_model_checks.rs
+++ b/prusti-interface/src/specs/checker/type_model_checks.rs
@@ -21,6 +21,11 @@ use rustc_hash::FxHashMap;
 pub struct IllegalModelUsagesChecker;
 
 impl<'tcx> SpecCheckerStrategy<'tcx> for IllegalModelUsagesChecker {
+    #[tracing::instrument(
+        name = "IllegalModelUsagesChecker::check",
+        level = "debug",
+        skip(self, env)
+    )]
     fn check(&self, env: &Environment<'tcx>) -> Vec<PrustiError> {
         let mut visit = ModelUsageVisitor {
             env_query: env.query,
@@ -91,6 +96,11 @@ impl<'tcx> NonSpecExprVisitor<'tcx> for ModelUsageVisitor<'tcx> {
 pub struct ModelDefinedOnTypeWithoutFields;
 
 impl<'tcx> SpecCheckerStrategy<'tcx> for ModelDefinedOnTypeWithoutFields {
+    #[tracing::instrument(
+        name = "ModelDefinedOnTypeWithoutFields::check",
+        level = "debug",
+        skip(self, env)
+    )]
     fn check(&self, env: &Environment<'tcx>) -> Vec<PrustiError> {
         let mut collect = CollectModelledTypes {
             env_query: env.query,

--- a/prusti-interface/src/specs/checker/version_checks.rs
+++ b/prusti-interface/src/specs/checker/version_checks.rs
@@ -10,6 +10,11 @@ use prusti_rustc_interface::{ast::ast::Attribute, errors::MultiSpan, hir, middle
 pub struct MismatchedVersionsChecker;
 
 impl<'tcx> SpecCheckerStrategy<'tcx> for MismatchedVersionsChecker {
+    #[tracing::instrument(
+        name = "MismatchedVersionsChecker::check",
+        level = "debug",
+        skip(self, env)
+    )]
     fn check(&self, env: &Environment<'tcx>) -> Vec<PrustiError> {
         let mut check_version = CheckVersionVisitor {
             env_query: env.query,

--- a/prusti-interface/src/specs/cross_crate.rs
+++ b/prusti-interface/src/specs/cross_crate.rs
@@ -17,11 +17,13 @@ use super::{decoder::DefSpecsDecoder, encoder::DefSpecsEncoder};
 pub struct CrossCrateSpecs;
 
 impl CrossCrateSpecs {
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn import_export_cross_crate(env: &mut Environment, def_spec: &mut DefSpecificationMap) {
         Self::export_specs(env, def_spec);
         Self::import_specs(env, def_spec);
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn export_specs(env: &Environment, def_spec: &DefSpecificationMap) {
         let outputs = env.tcx().output_filenames(());
         // If we run `rustc` without the `--out-dir` flag set, then don't export specs
@@ -44,6 +46,7 @@ impl CrossCrateSpecs {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn import_specs(env: &mut Environment, def_spec: &mut DefSpecificationMap) {
         let cstore = CStore::from_tcx(env.tcx());
         // TODO: atm one needs to write `extern crate extern_spec_lib` to import the specs
@@ -92,6 +95,7 @@ impl CrossCrateSpecs {
         file.write(&encoder.into_inner())
     }
 
+    #[tracing::instrument(level = "debug", skip(env, def_spec))]
     fn import_from_file(
         env: &mut Environment,
         def_spec: &mut DefSpecificationMap,

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -103,6 +103,13 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub fn collect_specs(&mut self, hir: Map<'tcx>) {
+        hir.walk_toplevel_module(self);
+        hir.walk_attributes(self);
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn build_def_specs(&mut self) -> typed::DefSpecificationMap {
         let mut def_spec = typed::DefSpecificationMap::new();
         self.determine_procedure_specs(&mut def_spec);
@@ -310,6 +317,7 @@ pub fn is_spec_fn(tcx: ty::TyCtxt, def_id: DefId) -> bool {
     read_prusti_attr("spec_id", attrs).is_some()
 }
 
+#[tracing::instrument(level = "trace")]
 fn get_procedure_spec_ids(def_id: DefId, attrs: &[ast::Attribute]) -> Option<ProcedureSpecRefs> {
     let mut spec_id_refs = vec![];
 

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -6,7 +6,6 @@
 
 //! Various helper functions for working with `mir::Place`.
 
-use log::trace;
 use prusti_rustc_interface::{
     ast::ast,
     data_structures::fx::FxHashSet,
@@ -86,6 +85,7 @@ pub fn try_pop_deref<'tcx>(tcx: TyCtxt<'tcx>, place: mir::Place<'tcx>) -> Option
 /// `{x.g, x.h, x.f.f, x.f.h, x.f.g.f, x.f.g.g, x.f.g.h}` and
 /// subtracting `{x.f.g.h}` from it, which results into `{x.g, x.h,
 /// x.f.f, x.f.h, x.f.g.f, x.f.g.g}`.
+#[tracing::instrument(level = "debug", skip(mir, tcx), ret)]
 pub fn expand<'tcx>(
     mir: &mir::Body<'tcx>,
     tcx: TyCtxt<'tcx>,
@@ -96,23 +96,12 @@ pub fn expand<'tcx>(
         is_prefix(subtrahend, minuend),
         "The minuend must be the prefix of the subtrahend."
     );
-    trace!(
-        "[enter] expand minuend={:?} subtrahend={:?}",
-        minuend,
-        subtrahend
-    );
     let mut place_set = Vec::new();
     while minuend.projection.len() < subtrahend.projection.len() {
         let (new_minuend, places) = expand_one_level(mir, tcx, minuend, subtrahend);
         minuend = new_minuend;
         place_set.extend(places);
     }
-    trace!(
-        "[exit] expand minuend={:?} subtrahend={:?} place_set={:?}",
-        minuend,
-        subtrahend,
-        place_set
-    );
     place_set
 }
 

--- a/prusti-server/Cargo.toml
+++ b/prusti-server/Cargo.toml
@@ -21,6 +21,7 @@ log = { version = "0.4", features = ["release_max_level_info"] }
 viper = { path = "../viper" }
 prusti-common = { path = "../prusti-common" }
 prusti-utils = { path = "../prusti-utils" }
+tracing = { path = "../tracing" }
 env_logger = "0.10"
 clap = { version = "4.0", features = ["derive"] }
 bincode = "1.0"

--- a/prusti-server/src/process_verification.rs
+++ b/prusti-server/src/process_verification.rs
@@ -17,6 +17,7 @@ use viper::{
     smt_manager::SmtManager, Cache, VerificationBackend, VerificationContext, VerificationResult,
 };
 
+#[tracing::instrument(level = "debug", skip_all, fields(program = %request.program.get_name()))]
 pub fn process_verification_request<'v, 't: 'v>(
     verification_context: &'v VerificationContext<'t>,
     mut request: VerificationRequest,

--- a/prusti-utils/src/config.rs
+++ b/prusti-utils/src/config.rs
@@ -86,6 +86,7 @@ lazy_static::lazy_static! {
         settings.set_default("log", "").unwrap();
         settings.set_default("log_style", "auto").unwrap();
         settings.set_default("log_dir", "log").unwrap();
+        settings.set_default("log_tracing", true).unwrap();
         settings.set_default("cache_path", "").unwrap();
         settings.set_default("dump_debug_info", false).unwrap();
         settings.set_default("dump_debug_info_during_fold", false).unwrap();
@@ -437,6 +438,11 @@ pub fn log_style() -> String {
 /// Path to directory in which log files and dumped output will be stored.
 pub fn log_dir() -> PathBuf {
     PathBuf::from(read_setting::<String>("log_dir"))
+}
+
+/// When enabled, trace using tracing_chrome crate.
+pub fn log_tracing() -> bool {
+    read_setting("log_tracing")
 }
 
 /// Path to a cache file, where verification cache will be loaded from and

--- a/prusti-viper/Cargo.toml
+++ b/prusti-viper/Cargo.toml
@@ -26,6 +26,7 @@ backtrace = "0.3"
 rustc-hash = "1.1.0"
 derive_more = "0.99.16"
 itertools = "0.10.3"
+tracing = { path = "../tracing" }
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use ::log::{info, debug, trace};
+use ::log::{info, debug};
 use prusti_common::utils::identifiers::encode_identifier;
 use vir_crate::common::check_mode::CheckMode;
 use crate::encoder::builtin_encoder::BuiltinEncoder;
@@ -26,6 +26,7 @@ use prusti_rustc_interface::hir::def_id::DefId;
 use prusti_rustc_interface::middle::mir;
 use prusti_rustc_interface::middle::ty;
 use std::cell::{Cell, RefCell, RefMut, Ref};
+use std::fmt::Debug;
 use rustc_hash::{FxHashSet, FxHashMap};
 use std::io::Write;
 use std::rc::Rc;
@@ -214,6 +215,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(name = "Encoder::initialize", level = "debug", skip(self))]
     fn initialize(&mut self) -> EncodingResult<()> {
         // These are used in optimization passes
         self.encode_builtin_method_def(BuiltinMethodKind::HavocBool)?;
@@ -251,8 +253,8 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(in crate::encoder) fn register_encoding_error(&self, encoding_error: SpannedEncodingError) {
-        debug!("Encoding error: {:?}", encoding_error);
         let prusti_error: PrustiError = encoding_error.into();
         if prusti_error.is_error() {
             self.encoding_errors_counter.borrow_mut().add_assign(1);
@@ -422,8 +424,8 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         }))
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn encode_builtin_domain(&self, domain_kind: BuiltinDomainKind) -> EncodingResult<vir::Domain> {
-        trace!("encode_builtin_domain({:?})", domain_kind);
         if !self.builtin_domains.borrow().contains_key(&domain_kind) {
             let builtin_encoder = BuiltinEncoder::new(self);
             let domain = builtin_encoder.encode_builtin_domain(domain_kind)?;
@@ -434,8 +436,8 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         Ok(self.builtin_domains.borrow()[&domain_kind].clone())
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn encode_builtin_domain_type(&self, domain_kind: BuiltinDomainKind) -> EncodingResult<vir::Type> {
-        trace!("encode_builtin_domain_type({:?})", domain_kind);
         // Also encode the definition, if it's not already under construction.
         let mut domains_in_progress = self.builtin_domains_in_progress.borrow_mut();
         if !domains_in_progress.contains(&domain_kind) {
@@ -449,8 +451,8 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         builtin_encoder.encode_builtin_domain_type(domain_kind)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn encode_builtin_method_def(&self, method_kind: BuiltinMethodKind) -> EncodingResult<vir::BodylessMethod> {
-        trace!("encode_builtin_method_def({:?})", method_kind);
         if !self.builtin_methods.borrow().contains_key(&method_kind) {
             let builtin_encoder = BuiltinEncoder::new(self);
             let method = builtin_encoder.encode_builtin_method_def(method_kind)?;
@@ -462,18 +464,18 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         Ok(self.builtin_methods.borrow()[&method_kind].clone())
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn encode_builtin_method_use(&self, method_kind: BuiltinMethodKind) -> EncodingResult<String> {
-        trace!("encode_builtin_method_use({:?})", method_kind);
         // Trigger encoding of definition
         self.encode_builtin_method_def(method_kind)?;
         let builtin_encoder = BuiltinEncoder::new(self);
         Ok(builtin_encoder.encode_builtin_method_name(method_kind))
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn encode_cast_function_use(&self, src_ty: ty::Ty<'tcx>, dst_ty: ty::Ty<'tcx>)
         -> EncodingResult<String>
     {
-        trace!("encode_cast_function_use(src_ty={:?}, dst_ty={:?})", src_ty, dst_ty);
         let function_name = format!("builtin$cast${src_ty}${dst_ty}");
         if !self.type_cast_functions.borrow().contains_key(&(src_ty, dst_ty)) {
             let arg = vir_local!{ number: {self.encode_snapshot_type(src_ty)?} };
@@ -496,10 +498,10 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         Ok(function_name)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn encode_unsize_function_use(&self, src_ty: ty::Ty<'tcx>, dst_ty: ty::Ty<'tcx>)
         -> EncodingResult<String>
     {
-        trace!("encode_unsize_function_use(src_ty={:?}, dst_ty={:?})", src_ty, dst_ty);
         // at some point we may want to add support for other types of unsizing calls?
         assert!(matches!(src_ty.kind(), ty::TyKind::Array(..) | ty::TyKind::Slice(..)));
         assert!(matches!(dst_ty.kind(), ty::TyKind::Array(..) | ty::TyKind::Slice(..)));
@@ -547,8 +549,8 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
 
     /// This encodes the Rust function as a Viper method for verification. It
     /// does this also for pure functions.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn encode_procedure(&self, def_id: ProcedureDefId) -> SpannedEncodingResult<()> {
-        debug!("encode_procedure({:?})", def_id);
         assert!(
             !self.is_trusted(def_id, None),
             "procedure is marked as trusted: {def_id:?}"
@@ -599,12 +601,12 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self), ret)]
     pub fn encode_const_expr(
         &self,
         ty: ty::Ty<'tcx>,
         value: mir::ConstantKind<'tcx>
     ) -> EncodingResult<vir::Expr> {
-        trace!("encode_const_expr {:?}", value);
         let scalar_value = self.const_eval_intlike(value)?;
 
         let expr = match ty.kind() {
@@ -646,13 +648,11 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
                 error_unsupported!("unsupported constant type {:?}", ty.kind());
             }
         };
-        debug!("encode_const_expr {:?} --> {:?}", value, expr);
         Ok(expr)
     }
 
+    #[tracing::instrument(level = "debug", skip(self), ret)]
     pub fn encode_int_cast(&self, value: u128, ty: ty::Ty<'tcx>) -> vir::Expr {
-        trace!("encode_int_cast {:?} as {:?}", value, ty);
-
         let expr = match ty.kind() {
             ty::TyKind::Bool => (value != 0).into(),
             ty::TyKind::Int(ty::IntTy::I8) => (value as i8).into(),
@@ -670,7 +670,6 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
             ty::TyKind::Char => value.into(),
             ref x => unimplemented!("{:?}", x),
         };
-        debug!("encode_int_cast {:?} as {:?} --> {:?}", value, ty, expr);
         expr
     }
 
@@ -698,6 +697,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn process_encoding_queue(&mut self) {
         if let Err(error) = self.initialize() {
             panic!("The initialization of the encoder failed with the error: {error:?}");
@@ -802,7 +802,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         }
     }
 
-    pub fn intern_viper_identifier<S: AsRef<str>>(&self, full_name: S, short_name: S) -> String {
+    pub fn intern_viper_identifier<S: AsRef<str> + Debug>(&self, full_name: S, short_name: S) -> String {
         let result = if config::disable_name_mangling() {
             short_name.as_ref().to_string()
         } else if config::intern_names() {

--- a/prusti-viper/src/encoder/errors/encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/encoding_error.rs
@@ -21,6 +21,7 @@ pub type EncodingResult<T> = Result<T, EncodingError>;
 
 impl EncodingError {
     /// Usage of an unsupported Rust feature (e.g. dereferencing raw pointers)
+    #[tracing::instrument(level = "debug", skip(message))]
     pub fn unsupported<M: ToString>(message: M) -> Self {
         if cfg!(debug_assertions) {
             debug!("Constructing unsupported error at:\n{:?}", Backtrace::new());
@@ -29,6 +30,7 @@ impl EncodingError {
     }
 
     /// An incorrect usage of Prusti (e.g. call an impure function in a contract)
+    #[tracing::instrument(level = "debug", skip(message))]
     pub fn incorrect<M: ToString>(message: M) -> Self {
         if cfg!(debug_assertions) {
             debug!("Constructing incorrect error at:\n{:?}", Backtrace::new());
@@ -37,6 +39,7 @@ impl EncodingError {
     }
 
     /// An internal error of Prusti (e.g. failure of the fold-unfold)
+    #[tracing::instrument(level = "error", skip(message))]
     pub fn internal<M: ToString>(message: M) -> Self {
         if cfg!(debug_assertions) {
             error!("Constructing internal error at:\n{:?}", Backtrace::new());

--- a/prusti-viper/src/encoder/errors/error_manager.rs
+++ b/prusti-viper/src/encoder/errors/error_manager.rs
@@ -4,13 +4,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::fmt::Debug;
+
 use vir_crate::polymorphic::Position;
 use rustc_hash::FxHashMap;
 use prusti_rustc_interface::span::source_map::SourceMap;
 use prusti_rustc_interface::errors::MultiSpan;
 use viper::VerificationError;
 use prusti_interface::PrustiError;
-use log::{debug, trace};
+use log::debug;
 use super::PositionManager;
 use prusti_interface::data::ProcedureDefId;
 
@@ -208,7 +210,7 @@ impl<'tcx> ErrorManager<'tcx> {
     }
 
     /// Register a new VIR position.
-    pub fn register_span<T: Into<MultiSpan>>(&mut self, def_id: ProcedureDefId, span: T) -> Position {
+    pub fn register_span<T: Into<MultiSpan> + Debug>(&mut self, def_id: ProcedureDefId, span: T) -> Position {
         self.position_manager.register_span(def_id, span)
     }
 
@@ -218,8 +220,8 @@ impl<'tcx> ErrorManager<'tcx> {
     }
 
     /// Register the ErrorCtxt on an existing VIR position.
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn set_error(&mut self, pos: Position, error_ctxt: ErrorCtxt) {
-        trace!("Register error {:?} at position id {:?}", error_ctxt, pos.id());
         assert_ne!(pos, Position::default(), "Trying to register an error on a default position");
         if let Some(existing_error_ctxt) = self.error_contexts.get(&pos.id()) {
             debug_assert_eq!(
@@ -248,7 +250,7 @@ impl<'tcx> ErrorManager<'tcx> {
 
     /// Register a new VIR position with the given ErrorCtxt.
     /// Equivalent to calling `set_error` on the output of `register_span`.
-    pub fn register_error<T: Into<MultiSpan>>(&mut self, span: T, error_ctxt: ErrorCtxt, def_id: ProcedureDefId) -> Position {
+    pub fn register_error<T: Into<MultiSpan> + Debug>(&mut self, span: T, error_ctxt: ErrorCtxt, def_id: ProcedureDefId) -> Position {
         let pos = self.register_span(def_id, span);
         self.set_error(pos, error_ctxt);
         pos
@@ -260,8 +262,8 @@ impl<'tcx> ErrorManager<'tcx> {
             .and_then(|id| self.position_manager.def_id.get(&id).copied())
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn translate_verification_error(&self, ver_error: &VerificationError) -> PrustiError {
-        debug!("Verification error: {:?}", ver_error);
         let opt_pos_id: Option<u64> = match ver_error.offending_pos_id {
             Some(ref viper_pos_id) => {
                 match viper_pos_id.parse() {
@@ -346,6 +348,7 @@ impl<'tcx> ErrorManager<'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn translate_verification_error_with_context(
         &self,
         ver_error: &VerificationError,

--- a/prusti-viper/src/encoder/errors/position_manager.rs
+++ b/prusti-viper/src/encoder/errors/position_manager.rs
@@ -4,11 +4,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::fmt::Debug;
+
 use vir_crate::polymorphic::Position;
 use rustc_hash::FxHashMap;
 use prusti_rustc_interface::span::source_map::SourceMap;
 use prusti_rustc_interface::errors::MultiSpan;
-use log::{debug, trace};
+use log::debug;
 use prusti_interface::data::ProcedureDefId;
 
 /// Mapping from VIR positions to the source code that generated them.
@@ -35,11 +37,11 @@ impl<'tcx> PositionManager<'tcx>
         }
     }
 
-    pub fn register_span<T: Into<MultiSpan>>(&mut self, def_id: ProcedureDefId, span: T) -> Position {
+    #[tracing::instrument(level = "trace", skip(self), ret)]
+    pub fn register_span<T: Into<MultiSpan> + Debug>(&mut self, def_id: ProcedureDefId, span: T) -> Position {
         let span = span.into();
         let pos_id = self.next_pos_id;
         self.next_pos_id += 1;
-        trace!("Register position id {} for span {:?} in {:?}, ", pos_id, span, def_id);
 
         let pos = if let Some(primary_span) = span.primary_span() {
             let lines_info_res = self

--- a/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
+++ b/prusti-viper/src/encoder/errors/spanned_encoding_error.rs
@@ -56,6 +56,7 @@ impl SpannedEncodingError {
     }
 
     /// Usage of an unsupported Rust feature (e.g. dereferencing raw pointers)
+    #[tracing::instrument(level = "debug", skip(message, span))]
     pub fn unsupported<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
         if cfg!(debug_assertions) {
             debug!("Constructing unsupported error at:\n{:?}", Backtrace::new());
@@ -67,6 +68,7 @@ impl SpannedEncodingError {
     }
 
     /// An incorrect usage of Prusti (e.g. call an impure function in a contract)
+    #[tracing::instrument(level = "debug", skip(message, span))]
     pub fn incorrect<M: ToString, S: Into<MultiSpan>>(message: M, span: S) -> Self {
         if cfg!(debug_assertions) {
             debug!("Constructing incorrect error at:\n{:?}", Backtrace::new());

--- a/prusti-viper/src/encoder/foldunfold/footprint.rs
+++ b/prusti-viper/src/encoder/foldunfold/footprint.rs
@@ -9,7 +9,6 @@ use super::{
     Predicates,
 };
 use crate::encoder::foldunfold::perm::{Perm::*, *};
-use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use vir_crate::polymorphic::{self as vir, PermAmount};
@@ -21,9 +20,9 @@ pub trait ExprFootprintGetter {
 }
 
 impl ExprFootprintGetter for vir::Expr {
+    #[tracing::instrument(level = "trace", skip(self, predicates), fields(self = %self), ret)]
     fn get_footprint(&self, predicates: &Predicates) -> FxHashSet<Perm> {
-        trace!("get_footprint {}", self);
-        let res = match self {
+        match self {
             vir::Expr::Local(_)
             | vir::Expr::Field(_)
             | vir::Expr::Variant(_)
@@ -177,9 +176,7 @@ impl ExprFootprintGetter for vir::Expr {
             vir::Expr::SnapApp(vir::SnapApp { ref base, .. }) => base.get_footprint(predicates),
 
             vir::Expr::Cast(vir::Cast { ref base, .. }) => base.get_footprint(predicates),
-        };
-        trace!("get_footprint {} = {:?}", self, res);
-        res
+        }
     }
 }
 

--- a/prusti-viper/src/encoder/foldunfold/log.rs
+++ b/prusti-viper/src/encoder/foldunfold/log.rs
@@ -58,12 +58,8 @@ impl EventLog {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(block_index = %block_index, action = %action))]
     pub fn log_prejoin_action(&mut self, block_index: vir::CfgBlockIndex, action: Action) {
-        trace!(
-            "[enter] log_prejoin_action(block_index={}, action={})",
-            block_index,
-            action
-        );
         let entry_rc = self
             .prejoin_actions
             .entry(block_index)
@@ -109,11 +105,11 @@ impl EventLog {
         self.id_generator += 1;
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn get_duplicated_read_permissions(
         &self,
         borrow: vir::borrows::Borrow,
     ) -> Vec<(vir::Expr, vir::Expr)> {
-        trace!("[enter] get_duplicated_read_permissions({:?})", borrow);
         let mut result = self
             .duplicated_reads
             .get(&borrow)
@@ -149,7 +145,7 @@ impl EventLog {
             },
         );
         trace!(
-            "[enter] get_duplicated_read_permissions({:?}) = {}",
+            "[exit] get_duplicated_read_permissions({:?}) = {}",
             borrow,
             result
                 .iter()

--- a/prusti-viper/src/encoder/foldunfold/perm.rs
+++ b/prusti-viper/src/encoder/foldunfold/perm.rs
@@ -4,7 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::fmt;
 use vir_crate::polymorphic::{Expr, PermAmount, Position, Type};
@@ -76,8 +75,8 @@ impl Perm {
         self.get_place().has_proper_prefix(other)
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(self = %self, new_perm = %new_perm))]
     pub fn init_perm_amount(self, new_perm: PermAmount) -> Self {
-        trace!("[enter] init_perm_amount({}, {})", self, new_perm);
         assert!(new_perm.is_valid_for_specs());
         match self {
             Perm::Acc(_expr, PermAmount::Remaining) => unreachable!(),
@@ -223,12 +222,8 @@ fn place_perm_difference(
 }
 
 /// Set difference that takes into account that removing `x.f` also removes any `x.f.g.h`
+#[tracing::instrument(level = "trace")]
 pub fn perm_difference(left: FxHashSet<Perm>, right: FxHashSet<Perm>) -> FxHashSet<Perm> {
-    trace!(
-        "[enter] perm_difference(left={:?}, right={:?})",
-        left,
-        right
-    );
     let left_acc = left.iter().filter(|x| x.is_acc()).cloned();
     let left_pred = left.iter().filter(|x| x.is_pred()).cloned();
     let right_acc = right.iter().filter(|x| x.is_acc()).cloned();

--- a/prusti-viper/src/encoder/foldunfold/semantics.rs
+++ b/prusti-viper/src/encoder/foldunfold/semantics.rs
@@ -48,12 +48,12 @@ pub trait ApplyOnState {
 }
 
 impl ApplyOnState for vir::Stmt {
+    #[tracing::instrument(level = "trace", skip_all, fields(self = %self))]
     fn apply_on_state(
         &self,
         state: &mut State,
         predicates: &Predicates,
     ) -> Result<(), FoldUnfoldError> {
-        trace!("apply_on_state '{}'", self);
         trace!("State acc before {{\n{}\n}}", state.display_acc());
         trace!("State pred before {{\n{}\n}}", state.display_pred());
         trace!("State moved before {{\n{}\n}}", state.display_moved());

--- a/prusti-viper/src/encoder/foldunfold/state.rs
+++ b/prusti-viper/src/encoder/foldunfold/state.rs
@@ -44,6 +44,7 @@ impl State {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn check_consistency(&self) {
         // Skip consistency checks in release mode
         if cfg!(not(debug_assertions)) {
@@ -340,12 +341,12 @@ impl State {
         info.join(",\n")
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(place = %place, perm = %perm))]
     pub fn insert_acc(
         &mut self,
         place: vir::Expr,
         perm: PermAmount,
     ) -> Result<(), FoldUnfoldError> {
-        trace!("insert_acc {}, {}", place, perm);
         if self.acc.contains_key(&place) {
             let new_perm = self.acc[&place].add(perm)?;
             assert!(
@@ -371,12 +372,12 @@ impl State {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(place = %place, perm = %perm))]
     pub fn insert_pred(
         &mut self,
         place: vir::Expr,
         perm: PermAmount,
     ) -> Result<(), FoldUnfoldError> {
-        trace!("insert_pred {}, {}", place, perm);
         if self.pred.contains_key(&place) {
             let new_perm = self.pred[&place].add(perm)?;
             assert!(
@@ -461,12 +462,12 @@ impl State {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(place = %place, perm = %perm))]
     pub fn remove_pred(
         &mut self,
         place: &vir::Expr,
         perm: PermAmount,
     ) -> Result<(), FoldUnfoldError> {
-        trace!("remove_pred {}, {}", place, perm);
         if !self.pred.contains_key(place) {
             return Err(FoldUnfoldError::FailedToRemovePred(place.clone(), perm));
         }
@@ -514,31 +515,29 @@ impl State {
     /// ```
     /// In such a case, the function keeps the most generic variant of
     /// permissions.
+    #[tracing::instrument(level = "trace", skip_all, fields(item = %item))]
     pub fn restore_dropped_perm(&mut self, item: Perm) -> Result<(), FoldUnfoldError> {
-        trace!("[enter] restore_dropped_perm item={}", item);
         for moved_place in &self.moved {
             trace!("  moved_place={}", moved_place);
         }
         match item {
             Perm::Acc(place, perm) => {
                 self.remove_moved_matching(|p| place.has_prefix(p));
-                self.restore_acc(place, perm)?;
+                self.restore_acc(place, perm)
             }
             Perm::Pred(place, perm) => {
                 self.remove_moved_matching(|p| place.has_prefix(p));
-                self.restore_pred(place, perm)?;
+                self.restore_pred(place, perm)
             }
-        };
-        trace!("[exit] restore_dropped_perm");
-        Ok(())
+        }
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(acc_place = %acc_place, perm = %perm))]
     fn restore_acc(
         &mut self,
         acc_place: vir::Expr,
         mut perm: PermAmount,
     ) -> Result<(), FoldUnfoldError> {
-        trace!("restore_acc {}, {}", acc_place, perm);
         if let Some(curr_perm_amount) = self.acc.get(&acc_place) {
             perm = perm.add(*curr_perm_amount)?;
         }
@@ -558,12 +557,12 @@ impl State {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(pred_place = %pred_place, perm = %perm))]
     fn restore_pred(
         &mut self,
         pred_place: vir::Expr,
         mut perm: PermAmount,
     ) -> Result<(), FoldUnfoldError> {
-        trace!("restore_pred {}, {}", pred_place, perm);
         if let Some(curr_perm_amount) = self.pred.get(&pred_place) {
             perm = perm.add(*curr_perm_amount)?;
             //trace!("restore_pred {}: ignored (state already contains place)", pred_place);
@@ -587,16 +586,15 @@ impl State {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn restore_dropped_perms<I>(&mut self, items: I) -> Result<(), FoldUnfoldError>
     where
         I: Iterator<Item = Perm>,
     {
-        trace!("[enter] restore_dropped_perms");
         for item in items {
             self.restore_dropped_perm(item)?;
         }
         self.check_consistency();
-        trace!("[exit] restore_dropped_perms");
         Ok(())
     }
 
@@ -620,8 +618,8 @@ impl State {
         exprs.into_iter().conjoin()
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn begin_frame(&mut self) {
-        trace!("begin_frame");
         trace!(
             "Before: {} frames are on the stack",
             self.framing_stack.len()
@@ -644,8 +642,8 @@ impl State {
         );
     }
 
+    #[tracing::instrument(level = "debug")]
     pub fn end_frame(&mut self) -> Result<(), FoldUnfoldError> {
-        trace!("end_frame");
         trace!(
             "Before: {} frames are on the stack",
             self.framing_stack.len()

--- a/prusti-viper/src/encoder/high/builtin_functions/interface.rs
+++ b/prusti-viper/src/encoder/high/builtin_functions/interface.rs
@@ -5,7 +5,6 @@ use crate::encoder::{
     high::builtin_functions::encoder::encode_builtin_function_def,
     mir::pure::PureFunctionEncoderInterface,
 };
-use log::trace;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -110,11 +109,11 @@ trait HighBuiltinFunctionEncoderInterfacePrivate<'tcx> {
 impl<'v, 'tcx: 'v> HighBuiltinFunctionEncoderInterfacePrivate<'tcx>
     for crate::encoder::encoder::Encoder<'v, 'tcx>
 {
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_builtin_function_def_high(
         &self,
         function_kind: BuiltinFunctionHighKind,
     ) -> SpannedEncodingResult<()> {
-        trace!("encode_builtin_function_def_high({:?})", function_kind);
         if !self
             .high_builtin_function_encoder_state
             .builtin_functions_high
@@ -139,8 +138,8 @@ impl<'v, 'tcx: 'v> HighBuiltinFunctionEncoderInterfacePrivate<'tcx>
     ) -> (String, Vec<vir_high::Type>) {
         encode_builtin_function_name_with_type_args(function)
     }
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_builtin_function_def(&self, function_kind: BuiltinFunctionKind) {
-        trace!("encode_builtin_function_def({:?})", function_kind);
         if !self
             .high_builtin_function_encoder_state
             .builtin_functions
@@ -176,11 +175,11 @@ pub(crate) trait HighBuiltinFunctionEncoderInterface<'tcx> {
 impl<'v, 'tcx: 'v> HighBuiltinFunctionEncoderInterface<'tcx>
     for crate::encoder::encoder::Encoder<'v, 'tcx>
 {
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_builtin_function_use_high(
         &self,
         function_kind: BuiltinFunctionHighKind,
     ) -> SpannedEncodingResult<(String, Vec<vir_high::Type>)> {
-        trace!("encode_builtin_function_use_high({:?})", function_kind);
         if !self
             .high_builtin_function_encoder_state
             .builtin_functions_high
@@ -192,11 +191,11 @@ impl<'v, 'tcx: 'v> HighBuiltinFunctionEncoderInterface<'tcx>
         }
         Ok(self.encode_builtin_function_name_with_type_args_high(&function_kind))
     }
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_builtin_function_use(
         &self,
         function_kind: BuiltinFunctionKind,
     ) -> (String, Vec<vir_poly::Type>) {
-        trace!("encode_builtin_function_use({:?})", function_kind);
         // FIXME: We should use encode_builtin_function_use_high with lowering instead..
         if !self
             .high_builtin_function_encoder_state

--- a/prusti-viper/src/encoder/high/procedures/inference/ensurer.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/ensurer.rs
@@ -124,13 +124,13 @@ pub(in super::super) fn try_ensure_enum_discriminant_by_unfolding(
     }
 }
 
+#[tracing::instrument(level = "debug", skip(context, state, actions))]
 pub(in super::super) fn ensure_required_permission(
     context: &mut impl Context,
     state: &mut FoldUnfoldState,
     required_permission: Permission,
     actions: &mut Vec<Action>,
 ) -> SpannedEncodingResult<()> {
-    debug!("required_permission: {}", required_permission);
     state.debug_print();
 
     let (place, permission_kind) = match required_permission {
@@ -311,6 +311,7 @@ fn check_contains_place(
 
 /// Returns `true` if the state should be droped because it should be
 /// unreachable.
+#[tracing::instrument(level = "debug", skip(context, predicate_state, actions))]
 fn ensure_permission_in_state(
     context: &mut impl Context,
     predicate_state: &mut PredicateStateOnPath,

--- a/prusti-viper/src/encoder/high/procedures/inference/mod.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/mod.rs
@@ -26,6 +26,7 @@ mod semantics;
 mod state;
 mod visitor;
 
+#[tracing::instrument(level = "debug", skip(encoder, procedure), fields(procedure = %procedure))]
 pub(super) fn infer_shape_operations<'v, 'tcx: 'v>(
     encoder: &mut Encoder<'v, 'tcx>,
     proc_def_id: DefId,

--- a/prusti-viper/src/encoder/high/procedures/inference/state/predicate_state_on_path.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/state/predicate_state_on_path.rs
@@ -82,6 +82,7 @@ impl PredicateStateOnPath {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(in super::super) fn remove(
         &mut self,
         kind: PermissionKind,

--- a/prusti-viper/src/encoder/high/procedures/inference/visitor/mod.rs
+++ b/prusti-viper/src/encoder/high/procedures/inference/visitor/mod.rs
@@ -184,6 +184,7 @@ impl<'p, 'v, 'tcx> Visitor<'p, 'v, 'tcx> {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip(self, state))]
     fn lower_statement(
         &mut self,
         statement: vir_typed::Statement,
@@ -271,6 +272,7 @@ impl<'p, 'v, 'tcx> Visitor<'p, 'v, 'tcx> {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip(self, actions))]
     fn process_actions(&mut self, actions: Vec<Action>) -> SpannedEncodingResult<()> {
         for action in actions {
             debug!("  action: {}", action);

--- a/prusti-viper/src/encoder/high/types/fields.rs
+++ b/prusti-viper/src/encoder/high/types/fields.rs
@@ -1,12 +1,11 @@
 //! Helper functions for creating fields.
 
 use crate::{encoder::errors::EncodingResult, error_internal, error_unsupported};
-use log::trace;
 
 use vir_crate::high as vir;
 
+#[tracing::instrument(level = "trace")]
 pub(crate) fn create_value_field(ty: vir::Type) -> EncodingResult<vir::FieldDecl> {
-    trace!("Encode value field for type '{:?}'", ty);
     let field_decl = match ty {
         vir::Type::Bool => vir::FieldDecl::new("val_bool", 0usize, vir::Type::MBool),
 

--- a/prusti-viper/src/encoder/high/types/interface.rs
+++ b/prusti-viper/src/encoder/high/types/interface.rs
@@ -173,6 +173,7 @@ impl<'v, 'tcx: 'v> HighTypeEncoderInterface<'tcx> for super::super::super::Encod
         self.ensure_viper_predicate_encoded(name)?;
         Ok(self.high_type_encoder_state.viper_predicates.borrow()[name].clone())
     }
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_type(&self, ty: ty::Ty<'tcx>) -> EncodingResult<vir_poly::Type> {
         let ty_kind = ty.kind();
         if !self

--- a/prusti-viper/src/encoder/initialisation.rs
+++ b/prusti-viper/src/encoder/initialisation.rs
@@ -26,6 +26,7 @@ pub struct InitInfo {
 }
 
 /// Create a set that contains all places and their prefixes of the original set.
+#[tracing::instrument(level = "trace", skip(mir, tcx))]
 fn explode<'tcx>(
     mir: &mir::Body<'tcx>,
     tcx: TyCtxt<'tcx>,
@@ -55,6 +56,7 @@ fn contains_prefix(set: &FxHashSet<vir::Expr>, place: &vir::Expr) -> bool {
     }
 }
 
+#[tracing::instrument(level = "debug", skip_all)]
 fn convert_to_vir<'tcx, T: Eq + Hash + Clone>(
     map: &FxHashMap<T, FxHashSet<mir::Place<'tcx>>>,
     mir_encoder: &MirEncoder<'_, '_, 'tcx>,
@@ -72,6 +74,7 @@ fn convert_to_vir<'tcx, T: Eq + Hash + Clone>(
 }
 
 impl<'p, 'v: 'p, 'tcx: 'v> InitInfo {
+    #[tracing::instrument(name = "InitInfo::new", level = "debug", skip_all)]
     pub fn new(
         mir: &'p mir::Body<'tcx>,
         tcx: ty::TyCtxt<'tcx>,

--- a/prusti-viper/src/encoder/loop_encoder.rs
+++ b/prusti-viper/src/encoder/loop_encoder.rs
@@ -11,7 +11,7 @@ use prusti_interface::environment::mir_sets::PlaceSet;
 use prusti_interface::environment::{BasicBlockIndex, LoopAnalysisError, PermissionForest, ProcedureLoops, Procedure};
 use prusti_interface::utils;
 use prusti_rustc_interface::middle::{mir, ty};
-use log::{trace, debug};
+use log::debug;
 
 pub enum LoopEncoderError {
     LoopInvariantInBranch(BasicBlockIndex),
@@ -131,11 +131,11 @@ impl<'p, 'tcx: 'p> LoopEncoder<'p, 'tcx> {
     }
 
     /// Return the block at whose end the loop invariant holds
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn get_loop_invariant_block(
         &self,
         loop_head: BasicBlockIndex
     ) -> Result<BasicBlockIndex, LoopEncoderError> {
-        trace!("get_loop_special_blocks: {:?}", loop_head);
         let loop_info = self.loops();
         debug_assert!(loop_info.is_loop_head(loop_head));
         let loop_depth = loop_info.get_loop_head_depth(loop_head);

--- a/prusti-viper/src/encoder/middle/core_proof/errors/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/errors/interface.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::encoder::{
     errors::{ErrorCtxt, MultiSpan},
     middle::core_proof::lowerer::Lowerer,
@@ -5,7 +7,7 @@ use crate::encoder::{
 use vir_crate::low as vir_low;
 
 pub(in super::super) trait ErrorsInterface {
-    fn register_error<T: Into<MultiSpan>>(
+    fn register_error<T: Into<MultiSpan> + Debug>(
         &mut self,
         span: T,
         error_ctxt: ErrorCtxt,
@@ -13,7 +15,7 @@ pub(in super::super) trait ErrorsInterface {
 }
 
 impl<'p, 'v: 'p, 'tcx: 'v> ErrorsInterface for Lowerer<'p, 'v, 'tcx> {
-    fn register_error<T: Into<MultiSpan>>(
+    fn register_error<T: Into<MultiSpan> + Debug>(
         &mut self,
         span: T,
         error_ctxt: ErrorCtxt,

--- a/prusti-viper/src/encoder/middle/core_proof/interface.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/interface.rs
@@ -30,6 +30,7 @@ pub(crate) trait MidCoreProofEncoderInterface<'tcx> {
 }
 
 impl<'v, 'tcx: 'v> MidCoreProofEncoderInterface<'tcx> for super::super::super::Encoder<'v, 'tcx> {
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_lifetimes_core_proof(
         &mut self,
         proc_def_id: DefId,

--- a/prusti-viper/src/encoder/mir/casts/interface.rs
+++ b/prusti-viper/src/encoder/mir/casts/interface.rs
@@ -1,4 +1,3 @@
-use log::{debug, trace};
 use prusti_rustc_interface::middle::ty;
 use vir_crate::high::{self as vir_high};
 
@@ -13,13 +12,12 @@ pub(crate) trait CastsEncoderInterface<'tcx> {
 }
 
 impl<'v, 'tcx: 'v> CastsEncoderInterface<'tcx> for super::super::super::Encoder<'v, 'tcx> {
+    #[tracing::instrument(level = "debug", skip(self), ret)]
     fn encode_int_cast_high(
         &self,
         value: u128,
         ty: ty::Ty<'tcx>,
     ) -> EncodingResult<vir_high::Expression> {
-        trace!("encode_int_cast {:?} as {:?}", value, ty);
-
         let expr = match ty.kind() {
             ty::TyKind::Bool => (value != 0).into(),
             ty::TyKind::Int(ty::IntTy::I8) => {
@@ -78,7 +76,6 @@ impl<'v, 'tcx: 'v> CastsEncoderInterface<'tcx> for super::super::super::Encoder<
                 error_unsupported!("unsupported integer cast: {:?}", kind);
             }
         };
-        debug!("encode_int_cast {:?} as {:?} --> {:?}", value, ty, expr);
         Ok(expr)
     }
 }

--- a/prusti-viper/src/encoder/mir/constants/interface.rs
+++ b/prusti-viper/src/encoder/mir/constants/interface.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use prusti_rustc_interface::middle::{mir, ty};
 use vir_crate::high::{self as vir_high};
 
@@ -17,6 +16,7 @@ pub(crate) trait ConstantsEncoderInterface<'tcx> {
 }
 
 impl<'v, 'tcx: 'v> ConstantsEncoderInterface<'tcx> for super::super::super::Encoder<'v, 'tcx> {
+    #[tracing::instrument(level = "debug", skip(self), ret)]
     fn encode_constant_high(
         &self,
         constant: &mir::Constant<'tcx>,
@@ -70,7 +70,6 @@ impl<'v, 'tcx: 'v> ConstantsEncoderInterface<'tcx> for super::super::super::Enco
                 error_unsupported!("unsupported constant type {:?}", mir_type.kind());
             }
         };
-        debug!("encode_const_expr {:?} --> {:?}", constant.literal, expr);
         Ok(expr)
     }
 

--- a/prusti-viper/src/encoder/mir/contracts/interface.rs
+++ b/prusti-viper/src/encoder/mir/contracts/interface.rs
@@ -98,6 +98,7 @@ impl<'v, 'tcx: 'v> ContractsEncoderInterface<'tcx> for super::super::super::Enco
         Ok(contract)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn get_procedure_contract_for_def(
         &self,
         proc_def_id: DefId,
@@ -109,6 +110,7 @@ impl<'v, 'tcx: 'v> ContractsEncoderInterface<'tcx> for super::super::super::Enco
             .map_err(|err| err.clone())
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn get_procedure_contract_for_call(
         &self,
         caller_def_id: DefId,
@@ -129,6 +131,7 @@ impl<'v, 'tcx: 'v> ContractsEncoderInterface<'tcx> for super::super::super::Enco
     }
 }
 
+#[tracing::instrument(level = "debug", skip(encoder, specification))]
 fn get_procedure_contract<'p, 'v: 'p, 'tcx: 'v>(
     encoder: &'p Encoder<'v, 'tcx>,
     specification: typed::ProcedureSpecification,
@@ -136,9 +139,6 @@ fn get_procedure_contract<'p, 'v: 'p, 'tcx: 'v>(
     substs: SubstsRef<'tcx>,
 ) -> EncodingResult<ProcedureContractMirDef<'tcx>> {
     let env = encoder.env();
-
-    trace!("[get_procedure_contract] enter name={:?}", proc_def_id);
-
     let args_ty: Vec<(mir::Local, ty::Ty<'tcx>)>;
     let return_ty;
 

--- a/prusti-viper/src/encoder/mir/errors/interface.rs
+++ b/prusti-viper/src/encoder/mir/errors/interface.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::encoder::errors::{ErrorCtxt, SpannedEncodingResult};
 use prusti_interface::data::ProcedureDefId;
 use prusti_rustc_interface::errors::MultiSpan;
@@ -11,7 +13,7 @@ use vir_crate::high::{
 };
 
 pub(crate) trait ErrorInterface {
-    fn register_error<T: Into<MultiSpan>>(
+    fn register_error<T: Into<MultiSpan> + Debug>(
         &mut self,
         span: T,
         error_ctxt: ErrorCtxt,
@@ -35,7 +37,7 @@ pub(crate) trait ErrorInterface {
         default_position: vir_high::Position,
         error_ctxt: ErrorCtxt,
     ) -> vir_high::Expression;
-    fn set_expression_error_ctxt<T: Into<MultiSpan>>(
+    fn set_expression_error_ctxt<T: Into<MultiSpan> + Debug>(
         &mut self,
         expression: vir_high::Expression,
         span: T,
@@ -54,7 +56,7 @@ pub(crate) trait ErrorInterface {
         default_position: vir_high::Position,
         error_ctxt: ErrorCtxt,
     ) -> vir_high::Rvalue;
-    fn set_statement_error_ctxt<T: Into<MultiSpan>>(
+    fn set_statement_error_ctxt<T: Into<MultiSpan> + Debug>(
         &mut self,
         statement: vir_high::Statement,
         span: T,
@@ -70,7 +72,7 @@ pub(crate) trait ErrorInterface {
 }
 
 impl<'v, 'tcx: 'v> ErrorInterface for super::super::super::Encoder<'v, 'tcx> {
-    fn register_error<T: Into<MultiSpan>>(
+    fn register_error<T: Into<MultiSpan> + Debug>(
         &mut self,
         span: T,
         error_ctxt: ErrorCtxt,
@@ -132,7 +134,7 @@ impl<'v, 'tcx: 'v> ErrorInterface for super::super::super::Encoder<'v, 'tcx> {
         };
         visitor.fold_expression(expression)
     }
-    fn set_expression_error_ctxt<T: Into<MultiSpan>>(
+    fn set_expression_error_ctxt<T: Into<MultiSpan> + Debug>(
         &mut self,
         expression: vir_high::Expression,
         span: T,
@@ -218,7 +220,7 @@ impl<'v, 'tcx: 'v> ErrorInterface for super::super::super::Encoder<'v, 'tcx> {
         };
         visitor.fold_rvalue(rvalue)
     }
-    fn set_statement_error_ctxt<T: Into<MultiSpan>>(
+    fn set_statement_error_ctxt<T: Into<MultiSpan> + Debug>(
         &mut self,
         statement: vir_high::Statement,
         span: T,

--- a/prusti-viper/src/encoder/mir/panics/interface.rs
+++ b/prusti-viper/src/encoder/mir/panics/interface.rs
@@ -7,6 +7,7 @@ pub(crate) trait MirPanicsEncoderInterface<'tcx> {
 }
 
 impl<'v, 'tcx: 'v> MirPanicsEncoderInterface<'tcx> for super::super::super::Encoder<'v, 'tcx> {
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_panic_cause(&self, span: Span) -> SpannedEncodingResult<PanicCause> {
         let macro_backtrace: Vec<_> = span.macro_backtrace().collect();
         debug!("macro_backtrace: {:?}", macro_backtrace);

--- a/prusti-viper/src/encoder/mir/places/interface.rs
+++ b/prusti-viper/src/encoder/mir/places/interface.rs
@@ -153,6 +153,7 @@ impl<'v, 'tcx: 'v> PlacesEncoderInterface<'tcx> for super::super::super::Encoder
         Ok(variable_decl)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_place_high(
         &self,
         mir: &mir::Body<'tcx>,

--- a/prusti-viper/src/encoder/mir/procedures/encoder/builtin_function_encoder.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/builtin_function_encoder.rs
@@ -17,6 +17,7 @@ pub(super) trait BuiltinFuncAppEncoder<'p, 'v, 'tcx> {
 }
 
 impl<'p, 'v, 'tcx> BuiltinFuncAppEncoder<'p, 'v, 'tcx> for super::ProcedureEncoder<'p, 'v, 'tcx> {
+    #[tracing::instrument(level = "debug", skip_all, fields(called_def_id = ?called_def_id))]
     fn try_encode_builtin_call(
         &mut self,
         block_builder: &mut BasicBlockBuilder,

--- a/prusti-viper/src/encoder/mir/procedures/encoder/ghost.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/ghost.rs
@@ -79,6 +79,7 @@ impl<'a, 'p, 'v, 'tcx> GhostChecker<'a, 'p, 'v, 'tcx> {
 }
 
 impl<'a, 'p, 'v, 'tcx> Visitor<'tcx> for GhostChecker<'a, 'p, 'v, 'tcx> {
+    #[tracing::instrument(level = "debug", skip(self))]
     fn visit_local(&mut self, local: mir::Local, context: PlaceContext, location: mir::Location) {
         let is_ghost = self.is_ghost_place(location) || self.is_ghost_local(&local);
         if !is_ghost && context.is_use() {

--- a/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
@@ -1281,6 +1281,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn encode_terminator_switch_int(
         &mut self,
         block_builder: &mut BasicBlockBuilder,

--- a/prusti-viper/src/encoder/mir/procedures/encoder/specification_blocks.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/specification_blocks.rs
@@ -29,6 +29,7 @@ pub(super) struct LoopInvariantBlocks {
 }
 
 impl SpecificationBlocks {
+    #[tracing::instrument(name = "SpecificationBlocks::build", level = "debug", skip_all)]
     pub fn build<'tcx>(
         env_query: EnvQuery<'tcx>,
         body: &mir::Body<'tcx>,

--- a/prusti-viper/src/encoder/mir/procedures/interface.rs
+++ b/prusti-viper/src/encoder/mir/procedures/interface.rs
@@ -22,6 +22,7 @@ pub(crate) trait MirProcedureEncoderInterface<'tcx> {
 }
 
 impl<'v, 'tcx: 'v> MirProcedureEncoderInterface<'tcx> for super::super::super::Encoder<'v, 'tcx> {
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_procedure_core_proof_high(
         &mut self,
         proc_def_id: DefId,

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_high.rs
@@ -153,6 +153,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip(self, state))]
     fn apply_assign_statement(
         &self,
         state: &mut ExprBackwardInterpreterState,
@@ -340,6 +341,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip(self, states))]
     fn apply_switch_int_terminator(
         &self,
         switch_ty: ty::Ty<'tcx>,
@@ -348,12 +350,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
         states: FxHashMap<mir::BasicBlock, &ExprBackwardInterpreterState>,
         span: Span,
     ) -> SpannedEncodingResult<ExprBackwardInterpreterState> {
-        trace!(
-            "SwitchInt ty '{:?}', discr '{:?}', targets '{:?}'",
-            switch_ty,
-            discriminant,
-            targets
-        );
         let encoded_discriminant = self.encode_operand(discriminant, span)?;
         let mut cfg_targets = Vec::new();
         for (value, target) in targets.iter() {
@@ -792,6 +788,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(level = "trace", skip(self, states))]
     fn encode_call_generic(
         &self,
         target_block: mir::BasicBlock,
@@ -871,6 +868,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
     type State = ExprBackwardInterpreterState;
     type Error = SpannedEncodingError;
 
+    #[tracing::instrument(level = "debug", skip(self, states))]
     fn apply_terminator(
         &self,
         _bb: mir::BasicBlock,
@@ -1040,6 +1038,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         Ok(state)
     }
 
+    #[tracing::instrument(level = "debug", skip(self, state), fields(state = %state))]
     fn apply_statement(
         &self,
         bb: mir::BasicBlock,
@@ -1047,7 +1046,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         statement: &mir::Statement<'tcx>,
         state: &mut Self::State,
     ) -> Result<(), Self::Error> {
-        trace!("apply_statement {:?}, state: {}", statement, state);
         let span = statement.source_info.span;
         let location = mir::Location {
             block: bb,

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
@@ -198,13 +198,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
     type State = ExprBackwardInterpreterState;
     type Error = SpannedEncodingError;
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn apply_terminator(
         &self,
         bb: mir::BasicBlock,
         term: &mir::Terminator<'tcx>,
         states: FxHashMap<mir::BasicBlock, &Self::State>,
     ) -> Result<Self::State, Self::Error> {
-        trace!("apply_terminator {:?}, states: {:?}", term, states);
         use prusti_rustc_interface::middle::mir::TerminatorKind;
         let span = term.source_info.span;
         let location = self.mir.terminator_loc(bb);
@@ -426,7 +426,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
 
                         match full_func_proc_name {
                             "prusti_contracts::old" => {
-                                trace!("Encoding old expression {:?}", args[0]);
                                 assert_eq!(args.len(), 1);
 
                                 // Return an error for unsupported old(..) types
@@ -808,6 +807,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         Ok(state)
     }
 
+    #[tracing::instrument(level = "debug", skip(self, state), fields(state = %state))]
     fn apply_statement(
         &self,
         bb: mir::BasicBlock,
@@ -815,7 +815,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
         stmt: &mir::Statement<'tcx>,
         state: &mut Self::State,
     ) -> Result<(), Self::Error> {
-        trace!("apply_statement {:?}, state: {}", stmt, state);
         let span = stmt.source_info.span;
         let location = mir::Location {
             block: bb,

--- a/prusti-viper/src/encoder/mir/pure/interpreter/state_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/state_high.rs
@@ -10,7 +10,6 @@ use std::{
     mem,
 };
 
-use log::trace;
 use vir_crate::high::{self as vir_high, Generic};
 
 #[derive(Clone, Debug)]
@@ -57,12 +56,12 @@ impl ExprBackwardInterpreterState {
         self.expr
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn substitute_value(
         &mut self,
         target: &vir_high::Expression,
         replacement: vir_high::Expression,
     ) {
-        trace!("substitute_value {:?} --> {:?}", target, replacement);
         let mut target = target.clone().substitute_types(&self.substs);
         let mut replacement = replacement.substitute_types(&self.substs);
 
@@ -76,8 +75,8 @@ impl ExprBackwardInterpreterState {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     pub(super) fn uses_place(&self, sub_target: &vir_high::Expression) -> bool {
-        trace!("use_place {:?}", sub_target);
         let sub_target = sub_target.clone().substitute_types(&self.substs);
         self.expr
             .as_ref()

--- a/prusti-viper/src/encoder/mir/pure/interpreter/state_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/state_poly.rs
@@ -4,7 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use log::trace;
 use rustc_hash::FxHashMap;
 use std::{
     fmt::{self, Debug, Display},
@@ -56,8 +55,8 @@ impl ExprBackwardInterpreterState {
         self.expr
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn substitute_value(&mut self, target: &vir::Expr, replacement: vir::Expr) {
-        trace!("substitute_value {:?} --> {:?}", target, replacement);
         let target = target.clone().patch_types(&self.substs);
         let replacement = replacement.patch_types(&self.substs);
 
@@ -69,8 +68,8 @@ impl ExprBackwardInterpreterState {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     pub fn uses_place(&self, sub_target: &vir::Expr) -> bool {
-        trace!("use_place {:?}", sub_target);
         let sub_target = sub_target.clone().patch_types(&self.substs);
         self.expr
             .as_ref()

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
@@ -21,7 +21,7 @@ use crate::encoder::{
     snapshot::interface::SnapshotEncoderInterface,
     Encoder,
 };
-use log::{debug, trace};
+use log::debug;
 use prusti_common::{config, vir::optimizations::functions::Simplifier, vir_local};
 
 use prusti_rustc_interface::{
@@ -56,6 +56,7 @@ pub(super) struct PureFunctionEncoder<'p, 'v: 'p, 'tcx: 'v> {
 }
 
 /// Used to encode expressions in assertions
+#[tracing::instrument(level = "debug", skip(encoder))]
 pub(super) fn encode_body<'p, 'v: 'p, 'tcx: 'v>(
     encoder: &'p Encoder<'v, 'tcx>,
     proc_def_id: DefId,
@@ -90,6 +91,11 @@ pub(super) fn encode_body<'p, 'v: 'p, 'tcx: 'v>(
 }
 
 impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
+    #[tracing::instrument(
+        name = "PureFunctionEncoder::new",
+        level = "trace",
+        skip(encoder, pure_encoding_context)
+    )]
     pub fn new(
         encoder: &'p Encoder<'v, 'tcx>,
         proc_def_id: DefId,
@@ -97,8 +103,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         parent_def_id: DefId,
         substs: SubstsRef<'tcx>,
     ) -> Self {
-        trace!("PureFunctionEncoder constructor: {:?}", proc_def_id);
-
         // should hold for extern specs as well (otherwise there would have
         // been an error reported earlier)
         assert_eq!(
@@ -124,6 +128,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn encode_function(&mut self) -> SpannedEncodingResult<vir::Function> {
         let mir = self.encoder.env().body.get_pure_fn_body(
             self.proc_def_id,
@@ -187,6 +192,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         self.encode_function_given_body(Some(body_expr))
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn encode_bodyless_function(&self) -> SpannedEncodingResult<vir::Function> {
         let function_name = self.encode_function_name();
         debug!("Encode trusted (bodyless) pure function {}", function_name);
@@ -194,6 +200,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         self.encode_function_given_body(None)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn encode_predicate_function(
         &self,
         predicate_body: &DefId,
@@ -233,6 +240,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
 
     // Private
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_function_given_body(
         &self,
         body: Option<vir::Expr>,
@@ -382,6 +390,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
     /// Encode the precondition with two expressions:
     /// - one for the type encoding
     /// - one for the functional specification.
+    #[tracing::instrument(level = "debug", skip(self), ret)]
     fn encode_precondition_expr(
         &self,
         contract: &ProcedureContract<'tcx>,
@@ -437,6 +446,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
 
     /// Encode the postcondition with one expression just for the functional specification (no
     /// type encoding).
+    #[tracing::instrument(level = "debug", skip(self), ret)]
     fn encode_postcondition_expr(
         &self,
         contract: &ProcedureContract<'tcx>,

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -69,7 +69,7 @@ type FunctionConstructor<'v, 'tcx> = Box<
 
 /// Depending on the context of the pure encoding,
 /// panics will be encoded slightly differently.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(crate) enum PureEncodingContext {
     /// Panics will be encoded as calls to unreachable functions
     /// (which have a `requires false` pre-condition).
@@ -274,13 +274,13 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
         Ok(self.pure_function_encoder_state.bodies_poly.borrow()[&key].clone())
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_pure_function_def(
         &self,
         proc_def_id: ProcedureDefId,
         parent_def_id: ProcedureDefId,
         substs: SubstsRef<'tcx>,
     ) -> SpannedEncodingResult<()> {
-        trace!("[enter] encode_pure_function_def({:?})", proc_def_id);
         assert!(
             self.is_pure(proc_def_id, Some(substs)),
             "procedure is not marked as pure: {proc_def_id:?}"
@@ -392,8 +392,6 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 }
             }
         }
-
-        trace!("[exit] encode_pure_function_def({:?})", proc_def_id);
         Ok(())
     }
 

--- a/prusti-viper/src/encoder/mir/specifications/interface.rs
+++ b/prusti-viper/src/encoder/mir/specifications/interface.rs
@@ -1,5 +1,4 @@
 use crate::encoder::mir::specifications::specs::Specifications;
-use log::trace;
 use prusti_interface::{
     specs::{
         typed,
@@ -128,6 +127,7 @@ pub(crate) trait SpecificationsInterface<'tcx> {
 }
 
 impl<'v, 'tcx: 'v> SpecificationsInterface<'tcx> for super::super::super::Encoder<'v, 'tcx> {
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     fn is_pure(&self, def_id: DefId, substs: Option<SubstsRef<'tcx>>) -> bool {
         let kind = self.get_proc_kind(def_id, substs);
         let mut pure = matches!(
@@ -143,8 +143,6 @@ impl<'v, 'tcx: 'v> SpecificationsInterface<'tcx> for super::super::super::Encode
         {
             pure = true;
         }
-
-        trace!("is_pure {:?} = {}", def_id, pure);
         pure
     }
 
@@ -164,37 +162,34 @@ impl<'v, 'tcx: 'v> SpecificationsInterface<'tcx> for super::super::super::Encode
             .unwrap_or(ProcedureSpecificationKind::Impure)
     }
 
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     fn is_trusted(&self, def_id: DefId, substs: Option<SubstsRef<'tcx>>) -> bool {
         let substs = substs.unwrap_or_else(|| self.env().query.identity_substs(def_id));
         let query = SpecQuery::GetProcKind(def_id, substs);
-        let result = self
-            .specifications_state
+        self.specifications_state
             .specs
             .borrow_mut()
             .get_and_refine_proc_spec(self.env(), query)
             .and_then(|spec| spec.trusted.extract_with_selective_replacement().copied())
-            .unwrap_or(false);
-        trace!("is_trusted {:?} = {}", query, result);
-        result
+            .unwrap_or(false)
     }
 
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     fn get_predicate_body(&self, def_id: DefId, substs: SubstsRef<'tcx>) -> Option<DefId> {
         let query = SpecQuery::FunctionDefEncoding(def_id, substs);
         let mut specs = self.specifications_state.specs.borrow_mut();
-        let result = specs
+        specs
             .get_and_refine_proc_spec(self.env(), query)
             // In case of error -> It is emitted in get_and_refine_proc_spec
-            .map(|spec| spec.kind.get_predicate_body().unwrap_or(None))
-            .unwrap_or(None);
-        trace!("get_predicate_body {:?} = {:?}", query, result);
-        result.cloned()
+            .and_then(|spec| spec.kind.get_predicate_body().unwrap_or(None))
+            .cloned()
     }
 
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     fn terminates(&self, def_id: DefId, substs: Option<SubstsRef<'tcx>>) -> bool {
         let substs = substs.unwrap_or_else(|| self.env().query.identity_substs(def_id));
         let query = SpecQuery::GetProcKind(def_id, substs);
-        let result = self
-            .specifications_state
+        self.specifications_state
             .specs
             .borrow_mut()
             .get_and_refine_proc_spec(self.env(), query)
@@ -204,9 +199,7 @@ impl<'v, 'tcx: 'v> SpecificationsInterface<'tcx> for super::super::super::Encode
                     .copied()
             })
             .unwrap_or(None)
-            .is_some();
-        trace!("terminates {:?} = {}", query, result);
-        result
+            .is_some()
     }
 
     fn get_loop_specs(&self, def_id: DefId) -> Option<typed::LoopSpecification> {

--- a/prusti-viper/src/encoder/mir/specifications/specs.rs
+++ b/prusti-viper/src/encoder/mir/specifications/specs.rs
@@ -5,7 +5,7 @@ use crate::encoder::{
         interface::{FunctionCallEncodingQuery, SpecQuery},
     },
 };
-use log::{debug, trace};
+use log::debug;
 use prusti_interface::{
     environment::Environment,
     specs::typed::{
@@ -71,43 +71,42 @@ impl<'tcx> Specifications<'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn get_loop_spec(&self, def_id: &DefId) -> Option<&LoopSpecification> {
-        trace!("Get loop specs of {:?}", def_id);
         self.user_typed_specs.get_loop_spec(def_id)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn get_type_spec(&self, def_id: &DefId) -> Option<&TypeSpecification> {
-        trace!("Get type specs of {:?}", def_id);
         self.user_typed_specs.get_type_spec(def_id)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn get_assertion(&self, def_id: &DefId) -> Option<&PrustiAssertion> {
-        trace!("Get assertion specs of {:?}", def_id);
         self.user_typed_specs.get_assertion(def_id)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn get_assumption(&self, def_id: &DefId) -> Option<&PrustiAssumption> {
-        trace!("Get assumption specs of {:?}", def_id);
         self.user_typed_specs.get_assumption(def_id)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn get_ghost_begin(&self, def_id: &DefId) -> Option<&GhostBegin> {
-        trace!("Get begin ghost block specs of {:?}", def_id);
         self.user_typed_specs.get_ghost_begin(def_id)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn get_ghost_end(&self, def_id: &DefId) -> Option<&GhostEnd> {
-        trace!("Get end ghost block specs of {:?}", def_id);
         self.user_typed_specs.get_ghost_end(def_id)
     }
 
+    #[tracing::instrument(level = "trace", skip(self, env))]
     pub(super) fn get_and_refine_proc_spec<'a, 'env: 'a>(
         &'a mut self,
         env: &'env Environment<'tcx>,
         query: SpecQuery<'tcx>,
     ) -> Option<&'a ProcedureSpecification> {
-        trace!("Get procedure specs of {:?}", query);
-
         if self.is_refined(&query) {
             return self.get_proc_spec(env, &query);
         }
@@ -129,17 +128,13 @@ impl<'tcx> Specifications<'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self, env))]
     fn perform_proc_spec_refinement<'a, 'env: 'a>(
         &'a mut self,
         env: &'env Environment<'tcx>,
         impl_query: &SpecQuery<'tcx>,
         trait_query: &SpecQuery<'tcx>,
     ) -> Option<&'a ProcedureSpecification> {
-        debug!(
-            "Refining specs of {:?} with specs of {:?}",
-            impl_query, trait_query
-        );
-
         let impl_spec = self
             .get_proc_spec(env, impl_query)
             .cloned()

--- a/prusti-viper/src/encoder/mir/types/encoder.rs
+++ b/prusti-viper/src/encoder/mir/types/encoder.rs
@@ -62,11 +62,11 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
         self.encoder.compute_array_len(size)
     }
 
+    #[tracing::instrument(level = "debug", skip(self), fields(ty = ?self.ty))]
     pub fn encode_type(
         self,
         const_arguments: &[vir::Expression],
     ) -> SpannedEncodingResult<vir::Type> {
-        debug!("Encode type '{:?}'", self.ty);
         // self.encode_polymorphic_predicate_use()
         let lifetimes = self.encoder.get_lifetimes_from_type_high(self.ty)?;
         let result = match self.ty.kind() {
@@ -338,8 +338,9 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
         }
     }
 
+    /// Encodes a type predicate for the given type.
+    #[tracing::instrument(level = "debug", skip(self), fields(ty = ?self.ty))]
     pub fn encode_type_def_high(self) -> SpannedEncodingResult<vir::TypeDecl> {
-        debug!("Encode type predicate '{:?}'", self.ty);
         let type_decl = match self.ty.kind() {
             ty::TyKind::Bool => vir::TypeDecl::bool(),
             ty::TyKind::Int(_) | ty::TyKind::Uint(_) | ty::TyKind::Char => {
@@ -712,6 +713,7 @@ fn encode_variant<'v, 'tcx: 'v>(
     Ok(variant)
 }
 
+#[tracing::instrument(level = "debug", skip(encoder))]
 pub(super) fn encode_adt_def<'v, 'tcx>(
     encoder: &Encoder<'v, 'tcx>,
     adt_def: ty::AdtDef<'tcx>,

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -50,6 +50,7 @@ use prusti_interface::{
     PrustiError,
 };
 use std::collections::{BTreeMap};
+use std::fmt::Debug;
 use prusti_interface::utils;
 use prusti_rustc_interface::middle::mir::Mutability;
 use prusti_rustc_interface::middle::mir;
@@ -135,12 +136,11 @@ pub struct ProcedureEncoder<'p, 'v: 'p, 'tcx: 'v> {
 }
 
 impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
+    #[tracing::instrument(name = "ProcedureEncoder::new", level = "debug", skip_all, fields(proc_def_id = ?procedure.get_id()))]
     pub fn new(
         encoder: &'p Encoder<'v, 'tcx>,
         procedure: &'p Procedure<'tcx>
     ) -> SpannedEncodingResult<Self> {
-        debug!("ProcedureEncoder constructor");
-
         let mir = procedure.get_mir();
         let proc_def_id = procedure.get_id();
         let substs = encoder.env().query.identity_substs(proc_def_id);
@@ -195,6 +195,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         })
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     fn encode_specification_blocks(&mut self) -> SpannedEncodingResult<()> {
         // Collect the entry points into the specification blocks.
         let mut entry_points: BTreeMap<_, _> = self
@@ -358,8 +359,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         self.procedure_contract.as_ref().unwrap()
     }
 
+    #[tracing::instrument(level = "debug", skip(self), fields(name = self.cfg_method.name()))]
     pub fn encode(mut self) -> SpannedEncodingResult<vir::CfgMethod> {
-        trace!("Encode procedure {}", self.cfg_method.name());
         let mir_span = self.mir.span;
 
         // Retrieve the contract
@@ -562,6 +563,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// * The first CFG block of the encoding.
     /// * A vector of unresolved edges.
     #[allow(clippy::type_complexity)]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn encode_blocks_group(
         &mut self,
         label_prefix: &str,
@@ -778,6 +780,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// }
     /// assume !g
     /// ```
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_loop(
         &mut self,
         label_prefix: &str,
@@ -785,8 +788,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         return_block: CfgBlockIndex,
     ) -> SpannedEncodingResult<(CfgBlockIndex, Vec<(CfgBlockIndex, BasicBlockIndex)>)> {
         let loop_info = self.loop_encoder.loops();
-        debug_assert!(loop_info.is_loop_head(loop_head));
-        trace!("encode_loop: {:?}", loop_head);
         debug_assert!(loop_info.is_loop_head(loop_head));
         let loop_label_prefix = format!("{}loop{}", label_prefix, loop_head.index());
         let loop_depth = loop_info.get_loop_head_depth(loop_head);
@@ -1190,6 +1191,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// Returns:
     /// * The head of the encoded block
     /// * A vector unresolved edges
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_block(
         &mut self,
         label_prefix: &str,
@@ -1287,6 +1289,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Encode the statements of the block.
     /// In case of unsupported statements, this function will return `MirSuccessor::Kill`.
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_block_statements(
         &mut self,
         bbi: BasicBlockIndex,
@@ -1321,12 +1324,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Encode the terminator of the block
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_block_terminator(
         &mut self,
         bbi: BasicBlockIndex,
         curr_block: CfgBlockIndex,
     ) -> SpannedEncodingResult<MirSuccessor> {
-        trace!("Encode terminator of {:?}", bbi);
         let bb_data = &self.mir.basic_blocks[bbi];
         let location = mir::Location {
             block: bbi,
@@ -1339,12 +1342,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Encode a MIR statement or terminator, encoding an `assert false` in case
     /// of usage of unsupported features.
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_statement_at(
         &mut self,
         location: mir::Location,
     ) -> SpannedEncodingResult<(Vec<vir::Stmt>, Option<MirSuccessor>)> {
-        debug!("Encode location {:?}", location);
-
         let span = self.mir_encoder.get_span_of_location(location);
         let bb_data = &self.mir[location.block];
         let index = location.statement_index;
@@ -1397,16 +1399,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Note: it's better to call `encode_statement_at` instead of this method.
+    #[tracing::instrument(level = "debug", skip(self), fields(statement = ?stmt.kind, span = ?stmt.source_info.span))]
     fn encode_statement(
         &mut self,
         stmt: &mir::Statement<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        debug!(
-            "Encode statement '{:?}', span: {:?}",
-            stmt.kind, stmt.source_info.span
-        );
-
         let mut stmts = vec![vir::Stmt::comment(format!("[mir] {stmt:?}"))];
         let span = self.mir_encoder.get_span_of_location(location);
 
@@ -1640,8 +1638,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Encode the lhs and the rhs of the assignment that create the loan
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_loan_places(&mut self, loan_places: &LoanPlaces<'tcx>) -> SpannedEncodingResult<(vir::Expr, Option<vir::Expr>, bool, Vec<vir::Stmt>)> {
-        debug!("encode_loan_places '{:?}'", loan_places);
         let location = loan_places.location;
         let span = self.mir_encoder.get_span_of_location(location);
 
@@ -1840,6 +1838,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn construct_vir_reborrowing_dag(
         &mut self,
         loans: &[facts::Loan],
@@ -1920,6 +1919,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     // will return None if not a slice borrow
     // as slicing is just a function call, we can only tell the difference upon
     // closer inspection
+    #[tracing::instrument(level = "trace", skip(self))]
     fn construct_vir_reborrowing_node_for_slice(
         &mut self,
         loan: facts::Loan,
@@ -1935,7 +1935,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             .map_err(EncodingError::from)
             .with_span(span)?;
         trace!("loan_places: {:?}", loan_places);
-        trace!("node: {:?}", node);
 
         Ok(if let Some(regained) = self.slice_created_at.get(&loan_location) {
             let guard = self.construct_location_guard(loan_location);
@@ -1961,6 +1960,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         })
     }
 
+    #[tracing::instrument(level = "trace", skip(self, _mir_dag))]
     fn construct_vir_reborrowing_node_for_assignment(
         &mut self,
         _mir_dag: &ReborrowingDAG,
@@ -2052,6 +2052,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn construct_vir_reborrowing_node_for_call(
         &mut self,
         _mir_dag: &ReborrowingDAG,
@@ -2171,6 +2172,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ))
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_expiration_of_loans(
         &mut self,
         loans: Vec<facts::Loan>,
@@ -2179,11 +2181,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         end_location: Option<mir::Location>,
         is_in_package_stmt: bool,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "encode_expiration_of_loans '{:?}' '{:?}'",
-            loans,
-            zombie_loans
-        );
         let mut stmts: Vec<vir::Stmt> = vec![];
         if !loans.is_empty() {
             let vir_reborrowing_dag =
@@ -2195,15 +2192,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(stmts)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_expiring_borrows_between(
         &mut self,
         begin_loc: mir::Location,
         end_loc: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        debug!(
-            "encode_expiring_borrows_beteewn '{:?}' '{:?}'",
-            begin_loc, end_loc
-        );
         let (all_dying_loans, zombie_loans) = self
             .polonius_info()
             .get_all_loans_dying_between(begin_loc, end_loc);
@@ -2211,25 +2205,22 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         self.encode_expiration_of_loans(all_dying_loans, &zombie_loans, begin_loc, Some(end_loc), false)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_expiring_borrows_at(&mut self, location: mir::Location)
         -> SpannedEncodingResult<Vec<vir::Stmt>>
     {
-        debug!("encode_expiring_borrows_at '{:?}'", location);
         let (all_dying_loans, zombie_loans) = self.polonius_info().get_all_loans_dying_at(location);
         let stmts = self.encode_expiration_of_loans(all_dying_loans, &zombie_loans, location, None, false)?;
         Ok(self.set_stmts_default_pos(stmts, self.mir_encoder.get_span_of_location(location)))
     }
 
     /// Note: it's better to call `encode_statement_at` instead of this method.
+    #[tracing::instrument(level = "debug", skip(self), fields(terminator = ?term.kind, span = ?term.source_info.span))]
     fn encode_terminator(
         &mut self,
         term: &mir::Terminator<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<(Vec<vir::Stmt>, MirSuccessor)> {
-        debug!(
-            "Encode terminator '{:?}', span: {:?}",
-            term.kind, term.source_info.span
-        );
         let mut stmts: Vec<vir::Stmt> = vec![vir::Stmt::comment(format!("[mir] {:?}", term.kind))];
         let span = self.mir_encoder.get_span_of_location(location);
 
@@ -2599,7 +2590,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         }
 
                         "core::slice::<impl [T]>::len" => {
-                            debug!("Encoding call of slice::len");
                             stmts.extend(
                                 self.encode_slice_len_call(
                                     destination,
@@ -2629,7 +2619,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
                         "core::ops::Index::index" |
                         "std::ops::Index::index" => {
-                            debug!("Encoding call of array/slice index call");
                             stmts.extend(
                                 self.encode_sequence_index_call(
                                     destination,
@@ -2775,6 +2764,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(result)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_slice_len_call(
         &mut self,
         destination: mir::Place<'tcx>,
@@ -2826,6 +2816,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(stmts)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_sequence_index_call(
         &mut self,
         destination: mir::Place<'tcx>,
@@ -2833,7 +2824,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         location: mir::Location,
         error_span: Span
     ) -> EncodingResult<Vec<vir::Stmt>> {
-        trace!("encode_sequence_index_call(destination={:?}, args={:?})", destination, args);
         // args[0] is the base array/slice, args[1] is the index
         // index is not specified exactly, as std::ops::Index::index is a trait method, so all we
         // know is there needs to be an impl Index<Idx> for T
@@ -3142,6 +3132,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_impure_function_call(
         &mut self,
         location: mir::Location,
@@ -3529,6 +3520,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_pure_function_call(
         &mut self,
         location: mir::Location,
@@ -3652,6 +3644,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok((encoded, pre_stmts))
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_pure_function_call_site(
         &mut self,
         location: mir::Location,
@@ -3811,6 +3804,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// - one for the type invariants
     /// - one for the functional specification.
     #[allow(clippy::type_complexity)]
+    #[tracing::instrument(level = "debug", skip(self, override_spans))]
     fn encode_precondition_expr(
         &self,
         contract: &ProcedureContract<'tcx>,
@@ -3924,6 +3918,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ))
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_spec_refinement(
         &self,
         pre_label: &str,
@@ -4060,6 +4055,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Encode precondition inhale on the definition side.
+    #[tracing::instrument(level = "debug", skip_all)]
     fn encode_preconditions(
         &mut self,
         start_cfg_block: CfgBlockIndex,
@@ -4117,6 +4113,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Encode the magic wand used in the postcondition with its
     /// functional specification. Returns (lhs, rhs).
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_postcondition_magic_wand(
         &self,
         location: Option<mir::Location>,
@@ -4315,6 +4312,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// `function_end` – are we encoding the exhale of the postcondition
     /// at the end of the method?
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_postcondition_expr(
         &mut self,
         location: Option<mir::Location>,
@@ -4490,6 +4488,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// same place. Instead, we replace them with ghost variables.
     ///
     /// This method replaces all places with `label` with ghost variables.
+    #[tracing::instrument(level = "trace", skip(self))]
     fn replace_old_places_with_ghost_vars(
         &mut self,
         label: Option<&str>,
@@ -4546,13 +4545,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Encode the package statement of magic wands at the end of the method
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_package_end_of_method(
         &mut self,
         pre_label: &str,
         post_label: &str,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        debug!("encode_package_end_of_method '{:?}'", location);
         let mut stmts = Vec::new();
         let span = self.mir.source_info(location).span;
 
@@ -4674,6 +4673,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Encode postcondition exhale in the `return_cfg_block` CFG block.
+    #[tracing::instrument(level = "debug", skip_all)]
     fn encode_postconditions(
         &mut self,
         return_cfg_block: CfgBlockIndex,
@@ -4999,18 +4999,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// Result:
     /// * The first vector contains permissions.
     /// * The second vector contains value preserving equalities.
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_loop_invariant_permissions(
         &mut self,
         loop_head: BasicBlockIndex,
         loop_inv: BasicBlockIndex,
         drop_read_references: bool,
     ) -> EncodingResult<(Vec<vir::Expr>, Vec<vir::Expr>, Vec<vir::Expr>)> {
-        trace!(
-            "[enter] encode_loop_invariant_permissions \
-             loop_head={:?} drop_read_references={}",
-            loop_head,
-            drop_read_references
-        );
         let permissions_forest = self
             .loop_encoder
             .compute_loop_invariant(loop_head, loop_inv)
@@ -5247,6 +5242,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Get the basic blocks that encode the specification of a loop invariant
+    #[tracing::instrument(level = "debug", skip(self))]
     fn get_loop_spec_blocks(&self, loop_head: BasicBlockIndex) -> Vec<BasicBlockIndex> {
         let mut res = vec![];
         for bbi in self.procedure.get_reachable_cfg_blocks() {
@@ -5267,6 +5263,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Encode the functional specification of a loop
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     fn encode_loop_invariant_specs(
         &self,
         loop_head: BasicBlockIndex,
@@ -5305,23 +5302,16 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 }
             }
         }
-        trace!("encoded specs: {:?}", encoded_specs);
-
         Ok((encoded_specs, MultiSpan::from_spans(encoded_spec_spans)))
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_loop_invariant_exhale_stmts(
         &mut self,
         loop_head: BasicBlockIndex,
         loop_inv_block: BasicBlockIndex,
         after_loop_iteration: bool,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_loop_invariant_exhale_stmts loop_head={:?} \
-             after_loop_iteration={}",
-            loop_head,
-            after_loop_iteration
-        );
         if !after_loop_iteration {
             self.pure_var_for_preserving_value_map
                 .insert(loop_head, FxHashMap::default());
@@ -5400,17 +5390,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(stmts)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_loop_invariant_inhale_perm_stmts(
         &mut self,
         loop_head: BasicBlockIndex,
         loop_inv_block: BasicBlockIndex,
         after_loop: bool,
     ) -> EncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_loop_invariant_inhale_perm_stmts loop_head={:?} after_loop={}",
-            loop_head,
-            after_loop
-        );
         let (permissions, equalities, invs_spec) =
             self.encode_loop_invariant_permissions(loop_head, loop_inv_block, true)?;
 
@@ -5432,17 +5418,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(stmts)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_loop_invariant_inhale_fnspec_stmts(
         &mut self,
         loop_head: BasicBlockIndex,
         loop_inv_block: BasicBlockIndex,
         after_loop: bool,
     ) -> SpannedEncodingResult<(Vec<vir::Stmt>, MultiSpan)> {
-        trace!(
-            "[enter] encode_loop_invariant_inhale_fnspec_stmts loop_head={:?} after_loop={}",
-            loop_head,
-            after_loop
-        );
         let (func_spec, func_spec_span) =
             self.encode_loop_invariant_specs(loop_head, loop_inv_block)?;
 
@@ -5685,16 +5667,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Return type:
     /// - `Vec<vir::Stmt>`: the statements that encode the assignment of `operand` to `lhs`
+    #[tracing::instrument(level = "debug", skip(self), ret())]
     fn encode_assign_operand(
         &mut self,
         lhs: &vir::Expr,
         operand: &mir::Operand<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_assign_operand(lhs={}, operand={:?}, location={:?})",
-            lhs, operand, location
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         let stmts = match operand {
             mir::Operand::Move(place) => {
@@ -5817,10 +5796,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             }
         };
         debug!(
-            "[enter] encode_assign_operand(lhs={}, operand={:?}, location={:?}) = {}",
-            lhs,
-            operand,
-            location,
+            "encode_assign_operand result: {}",
             vir::stmts_to_str(&stmts)
         );
         Ok(stmts)
@@ -5828,6 +5804,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Assignment with a binary operation on the RHS
     /// [encoded_lhs] = [left] [op] [right]
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_assign_binary_op(
         &mut self,
         op: mir::BinOp,
@@ -5837,12 +5814,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ty: ty::Ty<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_assign_binary_op(op={:?}, left={:?}, right={:?})",
-            op,
-            left,
-            right
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         let encoded_left = self.mir_encoder.encode_operand_expr(left)
             .with_span(span)?;
@@ -5873,6 +5844,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Assignment with a(n overflow-)checked binary operation on the RHS.
     /// [encoded_lhs] = [left] [op] [right]
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_assign_checked_binary_op(
         &mut self,
         op: mir::BinOp,
@@ -5882,12 +5854,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ty: ty::Ty<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_assign_checked_binary_op(op={:?}, left={:?}, right={:?})",
-            op,
-            left,
-            right
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         let operand_ty = if let ty::TyKind::Tuple(types) = ty.kind() {
             types[0]
@@ -5971,6 +5937,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// Assignment with unary op as RHS.
     /// Unary ops currently are logical and arithmetic negation
     /// [encoded_lhs] = [op] [operand]
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_assign_unary_op(
         &mut self,
         op: mir::UnOp,
@@ -5979,11 +5946,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ty: ty::Ty<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_assign_unary_op(op={:?}, operand={:?})",
-            op,
-            operand
-        );
         let encoded_val = self.mir_encoder.encode_operand_expr(operand)
             .with_span(
                 self.mir_encoder.get_span_of_location(location)
@@ -5996,6 +5958,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// Assignment with a nullary op on the RHS.
     /// Nullary ops currently are sizeof and alignof.
     /// [lhs] = [op] [op_ty]
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_assign_nullary_op(
         &mut self,
         op: mir::NullOp,
@@ -6004,7 +5967,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ty: ty::Ty<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!("[enter] encode_assign_nullary_op(op={op:?}, op_ty={op_ty:?})");
         let tcx = self.encoder.env().tcx();
         let param_env = tcx.param_env(self.proc_def_id);
         let layout = match tcx.layout_of(param_env.and(op_ty)) {
@@ -6063,6 +6025,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Assignment with the RHS being the discriminant value of an enum
     /// [lhs] = discriminant of [src]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_assign_discriminant(
         &mut self,
         src: mir::Place<'tcx>,
@@ -6070,11 +6033,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         encoded_lhs: vir::Expr,
         ty: ty::Ty<'tcx>,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_assign_discriminant(src={:?}, location={:?})",
-            src,
-            location
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         let (encoded_src, mut stmts, src_ty, _) = self.encode_place(src, ArrayAccessKind::Shared, location)?;
         let encode_stmts = match src_ty.kind() {
@@ -6130,6 +6088,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Assignment with the RHS being referenced
     /// [encoded_lhs] = &[mir_borrow_kind] [place]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_assign_ref(
         &mut self,
         mir_borrow_kind: mir::BorrowKind,
@@ -6138,12 +6097,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         encoded_lhs: vir::Expr,
         ty: ty::Ty<'tcx>,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_assign_ref(mir_borrow_kind={:?}, place={:?}, location={:?})",
-            mir_borrow_kind,
-            place,
-            location
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         let loan = self.polonius_info().get_loan_at_location(location);
         let (vir_assign_kind, array_encode_kind) = match mir_borrow_kind {
@@ -6181,6 +6134,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Assignment where the RHS is a cast operation
     /// [encoded_lhs] = [operand] as [dst_ty]
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_cast(
         &mut self,
         operand: &mir::Operand<'tcx>,
@@ -6189,11 +6143,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ty: ty::Ty<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_cast(operand={:?}, dst_ty={:?})",
-            operand,
-            dst_ty
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         let encoded_val = self.mir_encoder.encode_cast_expr(operand, dst_ty, span)?;
         self.encode_copy_value_assign(encoded_lhs, encoded_val, ty, location)
@@ -6201,6 +6150,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
 
     /// Take a slice into the RHS array
     /// (also happens for calls that you do on an array that are slice methods, like .len())
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_assign_slice(
         &mut self,
         encoded_lhs: vir::Expr,
@@ -6208,7 +6158,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         ty: ty::Ty<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!("encode_assign_slice(lhs={:?}, operand={:?}, ty={:?})", encoded_lhs, operand, ty);
         debug_assert!(ty.is_slice_ref());
         let span = self.mir_encoder.get_span_of_location(location);
         let mut stmts = Vec::new();
@@ -6300,6 +6249,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(stmts)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_assign_sequence_len(
         &mut self,
         encoded_lhs: vir::Expr,
@@ -6307,11 +6257,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         dst_ty: ty::Ty<'tcx>,
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] encode_assign_sequence_len(place={:?}, ty={:?})",
-            place,
-            dst_ty,
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         let (encoded_place, mut stmts, place_ty, ..) = self.encode_place(
             place,
@@ -6408,8 +6353,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         vir::LocalVar::new(name, vir_type)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_havoc(&mut self, dst: &vir::Expr) -> EncodingResult<Vec<vir::Stmt>> {
-        debug!("Encode havoc {:?}", dst);
         let havoc_ref_method_name = self
             .encoder
             .encode_builtin_method_use(BuiltinMethodKind::HavocRef)?;
@@ -6437,9 +6382,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// Havoc and assume permission on fields
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_havoc_and_initialization(&mut self, dst: &vir::Expr) -> EncodingResult<Vec<vir::Stmt>> {
-        debug!("Encode havoc and allocation {:?}", dst);
-
         let mut stmts = vec![];
         // Havoc `dst`
         stmts.extend(self.encode_havoc(dst)?);
@@ -6455,6 +6399,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// Prepare the ``dst`` to be copy target:
     ///
     /// 1.  Havoc and allocate if it is not yet allocated.
+    #[tracing::instrument(level = "debug", skip(self))]
     fn prepare_assign_target(
         &mut self,
         dst: vir::Expr,
@@ -6463,12 +6408,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         vir_assign_kind: vir::AssignKind,
         can_copy_reference: bool // reference copies are allowed if the field is a constant
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        trace!(
-            "[enter] prepare_assign_target(dst={}, field={}, location={:?})",
-            dst,
-            field,
-            location
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         if !self.init_info.is_vir_place_accessible(&dst, location) {
             let mut alloc_stmts = self.encode_havoc(&dst).with_span(span)?;
@@ -6608,6 +6547,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     /// tuples
     /// [dst] = Foo { x: [op_0], y: [op_1], .. }
     /// [dst] = [ op_0, op_1, ..];
+    #[tracing::instrument(level = "debug", skip(self))]
     fn encode_assign_aggregate(
         &mut self,
         dst: &vir::Expr,
@@ -6616,10 +6556,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         operands: &[mir::Operand<'tcx>],
         location: mir::Location,
     ) -> SpannedEncodingResult<Vec<vir::Stmt>> {
-        debug!(
-            "[enter] encode_assign_aggregate({:?}, {:?})",
-            aggregate, operands
-        );
         let span = self.mir_encoder.get_span_of_location(location);
         let mut stmts = self.encode_havoc_and_initialization(dst).with_span(span)?;
         // Initialize values
@@ -6776,6 +6712,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn get_label_after_location(&mut self, location: mir::Location) -> SpannedEncodingResult<Option<&String>> {
         let opt_label = self.label_after_location.get(&location);
         if opt_label.is_none() {
@@ -6807,6 +6744,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     }
 
     /// A local version of encode_place
+    #[tracing::instrument(level = "trace", skip(self))]
     fn encode_place(
         &mut self,
         place: mir::Place<'tcx>,
@@ -6960,12 +6898,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         Ok((res, stmts))
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn postprocess_place_encoding(
         &mut self,
         place_encoding: PlaceEncoding<'tcx>,
         array_encode_kind: ArrayAccessKind,
     ) -> EncodingResult<(vir::Expr, Vec<vir::Stmt>)> {
-        trace!("postprocess_place_encoding: {:?}", place_encoding);
         Ok(match place_encoding {
             PlaceEncoding::Expr(e) => (e, vec![]),
             PlaceEncoding::FieldAccess { box base, field } => {
@@ -6992,7 +6930,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         })
     }
 
-    fn register_error<T: Into<MultiSpan>>(&self, span: T, error_ctxt: ErrorCtxt) -> vir::Position {
+    fn register_error<T: Into<MultiSpan> + Debug>(&self, span: T, error_ctxt: ErrorCtxt) -> vir::Position {
         self.mir_encoder.register_error(span, error_ctxt)
     }
 }

--- a/prusti-viper/src/encoder/purifier.rs
+++ b/prusti-viper/src/encoder/purifier.rs
@@ -12,10 +12,10 @@ use log::{debug, trace};
 use crate::encoder::snapshot::interface::SnapshotEncoderInterface;
 
 /// Replaces shared references to pure Viper variables.
+#[tracing::instrument(level = "debug", skip(encoder, method), fields(method = method.name()))]
 pub fn purify_method(encoder: &Encoder, method: &mut vir::CfgMethod) {
     // A set of candidate references to be purified.
     let mut candidates = FxHashSet::default();
-    debug!("method: {}", method.name());
     for var in &method.local_vars {
         match var.typ {
             vir::Type::TypedRef(ref typed_ref) if typed_ref.label.starts_with("ref$") => {

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -17,7 +17,6 @@ use crate::{
     },
     error_internal,
 };
-use log::debug;
 use prusti_common::{vir_expr, vir_local};
 
 use prusti_rustc_interface::{
@@ -140,12 +139,12 @@ impl SnapshotEncoder {
     }
 
     /// Patches snapshots in a method.
+    #[tracing::instrument(level = "debug", skip_all, fields(method = %method.name()))]
     pub fn patch_snapshots_method<'p, 'v: 'p, 'tcx: 'v>(
         &mut self,
         encoder: &'p Encoder<'v, 'tcx>,
         method: vir::CfgMethod,
     ) -> EncodingResult<vir::CfgMethod> {
-        debug!("[snap] method: {:?}", method.name());
         let mut patcher = SnapshotPatcher {
             snapshot_encoder: self,
             encoder,
@@ -154,12 +153,12 @@ impl SnapshotEncoder {
     }
 
     /// Patches snapshots in a function.
+    #[tracing::instrument(level = "debug", skip(self, encoder), fields(function = %function.name))]
     pub fn patch_snapshots_function<'p, 'v: 'p, 'tcx: 'v>(
         &mut self,
         encoder: &'p Encoder<'v, 'tcx>,
         mut function: vir::Function,
     ) -> EncodingResult<vir::Function> {
-        debug!("[snap] function: {:?}", function.name);
         let mut patcher = SnapshotPatcher {
             snapshot_encoder: self,
             encoder,
@@ -181,12 +180,12 @@ impl SnapshotEncoder {
     }
 
     /// Patches snapshots in an expression.
+    #[tracing::instrument(level = "debug", skip(self, encoder))]
     pub fn patch_snapshots_expr<'p, 'v: 'p, 'tcx: 'v>(
         &mut self,
         encoder: &'p Encoder<'v, 'tcx>,
         expr: Expr,
     ) -> EncodingResult<Expr> {
-        debug!("[snap] expr: {:?}", expr);
         let mut patcher = SnapshotPatcher {
             snapshot_encoder: self,
             encoder,

--- a/prusti-viper/src/encoder/stub_function_encoder.rs
+++ b/prusti-viper/src/encoder/stub_function_encoder.rs
@@ -12,7 +12,7 @@ use vir_crate::polymorphic as vir;
 use prusti_rustc_interface::hir::def_id::DefId;
 use prusti_rustc_interface::middle::ty::subst::SubstsRef;
 use prusti_rustc_interface::middle::mir;
-use log::{trace, debug};
+use log::debug;
 
 use crate::encoder::errors::WithSpan;
 
@@ -27,13 +27,13 @@ pub struct StubFunctionEncoder<'p, 'v: 'p, 'tcx: 'v> {
 }
 
 impl<'p, 'v: 'p, 'tcx: 'v> StubFunctionEncoder<'p, 'v, 'tcx> {
+    #[tracing::instrument(name = "StubFunctionEncoder::new", level = "trace", skip(encoder, mir))]
     pub fn new(
         encoder: &'p Encoder<'v, 'tcx>,
         proc_def_id: DefId,
         mir: &'p mir::Body<'tcx>,
         substs: SubstsRef<'tcx>,
     ) -> Self {
-        trace!("StubFunctionEncoder constructor: {:?}", proc_def_id);
         StubFunctionEncoder {
             encoder,
             mir,
@@ -43,6 +43,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> StubFunctionEncoder<'p, 'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn encode_function(&self) -> SpannedEncodingResult<vir::Function> {
         let function_name = self.encode_function_name();
         debug!("Encode stub function {}", function_name);

--- a/prusti-viper/src/encoder/stub_procedure_encoder.rs
+++ b/prusti-viper/src/encoder/stub_procedure_encoder.rs
@@ -14,7 +14,6 @@ use prusti_interface::environment::Procedure;
 use prusti_common::report::log;
 use prusti_rustc_interface::hir::def_id::DefId;
 use prusti_rustc_interface::middle::mir;
-use ::log::trace;
 
 
 pub struct StubProcedureEncoder<'p, 'v: 'p, 'tcx: 'v>
@@ -27,10 +26,9 @@ pub struct StubProcedureEncoder<'p, 'v: 'p, 'tcx: 'v>
 }
 
 impl<'p, 'v: 'p, 'tcx: 'v> StubProcedureEncoder<'p, 'v, 'tcx> {
+    #[tracing::instrument(name = "StubProcedureEncoder::new", level = "trace", skip(encoder, procedure), fields(def_id = ?procedure.get_id()))]
     pub fn new(encoder: &'p Encoder<'v, 'tcx>, procedure: &'p Procedure<'tcx>) -> Self {
         let def_id = procedure.get_id();
-        trace!("StubProcedureEncoder constructor: {:?}", def_id);
-
         let mir = procedure.get_mir();
 
         StubProcedureEncoder {
@@ -42,9 +40,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> StubProcedureEncoder<'p, 'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(self), fields(procedure = %self.procedure.get_def_path()))]
     pub fn encode(self) -> vir::CfgMethod {
-        trace!("Encode stub for procedure {}", self.procedure.get_def_path());
-
         let mut cfg_method = vir::CfgMethod::new(
             // method name
             self.encoder.encode_item_name(self.def_id),

--- a/prusti-viper/src/utils/type_visitor.rs
+++ b/prusti-viper/src/utils/type_visitor.rs
@@ -10,7 +10,6 @@ use prusti_rustc_interface::middle::ty::{
     TypeFlags, TyKind, IntTy, UintTy, FloatTy, VariantDef, subst::SubstsRef, Const
 };
 use prusti_rustc_interface::hir::def_id::DefId;
-use log::trace;
 
 pub trait TypeVisitor<'tcx>: Sized {
     type Error;
@@ -19,14 +18,14 @@ pub trait TypeVisitor<'tcx>: Sized {
 
     fn unsupported<S: ToString>(&self, _msg: S) -> Self::Error;
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_ty(&mut self, ty: Ty<'tcx>) -> Result<(), Self::Error> {
-        trace!("visit_ty({:?})", ty);
         self.visit_sty(ty.kind())?;
         self.visit_flags(ty.flags())
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_sty(&mut self, sty: &TyKind<'tcx>) -> Result<(), Self::Error> {
-        trace!("visit_sty({:?})", sty);
         match *sty {
             TyKind::Bool => {
                 self.visit_bool()
@@ -123,15 +122,16 @@ pub trait TypeVisitor<'tcx>: Sized {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_adt(
         &mut self,
         adt_def: AdtDef<'tcx>,
         substs: SubstsRef<'tcx>
     ) -> Result<(), Self::Error> {
-        trace!("visit_adt({:?})", adt_def);
         walk_adt(self, adt_def, substs)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_adt_variant(
         &mut self,
         adt: AdtDef<'tcx>,
@@ -139,81 +139,80 @@ pub trait TypeVisitor<'tcx>: Sized {
         variant: &VariantDef,
         substs: SubstsRef<'tcx>,
     )  -> Result<(), Self::Error> {
-        trace!("visit_adt_variant({:?}, {:?}, {:?})", adt, idx, variant);
         walk_adt_variant(self, variant, substs)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_field(
         &mut self,
         index: usize,
         field: &FieldDef,
         substs: SubstsRef<'tcx>,
     ) -> Result<(), Self::Error> {
-        trace!("visit_field({}, {:?})", index, field);
         walk_field(self, field, substs)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_ref(
         &mut self,
         region: Region<'tcx>,
         ty: Ty<'tcx>,
         mutability: Mutability
     ) -> Result<(), Self::Error> {
-        trace!("visit_ref({:?}, {:?}, {:?})", region, ty, mutability);
         walk_ref(self, region, ty, mutability)
     }
 
     #[allow(dead_code)]
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_ref_type(
         &mut self,
         ty: Ty<'tcx>,
         mutability: Mutability
     ) -> Result<(), Self::Error> {
-        trace!("visit_ref_type({:?}, {:?})", ty, mutability);
         walk_ref_type(self, ty, mutability)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_tuple(
         &mut self,
         types: &'tcx List<Ty<'tcx>>
     ) -> Result<(), Self::Error> {
-        trace!("visit_tuple({:?})", types);
         walk_tuple(self, types)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_raw_ptr(
         &mut self,
         ty: Ty<'tcx>,
         mutability: Mutability
     ) -> Result<(), Self::Error> {
-        trace!("visit_raw_ptr({:?}, {:?})", ty, mutability);
         walk_raw_ptr(self, ty, mutability)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_closure(
         &mut self,
         def_id: DefId,
         substs: SubstsRef<'tcx>
     ) -> Result<(), Self::Error> {
-        trace!("visit_closure({:?})", def_id);
         walk_closure(self, def_id, substs)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_fndef(
         &mut self,
         def_id: DefId,
         substs: SubstsRef<'tcx>
     ) -> Result<(), Self::Error> {
-        trace!("visit_fndef({:?})", def_id);
         walk_fndef(self, def_id, substs)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_array(
         &mut self,
         ty: Ty<'tcx>,
         len: Const<'tcx>,
     ) -> Result<(), Self::Error> {
-        trace!("visit_array({:?}, {:?})", ty, len);
         walk_array(self, ty, len)
     }
 }

--- a/prusti-viper/src/verifier.rs
+++ b/prusti-viper/src/verifier.rs
@@ -44,12 +44,8 @@ impl<'v, 'tcx> Verifier<'v, 'tcx> {
         }
     }
 
+    #[tracing::instrument(name = "prusti_viper::verify", level = "info", skip(self))]
     pub fn verify(&mut self, task: &VerificationTask<'tcx>) -> VerificationResult {
-        info!(
-            "Received {} functions to be verified:",
-            task.procedures.len()
-        );
-
         let mut stopwatch = Stopwatch::start("prusti-viper", "encoding to Viper");
 
         // Dump the configuration

--- a/prusti/Cargo.toml
+++ b/prusti/Cargo.toml
@@ -18,6 +18,9 @@ prusti-common = { path = "../prusti-common" }
 prusti-rustc-interface = { path = "../prusti-rustc-interface" }
 log = { version = "0.4", features = ["release_max_level_info"] }
 lazy_static = "1.4.0"
+tracing = { path = "../tracing" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-chrome = "0.7"
 
 [build-dependencies]
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -23,6 +23,7 @@ pub struct PrustiCompilerCalls;
 // necessary; for crates which won't be verified or spec_fns it suffices to load just the fn body
 
 #[allow(clippy::needless_lifetimes)]
+#[tracing::instrument(level = "debug", skip(tcx))]
 fn mir_borrowck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> mir_borrowck<'tcx> {
     // *Don't take MIR bodies with borrowck info if we won't need them*
     if !is_spec_fn(tcx, def_id.to_def_id()) {
@@ -55,6 +56,7 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
             config.override_queries = Some(override_queries);
         }
     }
+    #[tracing::instrument(level = "debug", skip_all)]
     fn after_expansion<'tcx>(
         &mut self,
         compiler: &Compiler,
@@ -86,6 +88,8 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
         }
         Compilation::Continue
     }
+
+    #[tracing::instrument(level = "debug", skip_all)]
     fn after_analysis<'tcx>(
         &mut self,
         compiler: &Compiler,
@@ -100,8 +104,7 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
 
             let hir = env.query.hir();
             let mut spec_collector = specs::SpecCollector::new(&mut env);
-            hir.walk_toplevel_module(&mut spec_collector);
-            hir.walk_attributes(&mut spec_collector);
+            spec_collector.collect_specs(hir);
 
             let mut def_spec = spec_collector.build_def_specs();
             // Do print_typeckd_specs prior to importing cross crate

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -107,9 +107,11 @@ fn init_loggers() -> Option<FlushGuard> {
     // TODO: The `config::log() != ""` here is very bad; it makes us ignore the `log_tracing` flag
     // It's enabled so that we only create a `trace.json` file if the user has explicitly requested logging
     let guard = if config::log_tracing() && !config::log().is_empty() {
+        let log_dir = config::log_dir();
+        std::fs::create_dir_all(&log_dir).expect("failed to create log directory");
         let filter = EnvFilter::new(config::log());
         let (chrome_layer, guard) = ChromeLayerBuilder::new()
-            .file(config::log_dir().join("trace.json"))
+            .file(log_dir.join("trace.json"))
             .include_args(true)
             .build();
         tracing_subscriber::registry()

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -21,6 +21,8 @@ use log::info;
 use prusti_common::{config, report::user, Stopwatch};
 use prusti_rustc_interface::interface::interface::try_print_query_stack;
 use std::{borrow::Cow, env, panic};
+use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
+use tracing_subscriber::{filter::EnvFilter, prelude::*};
 
 /// Link to report Prusti bugs
 const BUG_REPORT_URL: &str = "https://github.com/viperproject/prusti-dev/issues/new";
@@ -101,14 +103,31 @@ fn report_prusti_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
 }
 
 /// Initialize Prusti and the Rust compiler loggers.
-fn init_loggers() {
-    env_logger::init_from_env(
-        env_logger::Env::new()
-            .filter_or("PRUSTI_LOG", config::log())
-            .write_style_or("PRUSTI_LOG_STYLE", config::log_style()),
-    );
+fn init_loggers() -> Option<FlushGuard> {
+    // TODO: The `config::log() != ""` here is very bad; it makes us ignore the `log_tracing` flag
+    // It's enabled so that we only create a `trace.json` file if the user has explicitly requested logging
+    let guard = if config::log_tracing() && !config::log().is_empty() {
+        let filter = EnvFilter::new(config::log());
+        let (chrome_layer, guard) = ChromeLayerBuilder::new()
+            .file(config::log_dir().join("trace.json"))
+            .include_args(true)
+            .build();
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(chrome_layer)
+            .init();
+        Some(guard)
+    } else {
+        env_logger::init_from_env(
+            env_logger::Env::new()
+                .filter_or("PRUSTI_LOG", config::log())
+                .write_style_or("PRUSTI_LOG_STYLE", config::log_style()),
+        );
+        None
+    };
 
     prusti_rustc_interface::driver::init_rustc_env_logger();
+    guard
 }
 
 fn main() {
@@ -141,7 +160,7 @@ fn main() {
     }
 
     lazy_static::initialize(&ICE_HOOK);
-    init_loggers();
+    let _guard = init_loggers();
 
     // Disable incremental compilation because it causes mir_borrowck not to
     // be called.

--- a/prusti/src/verifier.rs
+++ b/prusti/src/verifier.rs
@@ -1,6 +1,6 @@
 //! A module that invokes the verifier `prusti-viper`
 
-use log::{debug, trace, warn};
+use log::{debug, warn};
 use prusti_common::{config, report::user};
 use prusti_interface::{
     data::{VerificationResult, VerificationTask},
@@ -9,9 +9,8 @@ use prusti_interface::{
 };
 use prusti_viper::verifier::Verifier;
 
+#[tracing::instrument(name = "prusti::verify", level = "debug", skip(env))]
 pub fn verify(env: Environment<'_>, def_spec: typed::DefSpecificationMap) {
-    trace!("[verify] enter");
-
     if env.diagnostic.has_errors() {
         warn!("The compiler reported an error, so the program will not be verified.");
     } else {
@@ -83,6 +82,4 @@ pub fn verify(env: Environment<'_>, def_spec: typed::DefSpecificationMap) {
             }
         };
     }
-
-    trace!("[verify] exit");
 }

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 tracing = "0.1"
 proc-macro-tracing = { path = "proc-macro-tracing" }

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tracing"
+version = "0.1.0"
+authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
+edition = "2021"
+
+[dependencies]
+tracing = "0.1"
+proc-macro-tracing = { path = "proc-macro-tracing" }

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -2,4 +2,4 @@
 
 Utilities for tracing within Prusti. For now the main point of this crate
 is to wrap the `instrument` macro of the `tracing` crate to make it work nicely
-with return types and rust-analyzer.
+with return types and rust-analyzer (see comments in `proc-macro-tracing` crate).

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -1,0 +1,5 @@
+# Tracing
+
+Utilities for tracing within Prusti. For now the main point of this crate
+is to wrap the `instrument` macro of the `tracing` crate to make it work nicely
+with return types and rust-analyzer.

--- a/tracing/clippy.toml
+++ b/tracing/clippy.toml
@@ -1,0 +1,2 @@
+# use rustc-hash instead: https://crates.io/crates/rustc-hash
+disallowed-types = ["std::collections::HashMap", "std::collections::HashSet", "fxhash::FxHashMap", "fxhash::FxHashSet"]

--- a/tracing/proc-macro-tracing/Cargo.toml
+++ b/tracing/proc-macro-tracing/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { version = "1.0" }
-syn = "1.0"
+proc-macro2 = "1.0"
+syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/tracing/proc-macro-tracing/Cargo.toml
+++ b/tracing/proc-macro-tracing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "proc-macro-tracing"
+version = "0.1.0"
+authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { version = "1.0" }
+syn = "1.0"
+quote = "1.0"

--- a/tracing/proc-macro-tracing/Cargo.toml
+++ b/tracing/proc-macro-tracing/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/tracing/proc-macro-tracing/src/lib.rs
+++ b/tracing/proc-macro-tracing/src/lib.rs
@@ -1,4 +1,4 @@
-// © 2019, ETH Zurich
+// © 2023, ETH Zurich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,6 +11,11 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{ItemFn, ReturnType, token::Paren, Type, TypeParen};
 
+// Using `tracing::instrument` without this crate (from the vanilla tracing crate)
+// causes RA to not pick up the return type properly atm - it colours wrong and
+// appears like a local variable on hover. Somehow this is fixed by wrapping the
+// return type in brackets (i.e. `-> TokenStream` to `-> (TokenStream)`) and so we
+// do that here.
 #[proc_macro_attribute]
 pub fn instrument(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     let (attr, tokens): (TokenStream2, TokenStream2) = (attr.into(), tokens.into());

--- a/tracing/proc-macro-tracing/src/lib.rs
+++ b/tracing/proc-macro-tracing/src/lib.rs
@@ -1,0 +1,32 @@
+// © 2019, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#![feature(proc_macro_quote)]
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{ItemFn, ReturnType, token::Paren, Type, TypeParen};
+
+#[proc_macro_attribute]
+pub fn instrument(attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    let (attr, tokens): (TokenStream2, TokenStream2) = (attr.into(), tokens.into());
+    if let Ok(mut item) = syn::parse2::<ItemFn>(tokens.clone()) {
+        if let ReturnType::Type(a, ty) = item.sig.output {
+            let new_ty = Type::Paren(TypeParen { paren_token: Paren::default(), elem: ty });
+            item.sig.output = ReturnType::Type(a, Box::new(new_ty));
+        }
+        quote! {
+            #[tracing::tracing_instrument(#attr)]
+            #item
+        }.into()
+    } else {
+        quote! {
+            #[tracing::tracing_instrument(#attr)]
+            #tokens
+        }.into()
+    }
+}

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,0 +1,8 @@
+// © 2019, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+pub use tracing::{*, instrument as tracing_instrument};
+pub use proc_macro_tracing::instrument;

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-// © 2019, ETH Zurich
+// © 2023, ETH Zurich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/viper/Cargo.toml
+++ b/viper/Cargo.toml
@@ -19,6 +19,7 @@ rustc-hash = "1.1.0"
 tokio = { version = "1.20", features = ["io-util", "net", "rt", "sync"] }
 futures = "0.3.21"
 smt-log-analyzer = { path = "../smt-log-analyzer"}
+tracing = { path = "../tracing" }
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/viper/src/ast_utils.rs
+++ b/viper/src/ast_utils.rs
@@ -21,6 +21,7 @@ impl<'a> AstUtils<'a> {
     }
 
     /// Returns a vector of consistency errors, or a Java exception
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn check_consistency(
         &self,
         program: Program<'a>,
@@ -32,6 +33,7 @@ impl<'a> AstUtils<'a> {
             .map(|java_vec| self.jni.seq_to_vec(java_vec))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn pretty_print(&self, program: Program<'a>) -> String {
         let fast_pretty_printer_wrapper =
             silver::ast::pretty::FastPrettyPrinter_object::with(self.env);

--- a/viper/src/cache.rs
+++ b/viper/src/cache.rs
@@ -58,6 +58,7 @@ impl From<&PersistentCache> for ResultCache {
 }
 
 impl PersistentCache {
+    #[tracing::instrument(level = "debug")]
     pub fn load_cache(cache_loc: PathBuf) -> Self {
         let mut data_res: Option<ResultCache> = None;
         if !cache_loc.as_os_str().is_empty() {
@@ -92,6 +93,7 @@ impl PersistentCache {
             }),
         ))
     }
+    #[tracing::instrument(level = "debug")]
     pub fn save_cache(&self, cache_loc: &Path) {
         match fs::File::create(cache_loc) {
             Ok(f) => {

--- a/viper/src/verification_context.rs
+++ b/viper/src/verification_context.rs
@@ -57,6 +57,7 @@ impl<'a> VerificationContext<'a> {
         )
     }
 
+    #[tracing::instrument(level = "debug", skip(self, smt_manager))]
     pub fn new_verifier(
         &self,
         backend: VerificationBackend,

--- a/viper/src/verifier.rs
+++ b/viper/src/verifier.rs
@@ -13,7 +13,7 @@ use crate::{
     verification_backend::VerificationBackend,
     verification_result::{VerificationError, VerificationResult},
 };
-use jni::{objects::JObject, JNIEnv};
+use jni::{errors::Result, objects::JObject, JNIEnv};
 use log::{debug, error, info};
 use std::path::PathBuf;
 use viper_sys::wrappers::{scala, viper::*};
@@ -48,14 +48,7 @@ impl<'a> Verifier<'a> {
             };
 
             let debug_info = jni.new_seq(&[]);
-            match backend {
-                VerificationBackend::Silicon => {
-                    silicon::Silicon::with(env).new(reporter, debug_info)
-                }
-                VerificationBackend::Carbon => {
-                    carbon::CarbonVerifier::with(env).new(reporter, debug_info)
-                }
-            }
+            Self::instantiate_verifier(backend, env, reporter, debug_info)
         }));
 
         ast_utils.with_local_frame(16, || {
@@ -77,7 +70,23 @@ impl<'a> Verifier<'a> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
+    fn instantiate_verifier(
+        backend: VerificationBackend,
+        env: &'a JNIEnv,
+        reporter: JObject,
+        debug_info: JObject,
+    ) -> Result<JObject<'a>> {
+        match backend {
+            VerificationBackend::Silicon => silicon::Silicon::with(env).new(reporter, debug_info),
+            VerificationBackend::Carbon => {
+                carbon::CarbonVerifier::with(env).new(reporter, debug_info)
+            }
+        }
+    }
+
     #[must_use]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn parse_command_line(self, args: &[String]) -> Self {
         self.ast_utils.with_local_frame(16, || {
             let args = self.jni.new_seq(
@@ -95,6 +104,7 @@ impl<'a> Verifier<'a> {
     }
 
     #[must_use]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn start(self) -> Self {
         self.ast_utils.with_local_frame(16, || {
             self.jni
@@ -103,8 +113,10 @@ impl<'a> Verifier<'a> {
         self
     }
 
+    #[tracing::instrument(name = "viper::verify", level = "debug", skip_all)]
     pub fn verify(&mut self, program: Program) -> VerificationResult {
-        self.ast_utils.with_local_frame(16, || {
+        let ast_utils = self.ast_utils;
+        ast_utils.with_local_frame(16, || {
             debug!(
                 "Program to be verified:\n{}",
                 self.ast_utils.pretty_print(program)
@@ -134,8 +146,7 @@ impl<'a> Verifier<'a> {
 
             run_timed!("Viper verification", debug,
                 let viper_result = self.jni.unwrap_result(
-                    self.verifier_wrapper
-                        .call_verify(self.verifier_instance, program.to_jobject()),
+                    self.call_verify(program)
                 );
             );
             debug!(
@@ -332,6 +343,12 @@ impl<'a> Verifier<'a> {
                 VerificationResult::Success
             }
         })
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    fn call_verify(&self, program: Program) -> Result<JObject<'a>> {
+        self.verifier_wrapper
+            .call_verify(self.verifier_instance, program.to_jobject())
     }
 }
 

--- a/viper/src/viper.rs
+++ b/viper/src/viper.rs
@@ -25,6 +25,7 @@ impl Viper {
         Self::new_with_args(viper_home, vec![])
     }
 
+    #[tracing::instrument(level = "debug")]
     pub fn new_with_args(viper_home: &str, java_args: Vec<String>) -> Self {
         let heap_size = env::var("JAVA_HEAP_SIZE").unwrap_or_else(|_| "512".to_string());
 

--- a/vir/Cargo.toml
+++ b/vir/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.4.0"
 itertools = "0.10.3"
 derive_more = "0.99.16"
 rustc-hash = "1.1.0"
+tracing = { path = "../tracing" }
 
 [build-dependencies]
 vir-gen = { path = "../vir-gen" }

--- a/vir/defs/polymorphic/borrows.rs
+++ b/vir/defs/polymorphic/borrows.rs
@@ -103,8 +103,8 @@ impl DAG {
     pub fn iter(&self) -> impl Iterator<Item = &Node> {
         self.nodes.iter()
     }
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn get_borrow_index(&self, borrow: Borrow) -> usize {
-        trace!("get_borrow_index(borrow={:?})", borrow);
         self.borrow_indices[&borrow]
     }
     pub fn in_borrowed_places(&self, place: &Expr) -> bool {
@@ -112,8 +112,8 @@ impl DAG {
             .iter()
             .any(|borrowed_place| place.has_prefix(borrowed_place))
     }
+    #[tracing::instrument(level = "debug")]
     pub fn check_integrity(&self) {
-        trace!("[enter] check_integrity dag=[{:?}]", self);
         if let Some(first) = self.nodes.first() {
             assert!(first.reborrowing_nodes.is_empty());
         } else if let Some(last) = self.nodes.last() {
@@ -132,7 +132,6 @@ impl DAG {
                 debug!("{:?}: {}", node.borrow, place);
             }
         }
-        trace!("[exit] check_integrity dag=[{:?}]", self);
     }
     /// Get the complete guard for the given node.
     pub fn guard(&self, expiring_borrow: Borrow) -> Expr {

--- a/vir/defs/polymorphic/cfg/method.rs
+++ b/vir/defs/polymorphic/cfg/method.rs
@@ -415,16 +415,12 @@ impl CfgMethod {
     /// Find some path from the `start_block` to the `end_block`.
     ///
     /// The returned path includes both `start_block` and `end_block`.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn find_path(
         &self,
         start_block: CfgBlockIndex,
         end_block: CfgBlockIndex,
     ) -> Option<Vec<CfgBlockIndex>> {
-        trace!(
-            "[enter] find_path start={:?} end={:?}",
-            start_block,
-            end_block
-        );
         if start_block.weak_eq(&end_block) {
             return Some(vec![start_block]);
         }

--- a/vir/defs/polymorphic/cfg/visitor.rs
+++ b/vir/defs/polymorphic/cfg/visitor.rs
@@ -96,6 +96,7 @@ pub trait CfgReplacer<PathCtxt: Debug + Clone, Action: CheckNoOpAction + Debug> 
     ) -> Result<Vec<Stmt>, Self::Error>;
 
     /// The main method: visit and replace the reachable blocks of a CFG.
+    #[tracing::instrument(level = "debug", skip(self, cfg))]
     fn replace_cfg(&mut self, cfg: &CfgMethod) -> Result<CfgMethod, Self::Error> {
         // Initialize the variables of the new cfg
         let mut new_cfg = CfgMethod::new(

--- a/vir/defs/polymorphic/utils.rs
+++ b/vir/defs/polymorphic/utils.rs
@@ -15,11 +15,11 @@ use log::{debug, trace};
 /// Substitute (map) expressions in a statement
 impl Stmt {
     #[must_use]
+    #[tracing::instrument(name = "Stmt::map_expr", level = "trace", skip_all, fields(self = %self))]
     pub fn map_expr<F>(self, substitutor: F) -> Self
     where
         F: Fn(Expr) -> Expr,
     {
-        trace!("Stmt::map_expr {}", self);
         struct StmtExprSubstitutor<T>
         where
             T: Fn(Expr) -> Expr,
@@ -37,11 +37,11 @@ impl Stmt {
         StmtExprSubstitutor { substitutor }.fold(self)
     }
 
+    #[tracing::instrument(name = "Stmt::fallible_map_expr", level = "trace", skip_all, fields(self = %self))]
     pub fn fallible_map_expr<F, E>(self, substitutor: F) -> Result<Self, E>
     where
         F: Fn(Expr) -> Result<Expr, E>,
     {
-        trace!("Stmt::fallible_map_expr {}", self);
         struct StmtExprSubstitutor<T, U>
         where
             T: Fn(Expr) -> Result<Expr, U>,
@@ -65,11 +65,11 @@ impl Stmt {
 /// In an expression, substitute labels of old expressions
 impl Expr {
     #[must_use]
+    #[tracing::instrument(name = "Expr::map_old_expr_label", level = "trace", skip_all, fields(self = %self))]
     pub fn map_old_expr_label<F>(self, substitutor: F) -> Self
     where
         F: Fn(String) -> String,
     {
-        trace!("Expr::map_old_expr_label {}", self);
         struct ExprLabelSubstitutor<T>
         where
             T: Fn(String) -> String,

--- a/vir/src/high/builders/procedure.rs
+++ b/vir/src/high/builders/procedure.rs
@@ -122,8 +122,8 @@ impl ProcedureBuilder {
 }
 
 impl<'a> BasicBlockBuilder<'a> {
+    #[tracing::instrument(level = "debug", skip(self), fields(block_id = ?self.id))]
     pub fn build(self) {
-        debug!("Building: {:?}", self.id);
         let successor = match self.successor {
             SuccessorBuilder::Exit(SuccessorExitKind::Return) => {
                 self.procedure_builder.is_return_label_used = true;

--- a/vir/src/legacy/ast/expr.rs
+++ b/vir/src/legacy/ast/expr.rs
@@ -1361,6 +1361,7 @@ impl Expr {
     }
 
     #[must_use]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn replace_place(self, target: &Expr, replacement: &Expr) -> Self {
         // TODO: disabled for snapshot patching
         /*
@@ -1492,6 +1493,7 @@ impl Expr {
     }
 
     #[must_use]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn replace_multiple_places(self, replacements: &[(Expr, Expr)]) -> Self {
         // TODO: disabled for snapshot patching
         /*

--- a/vir/src/legacy/ast/typaram.rs
+++ b/vir/src/legacy/ast/typaram.rs
@@ -29,6 +29,7 @@ impl Substs {
     /// Takes the string representation of two types: `from` is the generic one; `to` is the more
     /// concrete one.
     /// This function will compute what is the type substitution needed to go from `from` to `to`.
+    #[tracing::instrument(level = "trace")]
     pub fn learn(from: &str, to: &str) -> Self {
         lazy_static::lazy_static! {
             static ref TYPARAM_RE: Regex = Regex::new("(__TYPARAM__\\$(.*?)\\$__)").unwrap();

--- a/vir/src/legacy/borrows.rs
+++ b/vir/src/legacy/borrows.rs
@@ -107,8 +107,8 @@ impl DAG {
     pub fn iter(&self) -> impl Iterator<Item = &Node> {
         self.nodes.iter()
     }
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn get_borrow_index(&self, borrow: Borrow) -> usize {
-        trace!("get_borrow_index(borrow={:?})", borrow);
         self.borrow_indices[&borrow]
     }
     pub fn in_borrowed_places(&self, place: &Expr) -> bool {
@@ -116,8 +116,8 @@ impl DAG {
             .iter()
             .any(|borrowed_place| place.has_prefix(borrowed_place))
     }
+    #[tracing::instrument(level = "debug")]
     pub fn check_integrity(&self) {
-        trace!("[enter] check_integrity dag=[{:?}]", self);
         if let Some(first) = self.nodes.first() {
             assert!(first.reborrowing_nodes.is_empty());
         }
@@ -137,7 +137,6 @@ impl DAG {
                 debug!("{:?}: {}", node.borrow, place);
             }
         }
-        trace!("[exit] check_integrity dag=[{:?}]", self);
     }
     /// Get the complete guard for the given node.
     pub fn guard(&self, expiring_borrow: Borrow) -> Expr {

--- a/vir/src/legacy/cfg/method.rs
+++ b/vir/src/legacy/cfg/method.rs
@@ -313,16 +313,12 @@ impl CfgMethod {
     /// Find some path from the `start_block` to the `end_block`.
     ///
     /// The returned path includes both `start_block` and `end_block`.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn find_path(
         &self,
         start_block: CfgBlockIndex,
         end_block: CfgBlockIndex,
     ) -> Option<Vec<CfgBlockIndex>> {
-        trace!(
-            "[enter] find_path start={:?} end={:?}",
-            start_block,
-            end_block
-        );
         if start_block.weak_eq(&end_block) {
             return Some(vec![start_block]);
         }

--- a/vir/src/legacy/utils.rs
+++ b/vir/src/legacy/utils.rs
@@ -15,11 +15,11 @@ use log::trace;
 /// Substitute (map) expressions in a statement
 impl Stmt {
     #[must_use]
+    #[tracing::instrument(name = "Stmt::map_expr", level = "trace", skip_all, fields(self = %self))]
     pub fn map_expr<F>(self, substitutor: F) -> Self
     where
         F: FnMut(Expr) -> Expr,
     {
-        trace!("Stmt::map_expr {}", self);
         struct StmtExprSubstitutor<T>
         where
             T: FnMut(Expr) -> Expr,
@@ -37,11 +37,11 @@ impl Stmt {
         StmtExprSubstitutor { substitutor }.fold(self)
     }
 
+    #[tracing::instrument(name = "Stmt::fallible_map_expr", level = "trace", skip_all, fields(self = %self))]
     pub fn fallible_map_expr<F, E>(self, substitutor: F) -> Result<Self, E>
     where
         F: Fn(Expr) -> Result<Expr, E>,
     {
-        trace!("Stmt::fallible_map_expr {}", self);
         struct StmtExprSubstitutor<T, U>
         where
             T: Fn(Expr) -> Result<Expr, U>,
@@ -65,11 +65,11 @@ impl Stmt {
 /// In an expression, substitute labels of old expressions
 impl Expr {
     #[must_use]
+    #[tracing::instrument(name = "Expr::map_old_expr_label", level = "trace", skip_all, fields(self = %self))]
     pub fn map_old_expr_label<F>(self, substitutor: F) -> Self
     where
         F: Fn(String) -> String,
     {
-        trace!("Expr::map_old_expr_label {}", self);
         struct ExprLabelSubstitutor<T>
         where
             T: Fn(String) -> String,


### PR DESCRIPTION
Running with e.g. `PRUSTI_LOG=debug` will now generate a `log/trace.json` file which can be opened in [ui.perfetto.dev](https://ui.perfetto.dev/).