### PR TITLE
Add macro to generate getters/setters for fields via JNI

### DIFF
--- a/jni-gen/src/errors.rs
+++ b/jni-gen/src/errors.rs
@@ -54,5 +54,10 @@ error_chain::error_chain! {
             description("no matching method")
             display("no method '{}' with signature '{}' in class '{}'", method, signature, class)
         }
+
+        NoField(class: String, field: String) {
+            description("no field")
+            display("no field '{}' in class'{}'", field, class)
+        }
     }
 }

--- a/jni-gen/src/errors.rs
+++ b/jni-gen/src/errors.rs
@@ -57,7 +57,7 @@ error_chain::error_chain! {
 
         NoField(class: String, field: String) {
             description("no field")
-            display("no field '{}' in class'{}'", field, class)
+            display("no field '{}' in class '{}'", field, class)
         }
     }
 }

--- a/jni-gen/src/generators/class.rs
+++ b/jni-gen/src/generators/class.rs
@@ -7,7 +7,7 @@
 use crate::{
     class_name::*,
     errors::*,
-    generators::{constructor::*, method::*, scala_object_getter::*, field_getter_setter::*},
+    generators::{constructor::*, field_getter_setter::*, method::*, scala_object_getter::*},
     wrapper_spec::*,
 };
 use jni::JNIEnv;
@@ -133,9 +133,7 @@ impl<'a> ClassGenerator<'a> {
                 ItemWrapperSpec::FieldGetterSetter {
                     ref field_name,
                     ref signature,
-                } => {
-                    generate_field_getter_setter(self.env, &self.class, field_name, signature)?
-                }
+                } => generate_field_getter_setter(self.env, &self.class, field_name, signature)?,
             };
             gen_items.push(gen)
         }

--- a/jni-gen/src/generators/class.rs
+++ b/jni-gen/src/generators/class.rs
@@ -130,10 +130,9 @@ impl<'a> ClassGenerator<'a> {
                     signature.clone(),
                     suffix.clone(),
                 )?,
-                ItemWrapperSpec::FieldGetterSetter {
-                    ref field_name,
-                    ref signature,
-                } => generate_field_getter_setter(self.env, &self.class, field_name, signature)?,
+                ItemWrapperSpec::FieldGetterSetter { ref field_name } => {
+                    generate_field_getter_setter(self.env, &self.class, field_name)?
+                }
             };
             gen_items.push(gen)
         }

--- a/jni-gen/src/generators/class.rs
+++ b/jni-gen/src/generators/class.rs
@@ -7,7 +7,7 @@
 use crate::{
     class_name::*,
     errors::*,
-    generators::{constructor::*, method::*, scala_object_getter::*},
+    generators::{constructor::*, method::*, scala_object_getter::*, field_getter_setter::*},
     wrapper_spec::*,
 };
 use jni::JNIEnv;
@@ -130,6 +130,12 @@ impl<'a> ClassGenerator<'a> {
                     signature.clone(),
                     suffix.clone(),
                 )?,
+                ItemWrapperSpec::FieldGetterSetter {
+                    ref field_name,
+                    ref signature,
+                } => {
+                    generate_field_getter_setter(self.env, &self.class, field_name, signature)?
+                }
             };
             gen_items.push(gen)
         }

--- a/jni-gen/src/generators/field_getter_setter.rs
+++ b/jni-gen/src/generators/field_getter_setter.rs
@@ -7,46 +7,68 @@
 use crate::{class_name::*, errors::*, utils::*};
 use jni::JNIEnv;
 
