### PR TITLE
Enable cargo sparse index protocol

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[unstable]
-bindeps = true

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[unstable]
+bindeps = true
+
+[registries.crates-io]
+protocol = "sparse"


### PR DESCRIPTION
This [Rust Blog](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html) describes the new sparse registry protocol for Cargo, which is currently opt-in.

In a test with a dummy crate, changing to the new protocol save ~90 seconds on the compilation time of the crate ([old protocol: 2 min](https://github.com/viperproject/prusti-dev/actions/runs/4424199541/jobs/7757734924#step:4:24), [new protocol: 32 sec](https://github.com/viperproject/prusti-dev/actions/runs/4424260889/jobs/7757866910#step:4:25))

This PR also renames the `config` file to `config.toml`, as this seems to be the recommended file format, as noted in the [documentation](https://doc.rust-lang.org/cargo/reference/config.html).