### PR TITLE
Support unevaluated constants in specs

### DIFF
--- a/prusti-tests/tests/verify_overflow/pass/issues/issue-1268.rs
+++ b/prusti-tests/tests/verify_overflow/pass/issues/issue-1268.rs
@@ -1,0 +1,13 @@
+use prusti_contracts::*;
+
+enum TestEnum {
+    Nil,
+}
+
+#[ensures(TestEnum::Nil === TestEnum::Nil)]
+fn test() {}
+
+fn main() {
+    let foo = 5;
+    prusti_assert!(foo === 5);
+}

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
@@ -134,9 +134,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
             &mir::Operand::Move(place) | &mir::Operand::Copy(place) => {
                 Ok((self.encode_place(place)?.0, false))
             }
-            mir::Operand::Constant(constant) => {
-                Ok((self.encoder.encode_snapshot_constant(constant)?, true))
-            }
+            mir::Operand::Constant(constant) => match constant.literal {
+                mir::ConstantKind::Unevaluated(c, _cty) => {
+                    Ok((self.encoder.encode_uneval_const(c)?, true))
+                }
+                _ => Ok((self.encoder.encode_snapshot_constant(constant)?, true)),
+            },
         }
     }
 


### PR DESCRIPTION
Fix #1268.

Constant encoding is a bit of a mess. There are some functions in `Enconder` to specifically handle scalar constants, there is `encode_snapshot_constant`, and there is the `ConstantsEncoderInterface` (@vakaras) which is a copy of the `Encoder` version but without using the `encode_snapshot_constant`…

Anyway, this PR adds support for unevaluated constants (for example, a reference to a constant) in the pure function encoder. In the MIR these are represented as "promoted" items, i.e. sub-bodies of MIR bodies identified by a pair the owner `DefId` and a [`Promoted`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Promoted.html) index. We can run such bodies through the pure function encoder to get a snapshot encoding of the "execution" of such a constant. Since #1304 this works for enums too, thanks to https://github.com/rust-lang/rust/pull/107267.