### PR TITLE
Make Prusti work with build scripts and AnonConst fns

### DIFF
--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -140,8 +140,15 @@ fn main() {
     // have been filtered out.
     let original_rustc_args = config::get_filtered_args();
 
-    // If the environment asks us to actually be rustc, then run `rustc` instead of Prusti.
-    if config::be_rustc() {
+    // Are we building a build script?
+    let build_script_build = arg_value(&original_rustc_args, "--crate-name", |val| {
+        val == "build_script_build"
+    })
+    .is_some();
+
+    // If the environment asks us to actually be rustc, then run `rustc` instead of Prusti,
+    // or if we're building a build script where we can't retrieve MIR bodies.
+    if config::be_rustc() || build_script_build {
         prusti_rustc_interface::driver::main();
     }
 


### PR DESCRIPTION
Prusti would crash when trying to get the MIR body of `AnonConst` functions, or any functions when compiling a build script. This change ignores both, in the future we might want to figure out if we actually want to handle these cases, and, if so, how.