### PR TITLE
Specifications of foreign functions

### DIFF
--- a/prusti-contracts/prusti-specs/src/common.rs
+++ b/prusti-contracts/prusti-specs/src/common.rs
@@ -13,8 +13,8 @@ use uuid::Uuid;
 /// These allow for writing of generic code over these types.
 mod syn_extensions {
     use syn::{
-        Attribute, Generics, ImplItemMacro, ImplItemMethod, ItemFn, ItemImpl, ItemStruct,
-        ItemTrait, Macro, Signature, TraitItemMacro, TraitItemMethod,
+        Attribute, ForeignItemFn, Generics, ImplItemMacro, ImplItemMethod, ItemFn, ItemImpl,
+        ItemStruct, ItemTrait, Macro, Signature, TraitItemMacro, TraitItemMethod,
     };
 
     /// Trait which signals that the corresponding syn item contains generics
@@ -105,6 +105,16 @@ mod syn_extensions {
         }
     }
 
+    impl HasSignature for ForeignItemFn {
+        fn sig(&self) -> &Signature {
+            &self.sig
+        }
+
+        fn sig_mut(&mut self) -> &mut Signature {
+            &mut self.sig
+        }
+    }
+
     /// Abstraction over everything that has a [syn::Macro]
     pub(crate) trait HasMacro {
         fn mac(&self) -> &Macro;
@@ -140,6 +150,12 @@ mod syn_extensions {
     }
 
     impl HasAttributes for ItemFn {
+        fn attrs(&self) -> &Vec<Attribute> {
+            &self.attrs
+        }
+    }
+
+    impl HasAttributes for ForeignItemFn {
         fn attrs(&self) -> &Vec<Attribute> {
             &self.attrs
         }

--- a/prusti-contracts/prusti-specs/src/extern_spec_rewriter/common.rs
+++ b/prusti-contracts/prusti-specs/src/extern_spec_rewriter/common.rs
@@ -145,7 +145,7 @@ pub(crate) fn generate_extern_spec_method_stub<T: HasSignature + HasAttributes +
 
     // Build the method stub
     let stub_method =
-        generate_extern_spec_function_stub(method, &method_path, extern_spec_kind, false);
+        generate_extern_spec_function_stub(method, &method_path, extern_spec_kind, false, false);
     let stub_method: syn::ImplItemMethod = syn::parse2(stub_method)?;
 
     // Eagerly extract and process specifications
@@ -191,6 +191,7 @@ pub(crate) fn generate_extern_spec_function_stub<Input: HasSignature + HasAttrib
     fn_path: &syn::ExprPath,
     extern_spec_kind: ExternSpecKind,
     mangle_name: bool,
+    is_unsafe: bool,
 ) -> TokenStream {
     let signature = function.sig();
     let mut signature = with_explicit_lifetimes(signature).unwrap_or_else(|| signature.clone());
@@ -202,6 +203,12 @@ pub(crate) fn generate_extern_spec_function_stub<Input: HasSignature + HasAttrib
     let generic_params = &signature.generic_params_as_call_args();
     let args = &signature.params_as_call_args();
     let extern_spec_kind_string: String = extern_spec_kind.into();
+    let fn_call = quote! { #fn_path :: < #generic_params > ( #args ) };
+    let stub_body = if is_unsafe {
+        quote! { unsafe { #fn_call } }
+    } else {
+        quote! { #fn_call }
+    };
 
     quote_spanned! {function.span()=>
         #[trusted]
@@ -209,26 +216,8 @@ pub(crate) fn generate_extern_spec_function_stub<Input: HasSignature + HasAttrib
         #(#attrs)*
         #[allow(unused, dead_code)]
         #signature {
-            #fn_path :: < #generic_params > ( #args )
+            #stub_body
         }
-    }
-}
-
-pub(crate) fn generate_extern_spec_foreign_function_stub<Input: HasSignature + HasAttributes + Spanned, Output: syn::parse::Parse>(
-    function: &Input,
-    extern_spec_kind: ExternSpecKind,
-) -> Output {
-    let signature = function.sig();
-    // Make elided lifetimes explicit, if necessary.
-    let signature = with_explicit_lifetimes(signature).unwrap_or_else(|| signature.clone());
-    let attrs: Vec<syn::Attribute> = function.attrs().clone();
-    let extern_spec_kind_string: String = extern_spec_kind.into();
-    
-    parse_quote_spanned! {function.span()=>
-        #[trusted]
-        #[prusti::extern_spec = #extern_spec_kind_string]
-        #(#attrs)*
-        #signature;
     }
 }
 

--- a/prusti-contracts/prusti-specs/src/extern_spec_rewriter/foreign_mods.rs
+++ b/prusti-contracts/prusti-specs/src/extern_spec_rewriter/foreign_mods.rs
@@ -1,0 +1,37 @@
+//! Process external specifications in Rust foreign modules marked with
+//! the #[extern_spec] attribute.
+
+use super::common::generate_extern_spec_foreign_function_stub;
+use crate::{
+    extract_prusti_attributes, generate_spec_and_assertions, specifications::untyped::AnyFnItem,
+    ExternSpecKind,
+};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
+pub fn rewrite_extern_spec(item_foreign_mod: &mut syn::ItemForeignMod) -> syn::Result<TokenStream> {
+    let mut specs = vec![];
+    for item in item_foreign_mod.items.iter_mut() {
+        if let syn::ForeignItem::Fn(item_fn) = item {
+            specs.extend(rewrite_fn(item_fn)?);
+        }
+        // eventually: handle specs for foreign variables
+    }
+
+    let mut res = TokenStream::new();
+    res.extend(specs.iter().map(syn::Item::to_token_stream));
+    res.extend(quote!(#item_foreign_mod));
+    Ok(res)
+}
+
+fn rewrite_fn(item_fn: &mut syn::ForeignItemFn) -> Result<Vec<syn::Item>, syn::Error> {
+    let stub_fn: syn::ForeignItemFn =
+        generate_extern_spec_foreign_function_stub(item_fn, ExternSpecKind::Method);
+    let mut stub_fn = AnyFnItem::ForeignFn(stub_fn);
+    let prusti_attributes = extract_prusti_attributes(&mut stub_fn);
+    let (spec_items, generated_attributes) =
+        generate_spec_and_assertions(prusti_attributes, &stub_fn)?;
+    stub_fn.attrs_mut().extend(generated_attributes);
+    *item_fn = stub_fn.expect_foreign_item_fn();
+    Ok(spec_items)
+}

--- a/prusti-contracts/prusti-specs/src/extern_spec_rewriter/foreign_mods.rs
+++ b/prusti-contracts/prusti-specs/src/extern_spec_rewriter/foreign_mods.rs
@@ -1,37 +1,22 @@
 //! Process external specifications in Rust foreign modules marked with
 //! the #[extern_spec] attribute.
 
-use super::common::generate_extern_spec_foreign_function_stub;
-use crate::{
-    extract_prusti_attributes, generate_spec_and_assertions, specifications::untyped::AnyFnItem,
-    ExternSpecKind,
-};
+use super::functions::rewrite_stub;
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use syn::spanned::Spanned;
+use quote::ToTokens;
 
-pub fn rewrite_extern_spec(item_foreign_mod: &mut syn::ItemForeignMod) -> syn::Result<TokenStream> {
-    let mut specs = vec![];
-    for item in item_foreign_mod.items.iter_mut() {
-        if let syn::ForeignItem::Fn(item_fn) = item {
-            specs.extend(rewrite_fn(item_fn)?);
-        }
-        // eventually: handle specs for foreign variables
-    }
-
+pub fn rewrite_extern_spec(item_foreign_mod: &syn::ItemForeignMod, path: &syn::Path) -> syn::Result<TokenStream> {
     let mut res = TokenStream::new();
-    res.extend(specs.iter().map(syn::Item::to_token_stream));
-    res.extend(quote!(#item_foreign_mod));
+    for item in item_foreign_mod.items.iter() {
+        match item {
+            syn::ForeignItem::Fn(item_fn) => {
+                let tokens = rewrite_stub(&item_fn.to_token_stream(), path /*&syn::Path { leading_colon: None, segments: syn::punctuated::Punctuated::new(), }*/, true);
+                res.extend(tokens);
+            },
+            // eventually: handle specs for foreign variables (statics)
+            _ => return Err(syn::Error::new(item.span(), "unexpected item")),
+        }
+    }
     Ok(res)
-}
-
-fn rewrite_fn(item_fn: &mut syn::ForeignItemFn) -> Result<Vec<syn::Item>, syn::Error> {
-    let stub_fn: syn::ForeignItemFn =
-        generate_extern_spec_foreign_function_stub(item_fn, ExternSpecKind::Method);
-    let mut stub_fn = AnyFnItem::ForeignFn(stub_fn);
-    let prusti_attributes = extract_prusti_attributes(&mut stub_fn);
-    let (spec_items, generated_attributes) =
-        generate_spec_and_assertions(prusti_attributes, &stub_fn)?;
-    stub_fn.attrs_mut().extend(generated_attributes);
-    *item_fn = stub_fn.expect_foreign_item_fn();
-    Ok(spec_items)
 }

--- a/prusti-contracts/prusti-specs/src/extern_spec_rewriter/mod.rs
+++ b/prusti-contracts/prusti-specs/src/extern_spec_rewriter/mod.rs
@@ -4,6 +4,7 @@ pub mod impls;
 pub mod mods;
 pub mod traits;
 pub mod functions;
+pub mod foreign_mods;
 mod common;
 
 #[derive(Debug, Clone, Copy)]

--- a/prusti-contracts/prusti-specs/src/extern_spec_rewriter/mods.rs
+++ b/prusti-contracts/prusti-specs/src/extern_spec_rewriter/mods.rs
@@ -23,10 +23,10 @@ pub fn rewrite_mod(item_mod: &syn::ItemMod, mut path: syn::Path) -> syn::Result<
         match item {
             syn::Item::Fn(ref item_fn) => {
                 check_is_stub(&item_fn.block)?;
-                rewritten_fns.extend(rewrite_fn(item_fn, &path));
+                rewritten_fns.extend(rewrite_fn(item_fn, &path, false));
             }
             syn::Item::Mod(ref inner_mod) => rewritten_fns.extend(rewrite_mod(inner_mod, path.clone())?),
-            syn::Item::Verbatim(ref tokens) => rewritten_fns.extend(rewrite_stub(tokens, &path)?),
+            syn::Item::Verbatim(ref tokens) => rewritten_fns.extend(rewrite_stub(tokens, &path, false)?),
             syn::Item::Use(_) => rewritten_fns.extend(syn::Error::new(
                 item.span(),
                 "`use` statements have no effect in #[extern_spec] modules; module contents share the outer scope.",

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -780,11 +780,11 @@ pub fn extern_spec(attr: TokenStream, tokens: TokenStream) -> TokenStream {
                 extern_spec_rewriter::mods::rewrite_mod(&item_mod, mod_path)
             }
             syn::Item::ForeignMod(item_foreign_mod) => {
-                extern_spec_rewriter::foreign_mods::rewrite_extern_spec(&item_foreign_mod)
+                extern_spec_rewriter::foreign_mods::rewrite_extern_spec(&item_foreign_mod, &mod_path)
             }
             // we're expecting function stubs, so they aren't represented as Item::Fn
             syn::Item::Verbatim(stub_tokens) => {
-                extern_spec_rewriter::functions::rewrite_stub(&stub_tokens, &mod_path)
+                extern_spec_rewriter::functions::rewrite_stub(&stub_tokens, &mod_path, false)
             }
             _ => Err(syn::Error::new(
                 Span::call_site(), // this covers the entire macro invocation, unlike attr.span() which changes to only cover arguments if possible

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -779,6 +779,9 @@ pub fn extern_spec(attr: TokenStream, tokens: TokenStream) -> TokenStream {
             syn::Item::Mod(item_mod) => {
                 extern_spec_rewriter::mods::rewrite_mod(&item_mod, mod_path)
             }
+            syn::Item::ForeignMod(item_foreign_mod) => {
+                extern_spec_rewriter::foreign_mods::rewrite_extern_spec(&item_foreign_mod)
+            }
             // we're expecting function stubs, so they aren't represented as Item::Fn
             syn::Item::Verbatim(stub_tokens) => {
                 extern_spec_rewriter::functions::rewrite_stub(&stub_tokens, &mod_path)

--- a/prusti-contracts/prusti-specs/src/specifications/untyped.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/untyped.rs
@@ -14,6 +14,7 @@ pub enum AnyFnItem {
     Fn(syn::ItemFn),
     TraitMethod(syn::TraitItemMethod),
     ImplMethod(syn::ImplItemMethod),
+    ForeignFn(syn::ForeignItemFn),
 }
 
 impl syn::parse::Parse for AnyFnItem {
@@ -42,6 +43,7 @@ impl AnyFnItem {
             AnyFnItem::Fn(item) => &mut item.attrs,
             AnyFnItem::TraitMethod(item) => &mut item.attrs,
             AnyFnItem::ImplMethod(item) => &mut item.attrs,
+            AnyFnItem::ForeignFn(item) => &mut item.attrs,
         }
     }
 
@@ -50,6 +52,7 @@ impl AnyFnItem {
             AnyFnItem::Fn(item) => Some(&item.block),
             AnyFnItem::ImplMethod(item) => Some(&item.block),
             AnyFnItem::TraitMethod(item) => item.default.as_ref(),
+            AnyFnItem::ForeignFn(_) => None,
         }
     }
 
@@ -58,12 +61,20 @@ impl AnyFnItem {
             AnyFnItem::Fn(item) => Some(&item.vis),
             AnyFnItem::ImplMethod(item) => Some(&item.vis),
             AnyFnItem::TraitMethod(_) => None,
+            AnyFnItem::ForeignFn(item) => Some(&item.vis),
         }
     }
 
     pub fn expect_impl_item(self) -> syn::ImplItemMethod {
         match self {
             AnyFnItem::ImplMethod(i) => i,
+            _ => unreachable!(),
+        }
+    }
+    
+    pub fn expect_foreign_item_fn(self) -> syn::ForeignItemFn {
+        match self {
+            AnyFnItem::ForeignFn(f) => f,
             _ => unreachable!(),
         }
     }
@@ -75,6 +86,7 @@ impl HasSignature for AnyFnItem {
             Self::Fn(item) => item.sig(),
             Self::ImplMethod(item) => item.sig(),
             Self::TraitMethod(item) => item.sig(),
+            Self::ForeignFn(item) => item.sig(),
         }
     }
 
@@ -83,6 +95,7 @@ impl HasSignature for AnyFnItem {
             Self::Fn(item) => item.sig_mut(),
             Self::ImplMethod(item) => item.sig_mut(),
             Self::TraitMethod(item) => item.sig_mut(),
+            Self::ForeignFn(item) => item.sig_mut(),
         }
     }
 }
@@ -93,6 +106,7 @@ impl ToTokens for AnyFnItem {
             AnyFnItem::Fn(item) => item.to_tokens(tokens),
             AnyFnItem::TraitMethod(item) => item.to_tokens(tokens),
             AnyFnItem::ImplMethod(item) => item.to_tokens(tokens),
+            AnyFnItem::ForeignFn(item) => item.to_tokens(tokens),
         }
     }
 }

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -436,6 +436,20 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for SpecCollector<'a, 'tcx> {
         self.env.query.hir()
     }
 
+    fn visit_foreign_item(&mut self, fi: &'tcx prusti_rustc_interface::hir::ForeignItem) {
+        intravisit::walk_foreign_item(self, fi);
+
+        let id = fi.hir_id();
+        let local_id = self.env.query.as_local_def_id(id);
+        let def_id = local_id.to_def_id();
+        let attrs = self.env.query.get_local_attributes(fi.owner_id.def_id);
+
+        // Collect procedure specifications
+        if let Some(procedure_spec_ref) = get_procedure_spec_ids(def_id, attrs) {
+            self.procedure_specs.insert(local_id, procedure_spec_ref);
+        }
+    }
+
     fn visit_trait_item(&mut self, ti: &'tcx prusti_rustc_interface::hir::TraitItem) {
         intravisit::walk_trait_item(self, ti);
 

--- a/prusti-tests/tests/cargo_verify/foreign_mods/Cargo.toml
+++ b/prusti-tests/tests/cargo_verify/foreign_mods/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "foreign_mods"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[dependencies]
+prusti-contracts = { path = "prusti-contracts/prusti-contracts" } # The test suite will prepare a symbolic link for this
+
+[build-dependencies]
+cc = "1.0"
+
+# Declare that this crate is not part of a workspace
+[workspace]

--- a/prusti-tests/tests/cargo_verify/foreign_mods/build.rs
+++ b/prusti-tests/tests/cargo_verify/foreign_mods/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    cc::Build::new()
+        .file("src/clib.c")
+        .compile("clib");
+}

--- a/prusti-tests/tests/cargo_verify/foreign_mods/src/clib.c
+++ b/prusti-tests/tests/cargo_verify/foreign_mods/src/clib.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+
+int32_t max(int32_t a, int32_t b) {
+	return a > b ? a : b;
+}
+
+void unannotated(void) {
+}
+
+int32_t abs(int32_t a) {
+	return a >= 0 ? a : -a;
+}

--- a/prusti-tests/tests/cargo_verify/foreign_mods/src/main.rs
+++ b/prusti-tests/tests/cargo_verify/foreign_mods/src/main.rs
@@ -1,5 +1,13 @@
 use prusti_contracts::*;
 
+extern "C" {
+    fn max(a: i32, b: i32) -> i32;
+
+    fn unannotated();
+
+    fn abs(a: i32) -> i32;
+}
+
 #[extern_spec]
 extern "C" {
     #[ensures(a >= b ==> result == a)]

--- a/prusti-tests/tests/cargotest.rs
+++ b/prusti-tests/tests/cargotest.rs
@@ -186,6 +186,11 @@ fn test_failing_stable_toolchain() {
 }
 
 #[cargo_test]
+fn test_foreign_mods() {
+    test_local_project("foreign_mods");
+}
+
+#[cargo_test]
 fn test_library_contracts_test() {
     test_local_project("library_contracts_test");
 }

--- a/prusti-tests/tests/parse/pass/extern-spec/foreign_mods.rs
+++ b/prusti-tests/tests/parse/pass/extern-spec/foreign_mods.rs
@@ -1,0 +1,24 @@
+use prusti_contracts::*;
+
+#[extern_spec]
+extern "C" {
+    #[ensures(a >= b ==> result == a)]
+    #[ensures(b >= a ==> result == b)]
+    fn max(a: i32, b: i32) -> i32;
+
+    fn unannotated();
+
+    #[ensures(a < 0 ==> result == -a)]
+    #[ensures(a >= 0 ==> result == a)]
+    fn abs(a: i32) -> i32;
+}
+
+fn main() {
+    assert!(unsafe { max(1, 2) } == 2);
+    assert!(unsafe { max(2, 1) } == 2);
+    unsafe {
+        unannotated();
+    };
+    assert!(unsafe { abs(-1) } == 1);
+    assert!(unsafe { abs(1) == 1 });
+}

--- a/prusti-tests/tests/parse/pass/extern-spec/on_function.rs
+++ b/prusti-tests/tests/parse/pass/extern-spec/on_function.rs
@@ -1,0 +1,12 @@
+use prusti_contracts::*;
+
+fn identity(a: i32) -> i32 {
+    a
+}
+
+#[extern_spec]
+#[ensures(a == 0 ==> result == 0)]
+fn identity(a: i32) -> i32;
+
+fn main() {
+}

--- a/prusti-tests/tests/parse/ui/foreign_mods.rs
+++ b/prusti-tests/tests/parse/ui/foreign_mods.rs
@@ -1,0 +1,16 @@
+use prusti_contracts::*;
+
+#[extern_spec]
+extern "C" {
+    #[ensures(a >= b ==> result = a)]
+    #[ensures(b >= a ==> result == b)]
+    fn max(a: i32, b: i32) -> i32;
+
+    fn unannotated();
+
+    #[ensures(a < 0 ==> result == -a)]
+    #[ensures(a >= 0 ==> result = a)]
+    fn abs(a: i32) -> i32;
+}
+
+fn main() {}

--- a/prusti-tests/tests/parse/ui/foreign_mods.rs
+++ b/prusti-tests/tests/parse/ui/foreign_mods.rs
@@ -1,5 +1,13 @@
 use prusti_contracts::*;
 
+extern "C" {
+    fn max(a: i32, b: i32) -> i32;
+
+    fn unannotated();
+
+    fn abs(a: i32) -> i32;
+}
+
 #[extern_spec]
 extern "C" {
     #[ensures(a >= b ==> result = a)]

--- a/prusti-tests/tests/parse/ui/foreign_mods.stderr
+++ b/prusti-tests/tests/parse/ui/foreign_mods.stderr
@@ -1,35 +1,39 @@
 error[E0308]: mismatched types
- --> $DIR/foreign_mods.rs:5:26
-  |
-5 |     #[ensures(a >= b ==> result = a)]
-  |                          ^^^^^^ expected `bool`, found `i32`
-
-error[E0308]: mismatched types
- --> $DIR/foreign_mods.rs:5:22
-  |
-5 |     #[ensures(a >= b ==> result = a)]
-  |                      ^^^^^^^^^^^^^^ expected `bool`, found `()`
-  |
-help: you might have meant to compare for equality
-  |
-5 |     #[ensures(a >= b ==> result == a)]
-  |                                  +
-
-error[E0308]: mismatched types
-  --> $DIR/foreign_mods.rs:12:26
+  --> $DIR/foreign_mods.rs:13:26
    |
-12 |     #[ensures(a >= 0 ==> result = a)]
-   |                          ^^^^^^ expected `bool`, found `i32`
+13 |     #[ensures(a >= b ==> result = a)]
+   |               ------     ^^^^^^ expected `bool`, found `i32`
+   |               |
+   |               expected because this is `bool`
 
 error[E0308]: mismatched types
-  --> $DIR/foreign_mods.rs:12:22
+  --> $DIR/foreign_mods.rs:13:15
    |
-12 |     #[ensures(a >= 0 ==> result = a)]
-   |                      ^^^^^^^^^^^^^^ expected `bool`, found `()`
+13 |     #[ensures(a >= b ==> result = a)]
+   |               ^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
    |
 help: you might have meant to compare for equality
    |
-12 |     #[ensures(a >= 0 ==> result == a)]
+13 |     #[ensures(a >= b ==> result == a)]
+   |                                  +
+
+error[E0308]: mismatched types
+  --> $DIR/foreign_mods.rs:20:26
+   |
+20 |     #[ensures(a >= 0 ==> result = a)]
+   |               ------     ^^^^^^ expected `bool`, found `i32`
+   |               |
+   |               expected because this is `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/foreign_mods.rs:20:15
+   |
+20 |     #[ensures(a >= 0 ==> result = a)]
+   |               ^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+20 |     #[ensures(a >= 0 ==> result == a)]
    |                                  +
 
 error: aborting due to 4 previous errors

--- a/prusti-tests/tests/parse/ui/foreign_mods.stderr
+++ b/prusti-tests/tests/parse/ui/foreign_mods.stderr
@@ -1,0 +1,37 @@
+error[E0308]: mismatched types
+ --> $DIR/foreign_mods.rs:5:26
+  |
+5 |     #[ensures(a >= b ==> result = a)]
+  |                          ^^^^^^ expected `bool`, found `i32`
+
+error[E0308]: mismatched types
+ --> $DIR/foreign_mods.rs:5:22
+  |
+5 |     #[ensures(a >= b ==> result = a)]
+  |                      ^^^^^^^^^^^^^^ expected `bool`, found `()`
+  |
+help: you might have meant to compare for equality
+  |
+5 |     #[ensures(a >= b ==> result == a)]
+  |                                  +
+
+error[E0308]: mismatched types
+  --> $DIR/foreign_mods.rs:12:26
+   |
+12 |     #[ensures(a >= 0 ==> result = a)]
+   |                          ^^^^^^ expected `bool`, found `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/foreign_mods.rs:12:22
+   |
+12 |     #[ensures(a >= 0 ==> result = a)]
+   |                      ^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+12 |     #[ensures(a >= 0 ==> result == a)]
+   |                                  +
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Allowing the extern_spec attribute on extern blocks

To test this, adding:
* a `parse/ui` test to check the behavior when the specs don't type check,
* a `cargo_verify` test to test the full compilation of a crate with `#[extern_spec]` on `extern "C"` and also including a C source file with the implementation of the foreign functions, and
* a `parse/pass` test to test that extern specs work correctly on free-standing (non-foreign) functions too
