### PR TITLE
Implement export/import of quantifiers

### DIFF
--- a/prusti-contracts-build/build.rs
+++ b/prusti-contracts-build/build.rs
@@ -47,6 +47,8 @@ fn main() {
         cmd.arg("--release");
     }
     cmd.env_remove("CARGO_MANIFEST_DIR");
+    // This is set when running clippy, but we can't run clippy and prusti at the same time.
+    cmd.env_remove("RUSTC_WORKSPACE_WRAPPER");
 
     // Not a warning but no other way to print to console
     println!("cargo:warning=Building `prusti-contracts` with {cmd:?}, please wait.",);

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -13,6 +13,7 @@ use prusti_rustc_interface::{
     data_structures::fx::FxHashMap,
     errors::MultiSpan,
     hir::{
+        self,
         def_id::{DefId, LocalDefId},
         intravisit, FnRetTy,
     },
@@ -290,7 +291,7 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
 
     fn ensure_local_mirs_fetched(&mut self, def_spec: &typed::DefSpecificationMap) {
         let (specs, pure_fns, predicates) = def_spec.defid_for_export();
-        for def_id in specs {
+        for def_id in &specs {
             self.env.body.load_spec_body(def_id.expect_local());
         }
         for def_id in pure_fns {
@@ -298,9 +299,45 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
                 self.env.body.load_pure_fn_body(def_id.expect_local());
             }
         }
-        for def_id in predicates {
+        for def_id in &predicates {
             self.env.body.load_predicate_body(def_id.expect_local());
         }
+
+        let mut cl_visitor = CollectAllClosureDefsVisitor {
+            map: self.env.query.hir(),
+            result: Vec::new(),
+        };
+        for def_id in specs.iter().chain(predicates.iter()) {
+            let body_id = self.env.query.hir().body_owned_by(def_id.expect_local());
+            intravisit::Visitor::visit_nested_body(&mut cl_visitor, body_id);
+        }
+        for def_id in cl_visitor.result {
+            self.env.body.load_closure_body(def_id);
+        }
+    }
+}
+
+/// Collects the LocalDefId of all closures. This is used to find all
+/// quantifiers/triggers inside specs and predicates, so they can be
+/// exported.
+struct CollectAllClosureDefsVisitor<'tcx> {
+    map: Map<'tcx>,
+    result: Vec<LocalDefId>,
+}
+
+impl<'tcx> intravisit::Visitor<'tcx> for CollectAllClosureDefsVisitor<'tcx> {
+    type NestedFilter = prusti_rustc_interface::middle::hir::nested_filter::OnlyBodies;
+
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self.map
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        if let hir::ExprKind::Closure(hir::Closure { def_id, .. }) = expr.kind {
+            self.result.push(*def_id);
+        }
+
+        intravisit::walk_expr(self, expr)
     }
 }
 

--- a/prusti-launch/src/bin/cargo-prusti.rs
+++ b/prusti-launch/src/bin/cargo-prusti.rs
@@ -50,7 +50,8 @@ where
         .args(args)
         .env("RUST_TOOLCHAIN", launch::get_rust_toolchain_channel())
         .env("RUSTUP_TOOLCHAIN", launch::get_rust_toolchain_channel())
-        .env("RUSTC_WRAPPER", prusti_rustc_path)
+        .env("RUSTC", prusti_rustc_path)
+        .env("PRUSTI_CARGO", "")
         .env("CARGO_TARGET_DIR", &cargo_target)
         // Category B flags (update the docs if any more are added):
         .env("PRUSTI_BE_RUSTC", config::be_rustc().to_string())

