### PR TITLE
Update test - infinite loop

### DIFF
--- a/prusti-tests/tests/verify/pass/rosetta/Knuth_shuffle.rs
+++ b/prusti-tests/tests/verify/pass/rosetta/Knuth_shuffle.rs
@@ -110,6 +110,7 @@ fn test() {
     let mut i = 0;
     while i < 10 {
         v.push(i);
+        i += 1;
     }
 
     print_vector_before(&mut v);


### PR DESCRIPTION
Add missing iterator index increment.

(When having the loop infinite the unreachable code detection fails this test and I wanted to include it in the benchmarks)
