### PR TITLE
Enable cfg!(prusti) when compiling with Prusti

### DIFF
--- a/prusti-launch/src/bin/prusti-rustc.rs
+++ b/prusti-launch/src/bin/prusti-rustc.rs
@@ -38,6 +38,7 @@ fn process(mut args: Vec<String>) -> Result<(), i32> {
     let compiler_lib = prusti_sysroot.join("lib");
 
     let mut cmd = Command::new(&prusti_driver_path);
+    cmd.arg("--cfg=prusti");
 
     launch::add_to_loader_path(vec![compiler_lib, compiler_bin, libjvm_path], &mut cmd);
 


### PR DESCRIPTION
This PR reintroduces the `--cfg=prusti` that was removed in https://github.com/viperproject/prusti-dev/pull/547/commits/4f8c47b19d300655d31b96ba3c7b5379db29d37c.

Useful for https://github.com/viperproject/prusti-dev/issues/1295.