### PR TITLE
Remove unnecessairy serde dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,8 +2214,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc-hash",
- "serde",
- "serde_json",
  "syn",
  "uuid",
 ]
@@ -3390,7 +3388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
- "serde",
 ]
 
 [[package]]

--- a/prusti-contracts/prusti-specs/Cargo.toml
+++ b/prusti-contracts/prusti-specs/Cargo.toml
@@ -18,8 +18,6 @@ doctest = false # we have no doc tests
 syn = { version = "1.0", features = ["full", "extra-traits", "visit", "visit-mut", "parsing", "printing"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-uuid = { version = "1.0", features = ["v4", "serde"] }
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+uuid = { version = "1.0", features = ["v4"] }
 itertools = "0.10.3"
 rustc-hash = "1.1.0"

--- a/prusti-contracts/prusti-specs/src/specifications/common.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/common.rs
@@ -46,19 +46,7 @@ impl<'a> TryFrom<&'a str> for SpecType {
     }
 }
 
-#[derive(
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    Hash,
-    Clone,
-    Copy,
-    serde::Serialize,
-    serde::Deserialize,
-    PartialOrd,
-    Ord,
-)]
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
 /// A unique ID of the specification element such as entire precondition
 /// or postcondition.
 pub struct SpecificationId(Uuid);


### PR DESCRIPTION
This PR removes the `serde` and `serde_json` dependency from `prusti-specs`.
On my machine (before this change), verifying a crate with a `prusti-contracts` dependency takes approximately 11 seconds to compile the dependencies, with about 5 seconds being just the compilation of `serde`.

The only place where `serde` is used is in the derive macro on the `SpecificationId` struct, but the derived functionality does not seem to be actually used anywhere.

This change should improve verification times for the first verification of a crate.
