### PR TITLE
Show duration of consistency checks

### DIFF
--- a/viper/Cargo.toml
+++ b/viper/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "MPL-2.0"
 
 [dependencies]
-log = { version = "0.4", features = ["release_max_level_info"] }
+log = { version = "0.4", features = ["release_max_level_debug"] }
 error-chain = "0.12"
 viper-sys = { path = "../viper-sys" }
 jni = { version = "0.20", features = ["invocation"] }


### PR DESCRIPTION
With this PR, it's possible to see in the `--release` binaries run with `PRUSTI_LOG=debug` how much of the verification time is spent doing consistency checks (to catch encoding bugs in Prusti, not verification errors) and how much is actually spent verifying the Viper program.