### PR TITLE
Bump `prusti-contracts` version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "prusti-specs"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/prusti-contracts/prusti-contracts-proc-macros/Cargo.toml
+++ b/prusti-contracts/prusti-contracts-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-contracts-proc-macros"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -15,7 +15,7 @@ categories = ["development-tools", "development-tools::testing"]
 proc-macro = true
 
 [dependencies]
-prusti-specs = { path = "../prusti-specs", version = "0.1.4", optional = true }
+prusti-specs = { path = "../prusti-specs", version = "0.1.5", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 
 [features]

--- a/prusti-contracts/prusti-contracts/Cargo.toml
+++ b/prusti-contracts/prusti-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-contracts"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/prusti-contracts/prusti-contracts/Cargo.toml
+++ b/prusti-contracts/prusti-contracts/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["prusti", "contracts", "verification", "formal", "specifications"]
 categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
-prusti-contracts-proc-macros = { path = "../prusti-contracts-proc-macros", version = "0.1.4" }
+prusti-contracts-proc-macros = { path = "../prusti-contracts-proc-macros", version = "0.1.5" }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/prusti-contracts/prusti-specs/Cargo.toml
+++ b/prusti-contracts/prusti-specs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-specs"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/prusti-contracts/prusti-std/Cargo.toml
+++ b/prusti-contracts/prusti-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-std"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -12,7 +12,7 @@ keywords = ["prusti", "contracts", "verification", "formal", "specifications"]
 categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
-prusti-contracts = { path = "../prusti-contracts", version = "0.1.4" }
+prusti-contracts = { path = "../prusti-contracts", version = "0.1.5" }
 
 # Forward "prusti" flag
 [features]


### PR DESCRIPTION
This PR increases the version number of the crates in `prusti-contracts` to publish the changes made in #1377 