-fn generate_type_check(type_signature: &str, type_name: &str, prefix: &str) -> String {
+fn generate_type_check(type_signature: &str, type_name: &str, is_result: bool) -> String {
+    if !type_signature.starts_with('L') {
+        return "".to_string();
+    }
+
     let type_class = &type_signature[1..(type_signature.len() - 1)];
-    vec![
+
+    let type_check = vec![
         "    debug_assert!(".to_string(),
         "        self.env.is_instance_of(".to_string(),
-        format!("            {},", type_name),
-        format!("            self.env.find_class(\"{}\")?,", type_class),
+        format!("            {type_name},"),
+        format!("            self.env.find_class(\"{type_class}\")?,"),
         "        )?".to_string(),
         "    );".to_string(),
-    ].iter().map(|x| format!("{}{}", prefix, x)).collect::<Vec<_>>().join("\n")
+    ];
+
+    if is_result {
+        let indented_type_check = type_check
+            .iter()
+            .map(|x| format!("    {x}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        vec![
+            "    if let Ok(result) = result {".to_string(),
+            indented_type_check,
+            "    }".to_string(),
+        ]
+    } else {
+        type_check
+    }
+    .join("\n")
+        + "\n"
 }
 
 fn generate_result_type_check(return_signature: &str) -> String {
-    vec![
-        "    if let Ok(result) = result {".to_string(),
-        generate_type_check(return_signature, "result", "    "),
-        "    }".to_string(),
-        "".to_string(),
-    ].join("\n")
+    generate_type_check(return_signature, "result", true)
 }
 
 fn generate_parameter_type_check(type_signature: &str, type_name: &str) -> String {
-    generate_type_check(type_signature, type_name, "")+"\n"
+    generate_type_check(type_signature, type_name, false)
 }
 
 fn generate_field_getter(class_name: &ClassName, field_name: &str, type_signature: &str) -> String {
-    let rust_getter_name = format!("call_getter_{}", java_identifier_to_rust(field_name));
+    let rust_getter_name = format!("get_{}", java_identifier_to_rust(field_name));
     let parameter_type = generate_jni_type(type_signature);
 
     vec![
-        format!("/// Returns the field `{}` of the scala class `{}`.", field_name, class_name.full_name()),
+        format!(
+            "/// Returns the field `{}` of the scala class `{}`.",
+            field_name,
+            class_name.full_name()
+        ),
         "///".to_string(),
-        format!("/// Return type and Java signature: `{}` (`{}`)", parameter_type, type_signature),
+        format!("/// Return type and Java signature: `{parameter_type}` (`{type_signature}`)"),
         format!("pub fn {rust_getter_name}("),
         "    &self,".to_string(),
         "    receiver: JObject<'a>,".to_string(),
         ") -> JNIResult<JObject> {".to_string(),
         format!("    let class_name = \"{}\";", class_name.path()),
-        format!("    let field_name = \"{}\";", field_name),
-        format!("    let return_signature = \"{}\";", type_signature),
+        format!("    let field_name = \"{field_name}\";"),
+        format!("    let return_signature = \"{type_signature}\";"),
         "".to_string(),
         "    debug_assert!(".to_string(),
         "        self.env.is_instance_of(".to_string(),
@@ -59,36 +81,44 @@ fn generate_field_getter(class_name: &ClassName, field_name: &str, type_signatur
         "        receiver,".to_string(),
         "        field_name,".to_string(),
         "        return_signature,".to_string(),
-        format!("    ).and_then(|x| x.{}());", generate_jni_type_char(&type_signature)),
+        format!(
+            "    ).and_then(|x| x.{}());",
+            generate_jni_type_char(type_signature)
+        ),
         "".to_string(),
-        if type_signature.starts_with('L') {generate_result_type_check(&type_signature)} else {"".to_string()},
+        generate_result_type_check(type_signature),
         "    result".to_string(),
         "}".to_string(),
     ]
-    .join("\n")+"\n"
+    .join("\n")
+        + "\n"
 }
 
 fn generate_field_setter(class_name: &ClassName, field_name: &str, type_signature: &str) -> String {
-    let rust_setter_name = format!("call_setter_{}", java_identifier_to_rust(field_name));
-    let parameter_name = format!("new_{}", field_name);
+    let rust_setter_name = format!("set_{}", java_identifier_to_rust(field_name));
+    let parameter_name = format!("new_{field_name}");
     let parameter_type = generate_jni_type(type_signature);
 
     vec![
-        format!("/// Sets the field `{}` of the scala class `{}`.", field_name, class_name.full_name()),
+        format!(
+            "/// Sets the field `{}` of the scala class `{}`.",
+            field_name,
+            class_name.full_name()
+        ),
         "///".to_string(),
         "/// Type and Java signature of parameters:".to_string(),
         "///".to_string(),
-        format!("/// - `{}`: `{}` (`{}`)", parameter_name, parameter_type, type_signature),
+        format!("/// - `{parameter_name}`: `{parameter_type}` (`{type_signature}`)"),
         "/// ".to_string(),
         "/// Return type and Java signature: `()` (`V`)".to_string(),
         format!("pub fn {rust_setter_name}("),
         "    &self,".to_string(),
         "    receiver: JObject<'a>,".to_string(),
-        format!("    {}: {},", parameter_name, parameter_type),
+        format!("    {parameter_name}: {parameter_type},"),
         ") -> JNIResult<()> {".to_string(),
         format!("    let class_name = \"{}\";", class_name.path()),
-        format!("    let field_name = \"{}\";", field_name),
-        format!("    let return_signature = \"{}\";", type_signature),
+        format!("    let field_name = \"{field_name}\";"),
+        format!("    let return_signature = \"{type_signature}\";"),
         "".to_string(),
         "    debug_assert!(".to_string(),
         "        self.env.is_instance_of(".to_string(),
@@ -97,30 +127,30 @@ fn generate_field_setter(class_name: &ClassName, field_name: &str, type_signatur
         "        )?".to_string(),
         "    );".to_string(),
         "".to_string(),
-        if type_signature.starts_with('L') {generate_parameter_type_check(&type_signature, &parameter_name)} else {"".to_string()},
-        "    let result = self.env.set_field(".to_string(),
+        generate_parameter_type_check(type_signature, &parameter_name),
+        "    self.env.set_field(".to_string(),
         "        receiver,".to_string(),
         "        field_name,".to_string(),
         "        return_signature,".to_string(),
-        format!("        JValue::from({})", parameter_name),
-        "    );".to_string(),
-        "".to_string(),
-        "    result".to_string(),
+        format!("        JValue::from({parameter_name})"),
+        "    )".to_string(),
         "}".to_string(),
     ]
-    .join("\n")+"\n"
+    .join("\n")
+        + "\n"
 }
 
-pub fn generate_field_getter_setter(env: &JNIEnv, class_name: &ClassName, field_name: &str, type_signature: &str) -> Result<String> {
-    env.get_field_id(
-        class_name.path(),
-        field_name,
-        type_signature,
-    )
-    .map(|_| ())?;
+pub fn generate_field_getter_setter(
+    env: &JNIEnv,
+    class_name: &ClassName,
+    field_name: &str,
+    type_signature: &str,
+) -> Result<String> {
+    env.get_field_id(class_name.path(), field_name, type_signature)
+        .map(|_| ())?;
 
     let setter_code = generate_field_getter(class_name, field_name, type_signature);
     let getter_code = generate_field_setter(class_name, field_name, type_signature);
 
-    Ok(format!("{}\n{}", setter_code, getter_code))
+    Ok(format!("{setter_code}\n{getter_code}"))
 }

--- a/jni-gen/src/generators/field_getter_setter.rs
+++ b/jni-gen/src/generators/field_getter_setter.rs
@@ -1,0 +1,126 @@
+// © 2019, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::{class_name::*, errors::*, utils::*};
+use jni::JNIEnv;
+
+fn generate_type_check(type_signature: &str, type_name: &str, prefix: &str) -> String {
+    let type_class = &type_signature[1..(type_signature.len() - 1)];
+    vec![
+        "    debug_assert!(".to_string(),
+        "        self.env.is_instance_of(".to_string(),
+        format!("            {},", type_name),
+        format!("            self.env.find_class(\"{}\")?,", type_class),
+        "        )?".to_string(),
+        "    );".to_string(),
+    ].iter().map(|x| format!("{}{}", prefix, x)).collect::<Vec<_>>().join("\n")
+}
+
+fn generate_result_type_check(return_signature: &str) -> String {
+    vec![
+        "    if let Ok(result) = result {".to_string(),
+        generate_type_check(return_signature, "result", "    "),
+        "    }".to_string(),
+        "".to_string(),
+    ].join("\n")
+}
+
+fn generate_parameter_type_check(type_signature: &str, type_name: &str) -> String {
+    generate_type_check(type_signature, type_name, "")+"\n"
+}
+
+fn generate_field_getter(class_name: &ClassName, field_name: &str, type_signature: &str) -> String {
+    let rust_getter_name = format!("call_getter_{}", java_identifier_to_rust(field_name));
+    let parameter_type = generate_jni_type(type_signature);
+
+    vec![
+        format!("/// Returns the field `{}` of the scala class `{}`.", field_name, class_name.full_name()),
+        "///".to_string(),
+        format!("/// Return type and Java signature: `{}` (`{}`)", parameter_type, type_signature),
+        format!("pub fn {rust_getter_name}("),
+        "    &self,".to_string(),
+        "    receiver: JObject<'a>,".to_string(),
+        ") -> JNIResult<JObject> {".to_string(),
+        format!("    let class_name = \"{}\";", class_name.path()),
+        format!("    let field_name = \"{}\";", field_name),
+        format!("    let return_signature = \"{}\";", type_signature),
+        "".to_string(),
+        "    debug_assert!(".to_string(),
+        "        self.env.is_instance_of(".to_string(),
+        "            receiver,".to_string(),
+        "            self.env.find_class(class_name)?,".to_string(),
+        "        )?".to_string(),
+        "    );".to_string(),
+        "".to_string(),
+        "    let result = self.env.get_field(".to_string(),
+        "        receiver,".to_string(),
+        "        field_name,".to_string(),
+        "        return_signature,".to_string(),
+        format!("    ).and_then(|x| x.{}());", generate_jni_type_char(&type_signature)),
+        "".to_string(),
+        if type_signature.starts_with('L') {generate_result_type_check(&type_signature)} else {"".to_string()},
+        "    result".to_string(),
+        "}".to_string(),
+    ]
+    .join("\n")+"\n"
+}
+
+fn generate_field_setter(class_name: &ClassName, field_name: &str, type_signature: &str) -> String {
+    let rust_setter_name = format!("call_setter_{}", java_identifier_to_rust(field_name));
+    let parameter_name = format!("new_{}", field_name);
+    let parameter_type = generate_jni_type(type_signature);
+
+    vec![
+        format!("/// Sets the field `{}` of the scala class `{}`.", field_name, class_name.full_name()),
+        "///".to_string(),
+        "/// Type and Java signature of parameters:".to_string(),
+        "///".to_string(),
+        format!("/// - `{}`: `{}` (`{}`)", parameter_name, parameter_type, type_signature),
+        "/// ".to_string(),
+        "/// Return type and Java signature: `()` (`V`)".to_string(),
+        format!("pub fn {rust_setter_name}("),
+        "    &self,".to_string(),
+        "    receiver: JObject<'a>,".to_string(),
+        format!("    {}: {},", parameter_name, parameter_type),
+        ") -> JNIResult<()> {".to_string(),
+        format!("    let class_name = \"{}\";", class_name.path()),
+        format!("    let field_name = \"{}\";", field_name),
+        format!("    let return_signature = \"{}\";", type_signature),
+        "".to_string(),
+        "    debug_assert!(".to_string(),
+        "        self.env.is_instance_of(".to_string(),
+        "            receiver,".to_string(),
+        "            self.env.find_class(class_name)?,".to_string(),
+        "        )?".to_string(),
+        "    );".to_string(),
+        "".to_string(),
+        if type_signature.starts_with('L') {generate_parameter_type_check(&type_signature, &parameter_name)} else {"".to_string()},
+        "    let result = self.env.set_field(".to_string(),
+        "        receiver,".to_string(),
+        "        field_name,".to_string(),
+        "        return_signature,".to_string(),
+        format!("        JValue::from({})", parameter_name),
+        "    );".to_string(),
+        "".to_string(),
+        "    result".to_string(),
+        "}".to_string(),
+    ]
+    .join("\n")+"\n"
+}
+
+pub fn generate_field_getter_setter(env: &JNIEnv, class_name: &ClassName, field_name: &str, type_signature: &str) -> Result<String> {
+    env.get_field_id(
+        class_name.path(),
+        field_name,
+        type_signature,
+    )
+    .map(|_| ())?;
+
+    let setter_code = generate_field_getter(class_name, field_name, type_signature);
+    let getter_code = generate_field_setter(class_name, field_name, type_signature);
+
+    Ok(format!("{}\n{}", setter_code, getter_code))
+}

--- a/jni-gen/src/generators/field_getter_setter.rs
+++ b/jni-gen/src/generators/field_getter_setter.rs
@@ -62,8 +62,8 @@ fn class_field_lookup<'a>(
     Ok(None)
 }
 
-// Generates a runtine check that the object is of the expected class - applies only to object types (starting with L)
-// If this value is also the returned value in the setter, unwrap it first (since it is of type Result<T>)
+/// Generates a runtime check that the object is of the expected class - applies only to object types (starting with L)
+/// If this value is also the returned value in the setter, unwrap it first (since it is of type Result<T>)
 fn generate_type_check(expected_variable_signature: &str, variable_name: &str, is_result: bool) -> String {
     if !expected_variable_signature.starts_with('L') {
         return "".to_string();
@@ -203,7 +203,7 @@ fn generate_field_setter(class: &ClassName, field_name: &str, type_signature: &s
 /// It works also for private fields and for inherited fields
 ///
 /// It determines the type of the field by iterating over the
-/// inheritance hierarchy and checking for a field with matching name
+/// inheritance hierarchy and checking for a field with the matching name
 ///
 /// For class type fields it also generates runtime checks verifying
 /// that the given object is of the specified class (or its descendant)

--- a/jni-gen/src/generators/field_getter_setter.rs
+++ b/jni-gen/src/generators/field_getter_setter.rs
@@ -64,7 +64,11 @@ fn class_field_lookup<'a>(
 
 /// Generates a runtime check that the object is of the expected class - applies only to object types (starting with L)
 /// If this value is also the returned value in the setter, unwrap it first (since it is of type Result<T>)
-fn generate_type_check(expected_variable_signature: &str, variable_name: &str, is_result: bool) -> String {
+fn generate_type_check(
+    expected_variable_signature: &str,
+    variable_name: &str,
+    is_result: bool,
+) -> String {
     if !expected_variable_signature.starts_with('L') {
         return "".to_string();
     }

--- a/jni-gen/src/generators/field_getter_setter.rs
+++ b/jni-gen/src/generators/field_getter_setter.rs
@@ -1,4 +1,4 @@
-// © 2019, ETH Zurich
+// © 2023, ETH Zurich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/jni-gen/src/generators/field_getter_setter.rs
+++ b/jni-gen/src/generators/field_getter_setter.rs
@@ -7,7 +7,62 @@
 // use core::num::flt2dec::Sign;
 
 use crate::{class_name::*, errors::*, utils::*};
-use jni::{objects::JObject, JNIEnv};
+use jni::{
+    objects::{JClass, JObject, JValue},
+    JNIEnv,
+};
+
+fn hierarchy_field_lookup<'a>(
+    env: &JNIEnv<'a>,
+    class: &ClassName,
+    lookup_name: &str,
+) -> Result<Option<JObject<'a>>> {
+    let mut clazz = env.find_class(class.path())?;
+    while !clazz.is_null() {
+        if let Some(field) = class_field_lookup(env, clazz, lookup_name)? {
+            return Ok(Some(field));
+        }
+
+        clazz = env.get_superclass(clazz)?;
+    }
+
+    Ok(None)
+}
+
+fn class_field_lookup<'a>(
+    env: &JNIEnv<'a>,
+    clazz: JClass<'a>,
+    lookup_name: &str,
+) -> Result<Option<JObject<'a>>> {
+    let fields = env
+        .call_method(
+            clazz,
+            "getDeclaredFields",
+            "()[Ljava/lang/reflect/Field;",
+            &[],
+        )?
+        .l()?;
+
+    let num_fields = env.get_array_length(*fields)?;
+
+    for field_index in 0..num_fields {
+        let field = env.get_object_array_element(*fields, field_index)?;
+
+        let field_name = java_str_to_string(
+            &env.get_string(
+                env.call_method(field, "getName", "()Ljava/lang/String;", &[])?
+                    .l()?
+                    .into(),
+            )?,
+        )?;
+
+        if field_name == lookup_name {
+            return Ok(Some(field));
+        }
+    }
+
+    Ok(None)
+}
 
 fn generate_type_check(type_signature: &str, type_name: &str, is_result: bool) -> String {
     if !type_signature.starts_with('L') {
@@ -52,7 +107,7 @@ fn generate_parameter_type_check(type_signature: &str, type_name: &str) -> Strin
     generate_type_check(type_signature, type_name, false)
 }
 
-fn generate_field_getter(class_name: &ClassName, field_name: &str, type_signature: &str) -> String {
+fn generate_field_getter(class: &ClassName, field_name: &str, type_signature: &str) -> String {
     let rust_getter_name = format!("get_{}", java_identifier_to_rust(field_name));
     let parameter_type = generate_jni_type(type_signature);
 
@@ -60,7 +115,7 @@ fn generate_field_getter(class_name: &ClassName, field_name: &str, type_signatur
         format!(
             "/// Returns the field `{}` of the scala class `{}`.",
             field_name,
-            class_name.full_name()
+            class.full_name()
         ),
         "///".to_string(),
         format!("/// Return type and Java signature: `{parameter_type}` (`{type_signature}`)"),
@@ -68,7 +123,7 @@ fn generate_field_getter(class_name: &ClassName, field_name: &str, type_signatur
         "    &self,".to_string(),
         "    receiver: JObject<'a>,".to_string(),
         format!(") -> JNIResult<{parameter_type}> {{"),
-        format!("    let class_name = \"{}\";", class_name.path()),
+        format!("    let class_name = \"{}\";", class.path()),
         format!("    let field_name = \"{field_name}\";"),
         format!("    let return_signature = \"{type_signature}\";"),
         "".to_string(),
@@ -96,7 +151,7 @@ fn generate_field_getter(class_name: &ClassName, field_name: &str, type_signatur
         + "\n"
 }
 
-fn generate_field_setter(class_name: &ClassName, field_name: &str, type_signature: &str) -> String {
+fn generate_field_setter(class: &ClassName, field_name: &str, type_signature: &str) -> String {
     let rust_setter_name = format!("set_{}", java_identifier_to_rust(field_name));
     let parameter_name = format!("new_{field_name}");
     let parameter_type = generate_jni_type(type_signature);
@@ -105,7 +160,7 @@ fn generate_field_setter(class_name: &ClassName, field_name: &str, type_signatur
         format!(
             "/// Sets the field `{}` of the scala class `{}`.",
             field_name,
-            class_name.full_name()
+            class.full_name()
         ),
         "///".to_string(),
         "/// Type and Java signature of parameters:".to_string(),
@@ -118,7 +173,7 @@ fn generate_field_setter(class_name: &ClassName, field_name: &str, type_signatur
         "    receiver: JObject<'a>,".to_string(),
         format!("    {parameter_name}: {parameter_type},"),
         ") -> JNIResult<()> {".to_string(),
-        format!("    let class_name = \"{}\";", class_name.path()),
+        format!("    let class_name = \"{}\";", class.path()),
         format!("    let field_name = \"{field_name}\";"),
         format!("    let return_signature = \"{type_signature}\";"),
         "".to_string(),
@@ -144,24 +199,33 @@ fn generate_field_setter(class_name: &ClassName, field_name: &str, type_signatur
 
 pub fn generate_field_getter_setter(
     env: &JNIEnv,
-    class_name: &ClassName,
+    class: &ClassName,
     field_name: &str,
 ) -> Result<String> {
-    let clazz = env.find_class(class_name.path())?;
+    let field_signature = match hierarchy_field_lookup(env, class, field_name)? {
+        Some(field) => {
+            let field_type = env
+                .call_method(field, "getType", "()Ljava/lang/Class;", &[])?
+                .l()?;
 
-    let field = env
-        .call_method(
-            clazz,
-            "getField",
-            "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-            &[JObject::from(env.new_string(field_name.to_owned())?).into()],
-        )?
-        .l()?;
+            java_str_to_string(
+                &env.get_string(
+                    env.call_static_method(
+                        "org/objectweb/asm/Type",
+                        "getDescriptor",
+                        "(Ljava/lang/Class;)Ljava/lang/String;",
+                        &[JValue::Object(field_type)],
+                    )?
+                    .l()?
+                    .into(),
+                )?,
+            )?
+        }
+        _ => return Err(ErrorKind::NoField(class.full_name(), field_name.into()).into()),
+    };
 
-    let type_signature = ""; // TODO Generate the signature in a proper format
-
-    let setter_code = generate_field_getter(class_name, field_name, type_signature);
-    let getter_code = generate_field_setter(class_name, field_name, type_signature);
+    let setter_code = generate_field_getter(class, field_name, &field_signature);
+    let getter_code = generate_field_setter(class, field_name, &field_signature);
 
     Ok(format!("{setter_code}\n{getter_code}"))
 }

--- a/jni-gen/src/generators/field_getter_setter.rs
+++ b/jni-gen/src/generators/field_getter_setter.rs
@@ -65,7 +65,7 @@ fn generate_field_getter(class_name: &ClassName, field_name: &str, type_signatur
         format!("pub fn {rust_getter_name}("),
         "    &self,".to_string(),
         "    receiver: JObject<'a>,".to_string(),
-        ") -> JNIResult<JObject> {".to_string(),
+        format!(") -> JNIResult<{parameter_type}> {{"),
         format!("    let class_name = \"{}\";", class_name.path()),
         format!("    let field_name = \"{field_name}\";"),
         format!("    let return_signature = \"{type_signature}\";"),

--- a/jni-gen/src/generators/method.rs
+++ b/jni-gen/src/generators/method.rs
@@ -147,8 +147,8 @@ pub fn generate_method(
     }
 
     let rust_method_name = match suffix {
-        None => format!("call_{}", java_method_to_rust(method_name)),
-        Some(s) => format!("call_{}_{}", java_method_to_rust(method_name), s),
+        None => format!("call_{}", java_identifier_to_rust(method_name)),
+        Some(s) => format!("call_{}_{}", java_identifier_to_rust(method_name), s),
     };
 
     if is_static {
@@ -190,9 +190,12 @@ fn generate(
         method_name,
         class.full_name()
     ));
-    code.push("///".to_string());
-    code.push("/// Type and Java signature of parameters:".to_string());
-    code.push("///".to_string());
+
+    if !parameter_names.is_empty() {
+        code.push("///".to_string());
+        code.push("/// Type and Java signature of parameters:".to_string());
+        code.push("///".to_string());
+    }
 
     for i in 0..parameter_names.len() {
         let par_name = &parameter_names[i];
@@ -450,9 +453,4 @@ fn generate_static(
     code.push("}".to_string());
 
     code.join("\n") + "\n"
-}
-
-fn java_method_to_rust(method_name: &str) -> String {
-    method_name.replace('_', "__").replace('$', "_dollar_")
-    // If needed, replace other charachters with "_{something}_"
 }

--- a/jni-gen/src/generators/mod.rs
+++ b/jni-gen/src/generators/mod.rs
@@ -9,3 +9,4 @@ mod constructor;
 mod method;
 pub mod module;
 mod scala_object_getter;
+mod field_getter_setter;

--- a/jni-gen/src/utils.rs
+++ b/jni-gen/src/utils.rs
@@ -72,11 +72,10 @@ pub fn java_str_to_string(string: &JavaStr) -> Result<String> {
 }
 
 pub fn java_str_to_valid_rust_argument_name(string: &JavaStr) -> Result<String> {
-    let mut res = "arg_".to_string();
-    res.push_str(
-        &java_str_to_string(string)?
-            .replace('_', "___")
-            .replace('$', "_d_"),
-    );
-    Ok(res)
+    Ok(format!("arg_{}", java_identifier_to_rust(&java_str_to_string(string)?)))
+}
+
+pub fn java_identifier_to_rust(name: &str) -> String {
+    // identifier can only be composed of [a-zA-Z&_] characters - https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8
+    name.replace('_', "__").replace('$', "_dollar_")
 }

--- a/jni-gen/src/utils.rs
+++ b/jni-gen/src/utils.rs
@@ -72,7 +72,10 @@ pub fn java_str_to_string(string: &JavaStr) -> Result<String> {
 }
 
 pub fn java_str_to_valid_rust_argument_name(string: &JavaStr) -> Result<String> {
-    Ok(format!("arg_{}", java_identifier_to_rust(&java_str_to_string(string)?)))
+    Ok(format!(
+        "arg_{}",
+        java_identifier_to_rust(&java_str_to_string(string)?)
+    ))
 }
 
 pub fn java_identifier_to_rust(name: &str) -> String {

--- a/jni-gen/src/wrapper_spec.rs
+++ b/jni-gen/src/wrapper_spec.rs
@@ -112,7 +112,7 @@ macro_rules! method {
 }
 
 #[macro_export]
-macro_rules! field_getter_setter {
+macro_rules! field {
     ($name:expr, $signature:expr) => {
         ItemWrapperSpec::FieldGetterSetter {
             field_name: $name.into(),

--- a/jni-gen/src/wrapper_spec.rs
+++ b/jni-gen/src/wrapper_spec.rs
@@ -41,6 +41,10 @@ pub enum ItemWrapperSpec {
         signature: Option<String>,
         suffix: Option<String>,
     },
+    FieldGetterSetter {
+        field_name: String,
+        signature: String,
+    },
 }
 
 #[macro_export]
@@ -103,6 +107,16 @@ macro_rules! method {
             name: $name.into(),
             signature: Some($signature.into()),
             suffix: Some($suffix.into()),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! field_getter_setter {
+    ($name:expr, $signature:expr) => {
+        ItemWrapperSpec::FieldGetterSetter {
+            field_name: $name.into(),
+            signature: $signature.into(),
         }
     };
 }

--- a/jni-gen/src/wrapper_spec.rs
+++ b/jni-gen/src/wrapper_spec.rs
@@ -43,7 +43,6 @@ pub enum ItemWrapperSpec {
     },
     FieldGetterSetter {
         field_name: String,
-        signature: String,
     },
 }
 
@@ -113,10 +112,9 @@ macro_rules! method {
 
 #[macro_export]
 macro_rules! field {
-    ($name:expr, $signature:expr) => {
+    ($name:expr) => {
         ItemWrapperSpec::FieldGetterSetter {
             field_name: $name.into(),
-            signature: $signature.into(),
         }
     };
 }

--- a/jni-gen/systest/build.rs
+++ b/jni-gen/systest/build.rs
@@ -28,14 +28,18 @@ fn main() {
         .use_jar(&asm_jar)
         .wrap(java_class!("java.lang.Object"))
         .wrap_all(vec![
-            java_class!("java.lang.Integer", vec![constructor!("(I)V")]),
-            java_class!(
-                "java.util.Arrays",
-                vec![method!(
-                    "binarySearch",
-                    "([Ljava/lang/Object;Ljava/lang/Object;)I"
-                ),]
-            ),
+            java_class!("java.lang.Integer", vec![
+                constructor!("(I)V"),
+                field!("value", "I")
+            ]),
+            java_class!("java.util.Arrays", vec![
+                method!("binarySearch", "([Ljava/lang/Object;Ljava/lang/Object;)I"),
+            ]),
+            java_class!("java.lang.Error", vec![
+                constructor!("(Ljava/lang/String;)V"),
+                method!("getMessage"),
+                field!("detailMessage", "Ljava/lang/String;"),
+            ]),
         ])
         .generate(&generated_dir)
         .unwrap_or_else(|e| {

--- a/jni-gen/systest/build.rs
+++ b/jni-gen/systest/build.rs
@@ -30,7 +30,7 @@ fn main() {
         .wrap_all(vec![
             java_class!("java.lang.Integer", vec![
                 constructor!("(I)V"),
-                field!("value", "I")
+                field!("value")
             ]),
             java_class!("java.util.Arrays", vec![
                 method!("binarySearch", "([Ljava/lang/Object;Ljava/lang/Object;)I"),
@@ -38,7 +38,7 @@ fn main() {
             java_class!("java.lang.Error", vec![
                 constructor!("(Ljava/lang/String;)V"),
                 method!("getMessage"),
-                field!("detailMessage", "Ljava/lang/String;"),
+                field!("detailMessage"),
             ]),
         ])
         .generate(&generated_dir)


### PR DESCRIPTION
This PR allows using a new macro `field_getter_setter` in the `viper-sys/build.rs`. For a given java class it will generate a getter/setter (rust code using JNI) for a certain field.

When reviewing this code please note that I have no prior experience with either Rust or Scala - hence there might be beginner mistakes and if you believe I did something because there had to be a specific reason there is probably none.