--- a/prusti-launch/src/bin/prusti-rustc.rs
+++ b/prusti-launch/src/bin/prusti-rustc.rs
@@ -5,12 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use prusti_utils::launch;
-use std::{
-    env,
-    io::Write,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{env, io::Write, path::PathBuf, process::Command};
 
 fn main() {
     if let Err(code) = process(std::env::args().skip(1).collect()) {
@@ -48,15 +43,7 @@ fn process(mut args: Vec<String>) -> Result<(), i32> {
 
     launch::set_environment_settings(&mut cmd, &prusti_home, &java_home);
 
-    // Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
-    // We're invoking the compiler programmatically, so we ignore this
-    let rustc_pos = args
-        .iter()
-        .position(|arg| Path::new(arg).file_stem() == Some("rustc".as_ref()));
-    let cargo_invoked = rustc_pos.is_some();
-    if let Some(rustc_pos) = rustc_pos {
-        args.drain(0..=rustc_pos);
-    }
+    let cargo_invoked = env::var("PRUSTI_CARGO").is_ok();
 
     // No need to check if we happen to be running on e.g. the `prusti-contracts` crate since this
     // should always be with `cargo` anyway (i.e. cargo_invoked == true)

--- a/prusti-launch/src/bin/prusti-rustc.rs
+++ b/prusti-launch/src/bin/prusti-rustc.rs
@@ -126,9 +126,9 @@ fn process(mut args: Vec<String>) -> Result<(), i32> {
         }
     }
 
-    let exit_status = cmd
-        .status()
-        .unwrap_or_else(|_| panic!("failed to execute prusti-driver ({prusti_driver_path:?})"));
+    let exit_status = cmd.status().unwrap_or_else(|e| {
+        panic!("failed to execute prusti-driver ({prusti_driver_path:?}): {e}")
+    });
 
     if exit_status.success() {
         Ok(())

--- a/prusti-tests/tests/cargo_verify/library_contracts_test/library_contracts_lib/src/lib.rs
+++ b/prusti-tests/tests/cargo_verify/library_contracts_test/library_contracts_lib/src/lib.rs
@@ -21,3 +21,21 @@ impl<T> Opt<T> {
         }
     }
 }
+
+#[trusted]
+#[pure]
+pub fn demo_fn(_a: u8) -> bool { unimplemented!() }
+
+// Test exporting quantifiers in specs.
+// Also test exporting triggers and nested quantifiers.
+#[trusted]
+#[ensures(forall(|i: u8| i == 0 ==> demo_fn(i)))]
+#[ensures(forall(|i: u8| i == 1 ==> forall(|j: u8| j == 1 ==> i == j), triggers=[(demo_fn(i),)]))]
+pub fn quantifier_test() {}
+
+// Test exporting quantifiers in predicates.
+predicate! {
+    pub fn quantifier_predicate(i: u8) -> bool {
+        forall(|j: u8| j < i ==> demo_fn(j))
+    }
+}

--- a/prusti-tests/tests/cargo_verify/library_contracts_test/src/main.rs
+++ b/prusti-tests/tests/cargo_verify/library_contracts_test/src/main.rs
@@ -20,6 +20,11 @@ fn test_dependency_import() {
     let b = Opt::None::<i32>;
     assert!(a.is_some() == true);
     assert!(b.is_some() == false);
+
+    // Test that quantifiers are imported.
+    library_contracts_lib::quantifier_test();
+    prusti_assert!(library_contracts_lib::demo_fn(0));
+    prusti_assert!(library_contracts_lib::quantifier_predicate(1));
 }
 
 fn test_extern_specs() {

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_high.rs
@@ -44,7 +44,7 @@ pub(super) fn inline_closure_high<'tcx>(
     let mir = encoder
         .env()
         .body
-        .get_closure_body(def_id.expect_local(), substs, parent_def_id);
+        .get_closure_body(def_id, substs, parent_def_id);
     assert_eq!(mir.arg_count, args.len() + 1);
     let mut body_replacements = vec![];
     for (arg_idx, arg_local) in mir.args_iter().enumerate() {

--- a/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/encoder_poly.rs
@@ -42,7 +42,7 @@ pub(super) fn inline_closure<'tcx>(
     let mir = encoder
         .env()
         .body
-        .get_closure_body(def_id.expect_local(), substs, parent_def_id);
+        .get_closure_body(def_id, substs, parent_def_id);
     assert_eq!(mir.arg_count, args.len() + 1);
     let mir_encoder = MirEncoder::new(encoder, &mir, def_id);
     let mut body_replacements = vec![];

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -135,8 +135,7 @@ fn init_loggers() -> Option<FlushGuard> {
 fn main() {
     let stopwatch = Stopwatch::start("prusti", "main");
 
-    // We assume that prusti-rustc already removed the first "rustc" argument
-    // added by RUSTC_WRAPPER and all command line arguments -P<arg>=<val>
+    // We assume that all command line arguments -P<arg>=<val>
     // have been filtered out.
     let original_rustc_args = config::get_filtered_args();
 
@@ -192,6 +191,13 @@ fn main() {
         ));
         user::message(format!("Prusti version: {}", get_prusti_version_info()));
         info!("Prusti version: {}", get_prusti_version_info());
+        if rustc_args.get(1).map(|s| s.as_ref()) == Some("-vV") {
+            // When cargo queries the verbose rustc version,
+            // also print the Prusti version to stdout.
+            // This ensures that the cargo build cache is
+            // invalidated when the Prusti version changes.
+            println!("Prusti version: {}", get_prusti_version_info());
+        }
 
         rustc_args.push("-Zalways-encode-mir".to_owned());
         rustc_args.push("-Zcrate-attr=feature(type_ascription)".to_owned());


### PR DESCRIPTION
When importing modules which contain specifications, these specs are also imported. The spec functions are serialized and written to a .specs file when the module is verified, and can be loaded from this file where the module is imported.
However, if there are quantifiers in the exported specs, this did not work before. Quantifiers are represented as closures, and are not included the spec functions themselves, they need to be exported separately. This change implements that.

There already exists a closure collecting visitor in prusti-interface/src/environment/collect_closure_defs_visitor.rs, but this is used for a different purpose, so it might not be a good idea to reuse it.

---

However, this changes the format of the .specs file. If you still have old .specs files in your target folder and run the new Prusti, it will panic trying to parse the old .specs file. This can be solved by deleting the target folder, but that is not a nice user experience. We would like everything to be re-verified when Prusti is updated.

Cargo uses various pieces of information to determine whether a recompile is needed, among them the rustc version. Cargo runs `rustc -vV` to obtain that. By replacing rustc with prusti-rustc, and outputting the Prusti version when running `prusti-rustc -vV`, we can achieve our goal. Everything is re-verified when the Prusti version changes.

Prusti previously set RUSTC_WRAPPER instead of RUSTC, but cargo does not use the wrapper when querying the version. I don't know why RUSTC_WRAPPER was used instead of RUSTC. Switching to RUSTC does not seem to cause problems.

