### PR TITLE
Sif extension

### DIFF
--- a/SIFExtendedTransformer.scala
+++ b/SIFExtendedTransformer.scala
@@ -1,0 +1,1727 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+package viper.silver.sif
+
+import viper.silver.ast._
+import viper.silver.ast.utility.Simplifier
+import viper.silver.verifier.errors
+import viper.silver.verifier.errors.{AssertFailed, ErrorNode}
+
+import scala.collection.immutable.HashSet
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+trait SIFExtendedTransformer {
+  object Config {
+    /** If true, don't generate all the control flow variables, just the ones needed for each method. */
+    var optimizeControlFlow: Boolean = true
+    /** If true, try to bunch as many statements into a single if statement which was introduced for checking active
+      * executions, instead of having one if stmt per original statement. */
+    var optimizeSequential: Boolean = true
+    /** If true, add an 'assume p1' at the beginning of each method, to cut down on redundant paths the
+      * verification could consider */
+    var optimizeRestrictActVars: Boolean = true
+    /** Applications of the functions which have an entry here, will be replaced by the expression
+      * determined by the entry in the second execution. */
+    var primedFuncAppReplacements: mutable.HashMap[String, (FuncApp, Exp, Exp) => Exp] = new mutable.HashMap
+    /** Set this to only transform methods that contain relational assertions somewhere in their spec or body.
+      * May lead to invalid programs when such a method calls another methods that does contain such specs.
+      */
+    var onlyTransformMethodsWithRelationalSpecs: Boolean = false
+    var generateAllLowFuncs: Boolean = true
+  }
+  def optimizeControlFlow(v: Boolean): Unit = {
+    Config.optimizeControlFlow = v
+  }
+  def optimizeSequential(v: Boolean): Unit = {
+    Config.optimizeSequential = v
+  }
+  def optimizeRestrictActVars(v: Boolean): Unit = {
+    Config.optimizeRestrictActVars = v
+  }
+  def generateAllLowFuncs(v: Boolean): Unit = {
+    Config.generateAllLowFuncs = v
+  }
+  def onlyTransformMethodsWithRelationalSpecs(v: Boolean): Unit = {
+    Config.onlyTransformMethodsWithRelationalSpecs = v
+  }
+  def addPrimedFuncAppReplacement(name: String, strategy: String): Unit = {
+    strategy match {
+      case "first_arg" => Config.primedFuncAppReplacements.put(name,
+        (func, p1, p2) => translatePrime(func.args.head, p1, p2))
+      case "true" => Config.primedFuncAppReplacements.put(name, (func, _, _) =>
+        TrueLit()(func.pos, func.info, func.errT))
+      case _ => new IllegalArgumentException(
+        s"""Unknown strategy "$strategy" for primed function application replacement.""")
+    }
+  }
+  def clearPrimedFuncAppReplacement(): Unit = {
+    Config.primedFuncAppReplacements.clear()
+  }
+
+  val primedNamesPerMethod = new mutable.HashMap[String, Map[String, String]]
+  val primedNames = new mutable.HashMap[String, String]
+  val relationalPredicates = new mutable.HashSet[Predicate]
+  val predLowFuncs = new mutable.HashMap[String, Option[Function]]
+  val predLowFuncInfo = new mutable.HashMap[String, Option[(String, Seq[LocalVarDecl], Seq[LocalVarDecl])]]
+  val predAllLowFuncs = new mutable.HashMap[String, Option[Function]]()
+  val predAllLowFuncInfo = new mutable.HashMap[String, Option[(String, Seq[LocalVarDecl], Seq[LocalVarDecl])]]
+  val usedNames = new mutable.HashSet[String]
+  var newFields : List[Field] = Nil
+  var newPredicates: Seq[Predicate] = Nil
+  var _program : Program = null
+  var getArgFunc : DomainFunc = null
+  var getOldFunc : DomainFunc = null
+  var getArgPFunc : DomainFunc = null
+  var getOldPFunc : DomainFunc = null
+
+  private var _allLowMethods: Set[String] = HashSet[String]()
+  def allLowMethods: Set[String] = _allLowMethods
+  def setAllLowMethods(value: Set[String]): Unit = _allLowMethods = value
+
+  private var _preservesLowMethods: Set[String] = HashSet[String]()
+  def preservesLowMethods: Set[String] = _preservesLowMethods
+  def setPreservesLowMethods(value: Set[String]): Unit =_preservesLowMethods = value
+
+  private val _domainFuncsToDuplicate = new mutable.HashSet[DomainFunc]()
+  def domainFuncsToDuplicate: mutable.Set[DomainFunc] = _domainFuncsToDuplicate
+  def addDomainFuncToDuplicate(funcs: DomainFunc*): Unit = _domainFuncsToDuplicate ++= funcs
+
+  var timing = false
+  var time : Option[LocalVar] = None
+
+  val skip: Seqn = Seqn(Seq(), Seq())()
+
+  def transform(p: Program, enableTiming: Boolean) : Program = {
+    primedNames.clear()
+    predLowFuncs.clear()
+    predLowFuncInfo.clear()
+    predAllLowFuncInfo.clear()
+    usedNames.clear()
+    newPredicates = Nil
+    timing = enableTiming
+    _program = p
+
+    val allNames = p.collect({
+      case d: Declaration => d.name
+    })
+    usedNames ++= allNames
+
+    collectRelationalPredicates(_program, relationalPredicates)
+    createNewNames(p)
+    var newFunctions: Seq[Function] = p.functions //.flatMap(f => translateFunction(f))
+    newPredicates = Seq()
+    for (pred <- p.predicates) {
+      val (newPs, predFuncs) = translatePredicate(pred)
+      newPredicates ++= newPs
+      newFunctions ++= predFuncs.collect{case f if f.isDefined => f.get}
+    }
+
+    val newMethods: Seq[Method] = if (Config.onlyTransformMethodsWithRelationalSpecs) {
+      val relationalMethods = p.methods.filter(m => m.existsDefined({
+        case e: Exp if !isUnary(e) => true
+      }))
+      val unaryMethods = p.methods.filter(m => !relationalMethods.contains(m))
+      relationalMethods.map(m => translateMethod(m)) ++ unaryMethods
+    }else{
+      p.methods.map(m => translateMethod(m))
+    }
+
+    p.copy(functions = newFunctions, predicates = newPredicates,
+      methods = newMethods)(p.pos, p.info, p.errT)
+  }
+
+  def getName(orig: String) : String = {
+    if (usedNames.contains(orig)){
+      var index = 0
+      while (usedNames.contains(orig + "_" + index)){
+        index += 1
+      }
+      val result = orig + "_" + index
+      usedNames.add(result)
+      return result
+    }else{
+      usedNames.add(orig)
+      return orig
+    }
+  }
+
+  /** Create the new names for the programs variables, functions (those which depend on the heap),
+    * and predicates, which are used for the second execution. Updates [[primedNames]].
+    * @param p The program being encoded.
+    */
+  def createNewNames(p: Program): Unit = {
+    // duplicate names for predicates
+    for (pred <- p.predicates) {
+      val duplicatedArgs = pred.formalArgs.map{a =>
+        val newName = getName(a.name)
+        a.copy(name = newName)(a.pos, a.info, a.errT)
+      }
+      predLowFuncInfo.update(pred.name, if (relationalPredicates.contains(pred) && pred.body.isDefined)
+          Some(getName(pred.name + "_low"), pred.formalArgs, duplicatedArgs)
+        else None
+      )
+      predAllLowFuncInfo.update(pred.name, pred.body match {
+        case Some(_) =>
+          Some(getName(pred.name + "_all_low"), pred.formalArgs, duplicatedArgs)
+        case None => None
+      })
+    }
+  }
+
+  def collectRelationalPredicates(p: Program, relPreds: mutable.HashSet[Predicate]): Unit = {
+    def directlyRelational(pred: Predicate): Boolean = {
+       pred.body.isDefined && !isUnary(pred.body.get)
+    }
+
+    relPreds.clear()
+    relPreds ++= p.predicates.filter(pred => directlyRelational(pred))
+    val dependencies = mutable.HashMap[String, Seq[String]]()
+
+    relPreds.foreach(pred =>
+      // put the name of this as depending on all referenced predicates
+      pred.body.collect{
+        case pap: PredicateAccessPredicate => pap
+      }.foreach(pap =>
+        dependencies.update(pap.loc.predicateName, dependencies.getOrElse(pap.loc.predicateName, Seq()) :+ pred.name)
+      )
+    )
+    // go through dependent predicates to add them to relationals
+    val queue = mutable.Queue[String](relPreds.toSeq.map(rp => rp.name): _*)
+    while (queue.nonEmpty) {
+      val head: String = queue.dequeue()
+      for (dep <- dependencies.getOrElse(head, Seq())) {
+        if (relPreds.add(p.findPredicate(dep))) queue.enqueue(dep)
+      }
+    }
+  }
+
+  def translateMethod(m: Method) : Method = {
+    val primedBefore = primedNames.clone()
+    val (p1d, p1r) = getNewBool("p1")
+    val (p2d, p2r) = getNewBool("p2")
+    var toAdd = Seq(p1d, p2d)
+    val (t1d, t1r) = getNewVar("t1", Int)
+    val (t2d, t2r) = getNewVar("t2", Int)
+    if (timing){
+      toAdd = Seq(p1d, p2d, t1d, t2d)
+      primedNames.update(t1d.name, t2d.name)
+      time = Some(t1r)
+    }
+
+    val newArgs = toAdd ++ m.formalArgs.flatMap{a =>
+      val newName = getName(a.name)
+      primedNames.update(a.name, newName)
+      val primedArg = a.copy(name = newName)(a.pos, a.info, a.errT)
+      Seq(a, primedArg)
+    }
+    var toAddRet : Seq[LocalVarDecl] = Seq()
+    val (t1dr, t1rr) = getNewVar("t1", Int)
+    val (t2dr, t2rr) = getNewVar("t2", Int)
+    if (timing){
+      toAddRet = Seq(t1dr, t2dr)
+      primedNames.update(t1dr.name, t2dr.name)
+      time = Some(t1rr)
+    }
+    val newReturns = toAddRet ++ m.formalReturns.flatMap{r =>
+      val newName = getName(r.name)
+      primedNames.update(r.name, newName)
+      val primedRet = r.copy(name = newName)(r.pos, r.info, r.errT)
+      Seq(r, primedRet)
+    }
+
+    var (newPres, newPosts) = addLownessConditions(m, m.pres, m.posts)
+    val condCtx = TranslationContext(p1r, p2r, EmptyControlFlowVars(), m)
+    newPres = newPres.map{e => translateSIFAss(e, condCtx.copy(translatingPrecond = true))}
+    newPosts = newPosts.map{e => translateSIFAss(e, condCtx)}
+    // Termination channels
+    var terminates: Option[SIFTerminatesExp] = None
+    m.pres.foreach(pre => pre.visit{
+      case t: SIFTerminatesExp => terminates = Some(t)
+    })
+    if (terminates.isDefined) {
+      newPres = simplifyConditions(newPres ++
+        terminationChannelsLowChecks(terminates.get, condCtx))
+      newPosts :+= translateSIFAss(Old(terminates.get.cond)(
+        terminates.get.cond.pos, terminates.get.cond.info,
+        ErrTrafo({case _ => SIFTerminationChannelCheckFailed(terminates.get.cond, SIFTermCondNotTight(terminates.get))})
+      ), condCtx)
+    }
+
+    if (timing){
+      val timeUnchanged1 = Implies(Not(p1r)(), EqCmp(t1r, t1rr)())()
+      val timeUnchanged2 = Implies(Not(p2r)(), EqCmp(t2r, t2rr)())()
+      newPosts ++= Seq(timeUnchanged1, timeUnchanged2)
+    }
+
+    var firstStatements : Seq[Stmt] = Seq()
+    if (Config.optimizeRestrictActVars) firstStatements :+= Inhale(p1r)()
+    if (timing){
+      val assignTime1 = LocalVarAssign(t1rr, t1r)()
+      val assignTime2 = LocalVarAssign(t2rr, t2r)()
+      firstStatements ++= Seq(assignTime1, assignTime2)
+      time = Some(t1rr)
+    }
+
+    var newBody: Option[Seqn] = None
+    if (m.body.isDefined) {
+      var body: Seqn = m.body.get
+      if (allLowMethods.contains(m.name) || preservesLowMethods.contains(m.name)) {
+        body = inferLowLoopInvariants(m, preservesOnly = preservesLowMethods.contains(m.name))
+      }
+
+      // find which control variables the method requires
+      val ctrlVars: MethodControlFlowVars = createControlFlowVars(body)
+      val ctx: TranslationContext = TranslationContext(p1r, p2r, ctrlVars, m)
+
+      newBody = Some(Seqn(firstStatements ++ ctrlVars.initAssigns() ++
+        Seq(translateStatement(body, ctx).asInstanceOf[Seqn]), ctrlVars.declarations())())
+    }
+
+    time = None
+    primedNamesPerMethod.update(m.name, primedNames.toMap)
+    primedNames.clear()
+    primedNames ++= primedBefore
+    Method(m.name, newArgs, newReturns, newPres, newPosts, newBody)(m.pos)
+  }
+
+  def _conjoinOptions(in: Seq[Option[Exp]]): Exp = {
+    val defined = in.filter(x => x.isDefined).map(x => x.get)
+    defined.size match {
+      case 0 => TrueLit()()
+      case _ => defined.reduceRight((a, b) => And(a, b)(a.pos))
+    }
+  }
+
+  /** Takes a sequence of LocalVarDecls and produces an expression saying each pair of adjacent variables are equal.
+    */
+  def _varDeclsToAllLow(in: Seq[LocalVarDecl]): Exp = {
+    in.map(decl => decl.localVar)
+      .map(v => SIFLowExp(v, None)())
+      .reduceRight[Exp]((v, e) => And(v, e)())
+  }
+
+  def allReachableStateLow(m: Method, old: Boolean, predicateSrc: Seq[Exp]): Option[Exp] = {
+    var lowExpressions: Seq[Exp] = Seq()
+
+    // all accs to fields in preconditions
+    val allFieldAccesses: Seq[FieldAccess] = m.pres.flatMap(e => e.deepCollect({
+      case FieldAccessPredicate(loc, _) => Seq(loc)
+    })).flatten.distinct
+    for (fieldAcc <- allFieldAccesses) {
+      val eq = SIFLowExp(fieldAcc, None)(m.pos)
+      if (old)
+        lowExpressions :+= Old(eq)(m.pos)
+      else
+        lowExpressions :+= eq
+    }
+
+    // all accs we get via predicates
+    lowExpressions ++= predicateSrc.flatMap(e => e.deepCollect{
+      case PredicateAccessPredicate(loc, _) =>
+        val funcApp = FuncApp(predAllLowFuncs(loc.predicateName).get,
+          loc.args ++ loc.args.map(a => translatePrime(a, null, null)))()
+        if (old)
+          Old(funcApp)(m.pos)
+        else
+          funcApp
+    })
+
+    if (lowExpressions.nonEmpty)
+      Some(lowExpressions.reduceRight[Exp]((a, b) => And(a, b)(m.pos)))
+    else
+      None
+  }
+
+  def allVarsAndStateLow(m: Method, vars: Seq[LocalVarDecl], old: Boolean, predicateSrc: Seq[Exp]): Exp = {
+    val nonObligationVars = vars.filterNot(isObligationVar)
+    val allArgsLow: Option[Exp] = if (nonObligationVars.isEmpty) None else Some(_varDeclsToAllLow(nonObligationVars))
+    val allStateLow: Option[Exp] = allReachableStateLow(m, old, predicateSrc)
+    _conjoinOptions(Seq(allArgsLow, allStateLow))
+  }
+
+  def addLownessConditions(m: Method, pres: Seq[Exp], posts: Seq[Exp]): (Seq[Exp], Seq[Exp]) = {
+    var newPres = pres
+    if (allLowMethods.contains(m.name)) newPres :+= allVarsAndStateLow(m, m.formalArgs, old = false, predicateSrc = m.pres)
+    var newPosts = posts
+    if (allLowMethods.contains(m.name)) newPosts :+= allVarsAndStateLow(m, m.formalReturns, old = false, predicateSrc = m.posts)
+    if (preservesLowMethods.contains(m.name)) newPosts :+= Implies(
+      allVarsAndStateLow(m, m.formalArgs, old = true, predicateSrc = m.pres),
+      allVarsAndStateLow(m, m.formalReturns, old = false, predicateSrc = m.posts))(m.pos)
+    (newPres, newPosts)
+  }
+
+  def inferLowLoopInvariants(m: Method, preservesOnly: Boolean): Seqn = {
+    val _obligationVars: Seq[String] = obligationVars(m)
+    m.body.get.transform{
+      case w@While(cond, invs, body) =>
+        val targets: Seq[LocalVar] = w.deepCollect({
+          case LocalVarAssign(lhs, _) => Seq(lhs)
+          case MethodCall(_, _, ts) => ts
+          case NewStmt(t, _) => Seq(t)
+        }).flatten
+          .distinct
+          .filterNot(v => _obligationVars.contains(v.name))
+        var additionalInvs: Seq[Exp] = targets.map(lv => SIFLowExp(lv, None)()) ++
+          allReachableStateLow(m, old = false, predicateSrc = m.pres)
+        if (preservesOnly) {
+          additionalInvs = additionalInvs.map(
+            i => Implies(allVarsAndStateLow(m, m.formalArgs, old=true, predicateSrc = m.pres), i)())
+        }
+        val newInvs: Seq[Exp] = invs ++ additionalInvs
+        While(cond, newInvs, body)(w.pos, w.info, w.errT)
+    }
+  }
+
+  def isObligationVar(v: LocalVarDecl): Boolean = {
+    val vi = v.info.getUniqueInfo[SIFInfo]
+    vi match {
+      case Some(info) => info.obligationVar
+      case _ => false
+    }
+  }
+
+  def obligationVars(m: Method): Seq[String] = {
+    m.deepCollect[LocalVarDecl]({
+      case d: LocalVarDecl if isObligationVar(d) => d
+    }).map(v => v.name)
+  }
+
+  def createControlFlowVars(methodBody: Seqn): MethodControlFlowVars = {
+    val gotos = methodBody.collect({case Goto(l) => l}).toSet
+    val labels = methodBody.collect({case l@Label(n, _) if gotos.contains(n) => l}).toSet
+    if (!Config.optimizeControlFlow) return new MethodControlFlowVars(true, true, true, true, labels)
+    var hasRet, hasBreak, hasCont, hasExcept: Boolean = false
+    methodBody.visit({
+      case _: SIFReturnStmt => hasRet = true
+      case _: SIFBreakStmt => hasBreak = true
+      case _: SIFContinueStmt => hasCont = true
+      case _: SIFRaiseStmt => hasExcept = true
+      case _: SIFTryCatchStmt => hasExcept = true
+    })
+    if (labels.nonEmpty && (hasRet || hasBreak || hasCont || hasExcept))
+      throw new IllegalArgumentException
+    new MethodControlFlowVars(hasRet, hasBreak, hasCont, hasExcept, labels)
+  }
+
+  def incrementTime(p1: Exp, p2: Exp) : Seqn = {
+    if (timing){
+      val timeInc1 = If(p1, Seqn(Seq(LocalVarAssign(time.get, Add(time.get, IntLit(1)())())()), Seq())(), skip)()
+      val timeInc2 = If(p2, Seqn(Seq(LocalVarAssign(translatePrime(time.get, p1, p2), translatePrime(Add(time.get, IntLit(1)())(), p1, p2))()), Seq())(), skip)()
+      Seqn(Seq(timeInc1, timeInc2), Seq())()
+    }else{
+      skip
+    }
+
+  }
+
+  private def terminationChannelsLowChecks(terminates: SIFTerminatesExp,
+                                           ctx: TranslationContext): Seq[Exp] = {
+    val condLowEventReasonTrafo = ErrTrafo({case _ =>
+      SIFTerminationChannelCheckFailed(terminates, SIFTermCondLowEvent(terminates))}) +
+      ReTrafo({case _ => SIFTermCondLowEvent(terminates)})
+    val condLowReasonTrafo = ErrTrafo({case _ =>
+      SIFTerminationChannelCheckFailed(terminates, SIFTermCondNotLow(terminates))}) +
+      ReTrafo({case _ => SIFTermCondNotLow(terminates)})
+    val pos = terminates.pos
+    val info = terminates.info
+    Seq(
+      // Note: cast here is not very elegant, maybe there's a better way to attach the error reason
+      // to result of translateSIFAss
+      translateSIFAss(Implies(Not(terminates.cond)(pos, info, condLowEventReasonTrafo),
+        SIFLowEventExp()(pos, info, condLowEventReasonTrafo))(pos, info, condLowEventReasonTrafo), ctx)
+        .asInstanceOf[Implies].copy()(pos, info, condLowEventReasonTrafo),
+      translateSIFAss(SIFLowExp(terminates.cond)(pos, info, condLowReasonTrafo), ctx)
+        .asInstanceOf[Implies].copy()(pos, info, condLowReasonTrafo)
+    )
+  }
+
+  /** Translate a predicate into MPP. Creates two copies of the predicate: one version for first execution,
+    * one for the second. The predicates only contain the unary expressions of the original predicate.
+    * Generates a function containing all the relational expressions in the predicates body.
+    * @param pred The predicate to translate.
+    * @return List of the new predicates, plus the low-function.
+    */
+  def translatePredicate(pred: Predicate): (Seq[Predicate], Seq[Option[Function]]) = {
+    val unaryBody: Option[Exp] = translateToUnary(pred.body)
+
+    val newPred = pred.copy(body = unaryBody)(pred.pos, pred.info, pred.errT)
+
+    var lowF: Option[Function] = None
+    var allLowF: Option[Function] = None
+    if (pred.body.isDefined) {
+      val (allLowFName, formalArgs, duplicatedFormalArgs) = predAllLowFuncInfo(pred.name).get
+
+      val access1 = PredicateAccess(formalArgs.map{a => a.localVar}, newPred.name)(pred.pos)
+      val access2 = PredicateAccess(duplicatedFormalArgs.map{a => a.localVar}, newPred.name)(pred.pos)
+      val fPres: Seq[Exp] = Seq(And(PredicateAccessPredicate(access1, WildcardPerm()())(),
+        PredicateAccessPredicate(access2, WildcardPerm()())())())
+      val lowFFormalArgs = pred.formalArgs ++ duplicatedFormalArgs
+      val primedBefore = primedNames.clone()
+      formalArgs.zip(duplicatedFormalArgs).foreach(t => primedNames.update(t._1.name, t._2.name))
+
+      def unfoldingPredicates(body: Exp): Exp = {
+        Unfolding(PredicateAccessPredicate(access1, WildcardPerm()())(),
+          Unfolding(PredicateAccessPredicate(access2, WildcardPerm()())(),
+            body)())()
+      }
+      if (relationalPredicates.contains(pred)) {
+        val (lowFName, _, _) = predLowFuncInfo(pred.name).get
+        val fBody: Exp = unfoldingPredicates(translatePredLowFuncBody(pred.body.get))
+        lowF = Some(Function(lowFName, lowFFormalArgs, Bool, fPres, Seq(), Some(fBody))
+        (pred.pos, pred.info, pred.errT))
+      }
+
+      val allLowBody: Exp = unfoldingPredicates(translatePredAllLowFuncBody(pred.body.get))
+      allLowF = Some(Function(allLowFName, lowFFormalArgs, Bool, fPres, Seq(), Some(allLowBody))
+        (pred.pos, pred.info, pred.errT))
+
+      primedNames.clear()
+      primedNames ++= primedBefore
+    }
+
+    predLowFuncs.update(pred.name, lowF)
+    predAllLowFuncs.update(pred.name, allLowF)
+    if (Config.generateAllLowFuncs)
+      (Seq(newPred), Seq(lowF, allLowF))
+    else
+      (Seq(newPred), Seq(lowF, None))
+  }
+
+  private def bypassPreamble(p1: Exp, p2: Exp, ctrlVars: MethodControlFlowVars,
+                             bypass1r: LocalVar, bypass2r: LocalVar): Seq[Stmt] = {
+    Seq(LocalVarAssign(bypass1r,
+      Not(ctrlVars.activeExecNormal(Some(p1)))())(),
+      LocalVarAssign(bypass2r, Not(ctrlVars.activeExecPrime(Some(p2)))())())
+  }
+
+  /** Translate a while statement into MPP.
+    */
+  private def translateWhileStmt(w: While, ctx: TranslationContext): Seqn = {
+    val p1 = ctx.p1; val p2 = ctx.p2; val ctrlVars = ctx.ctrlVars
+
+    // check if we need to do a reconstruction of this loop (iff it has ret/break/except stmt or we don't optimize)
+    val recNeeded: Boolean = {
+      var rn = !Config.optimizeControlFlow
+    w.body.visit({
+      case _: SIFReturnStmt => rn = true
+      case _: SIFBreakStmt => rn = true
+      case _: SIFRaiseStmt => rn = true
+      case _: SIFTryCatchStmt => rn = true
+    })
+    rn
+    }
+
+    var newVarDecls = Seq[LocalVarDecl]()
+    //var targetValRefs = Seq[LocalVar]()
+    var targetValAssigns = Seq[Stmt]()
+    var targetValEqualities1 = Set[Exp]()
+    var targetValEqualities2 = Set[Exp]()
+
+    val (bypass1d, bypass1r) = getNewBool("bypass1")
+    val (bypass2d, bypass2r) = getNewBool("bypass2")
+    newVarDecls ++= Seq(bypass1d, bypass2d)
+    var stmts: Seq[Stmt] = bypassPreamble(p1, p2, ctrlVars, bypass1r, bypass2r)
+
+    def targetCollectF: PartialFunction[Node, Seq[LocalVar]] = {
+      case LocalVarAssign(lhs, _) => Seq(lhs)
+      case MethodCall(_, _, ts) => ts
+      case NewStmt(t, _) => Seq(t)
+      case SIFReturnStmt(_, _) => Seq(ctrlVars.ret1r.get)
+      case SIFRaiseStmt(_) => Seq(ctrlVars.except1r.get)
+      case SIFTryCatchStmt(body, handlers, elseBlock, finallyBlock) =>
+        (body.deepCollect(targetCollectF).distinct.flatten ++
+        handlers.map(h => h.body.deepCollect(targetCollectF).flatten).distinct.flatten ++ (elseBlock match {
+          case Some(eb) => eb.deepCollect(targetCollectF).distinct.flatten
+          case None => Seq()
+        }) ++ (finallyBlock match {
+          case Some(fb) => fb.deepCollect(targetCollectF).distinct.flatten
+          case None => Seq()
+        })).distinct
+    }
+
+    // continue and break control variables will be assigned even if there is no continue in this loop -> add to targets
+    val targets = w.deepCollect(targetCollectF).flatten.distinct ++ (if (ctrlVars.cont1r.isDefined)
+      Seq(ctrlVars.cont1r.get, ctrlVars.cont2r.get) else Seq()) ++ (if (ctrlVars.break1r.isDefined)
+      Seq(ctrlVars.break1r.get, ctrlVars.break2r.get) else Seq())
+
+    var tmpAssigns1 = Seq[LocalVarAssign]()
+    var tmpAssigns2 = Seq[LocalVarAssign]()
+    for (t <- targets) {
+      // make sure the variable is defined outside the loop
+      if (primedNames.contains(t.name)){
+        val (tmp1d, tmp1r) = getNewVar("tmp1", t.typ)
+        val (tmp2d, tmp2r) = getNewVar("tmp2", t.typ)
+        newVarDecls ++= Seq(tmp1d, tmp2d)
+        //targetValRefs ++= Seq(tmp1r, tmp2r)
+        tmpAssigns1 :+= LocalVarAssign(tmp1r, t)()
+        tmpAssigns2 :+= LocalVarAssign(tmp2r, translatePrime(t, p1, p2))()
+        val eq1 = EqCmp(tmp1r, t)()
+        val eq2 = EqCmp(tmp2r, translatePrime(t, p1, p2))()
+        targetValEqualities1 ++= Seq(eq1)
+        targetValEqualities2 ++= Seq(eq2)
+      }
+    }
+    if (tmpAssigns1.nonEmpty) targetValAssigns :+= If(bypass1r, Seqn(tmpAssigns1, Seq())(), skip)()
+    if (tmpAssigns2.nonEmpty) targetValAssigns :+= If(bypass2r, Seqn(tmpAssigns2, Seq())(), skip)()
+
+    /*if (timing){
+      val (tmp1d, tmp1r) = getNewVar("tmp1", Int)
+      val (tmp2d, tmp2r) = getNewVar("tmp2", Int)
+      newVarDecls ++= Seq(tmp1d, tmp2d)
+      val assign1 = LocalVarAssign(tmp1r, time.get)()
+      val assign2 = LocalVarAssign(tmp2r, translatePrime(time.get, p1, p2))()
+      targetValAssigns ++= Seq(assign1, assign2)
+      val eq1 = EqCmp(tmp1r, time.get)()
+      val eq2 = EqCmp(tmp2r, translatePrime(time.get, p1, p2))()
+      targetValEqualities1 ++= Seq(eq1)
+      targetValEqualities2 ++= Seq(eq2)
+    }*/
+    stmts ++= targetValAssigns
+
+    // tmp assigns for all ctrlVars
+    var ctrlVarToOldMap: Map[LocalVar, LocalVar] = Map()
+    if (recNeeded) {
+      var ctrlFlowTmpAssigns = Seq[Stmt]()
+      for (v <- ctrlVars.declarations().map(d => d.localVar)) {
+        val (tmp1d, tmp1r) = getNewBool("old" + v.name)
+        ctrlVarToOldMap += (v -> tmp1r)
+        newVarDecls :+= tmp1d
+        stmts :+= LocalVarAssign(tmp1r, v)()
+        ctrlFlowTmpAssigns :+= LocalVarAssign(v, tmp1r)()
+      }
+    }
+
+    val newCond = Or(And(And(ctrlVars.activeExecNoContNormal(Some(p1)), Not(bypass1r)())(), w.cond)(),
+      And(And(ctrlVars.activeExecNoContPrime(Some(p2)), Not(bypass2r)())(), translatePrime(w.cond, p1, p2))())()
+    var bodyPreamble: Seq[Stmt] = Seq()
+    if (ctrlVars.cont1r.isDefined) bodyPreamble = bodyPreamble :+
+      LocalVarAssign(ctrlVars.cont1r.get, FalseLit()())() :+
+      LocalVarAssign(ctrlVars.cont2r.get, FalseLit()())()
+    val (p1d, p1r) = getNewBool("p1")
+    val (p2d, p2r) = getNewBool("p2")
+    newVarDecls ++= Seq(p1d, p2d)
+    val p1Assign = LocalVarAssign(p1r, And(ctrlVars.activeExecNormal(Some(p1)), w.cond)())()
+    val p2Assign = LocalVarAssign(p2r, And(ctrlVars.activeExecPrime(Some(p2)), translatePrime(w.cond, p1, p2))())()
+    bodyPreamble ++= Seq(p1Assign, p2Assign)
+
+    var newStdInvs = w.invs
+    // check if there is an InhaleExhaleExp in invariants
+    if (w.invs.exists(inv => inv.contains[InhaleExhaleExp])) {
+      val (idle1d, idle1r) = getNewBool("idle1")
+      val (idle2d, idle2r) = getNewBool("idle2")
+      primedNames.update(idle1r.name, idle2r.name)
+      newVarDecls ++= Seq(idle1d, idle2d)
+      // assign false before the loop
+      stmts ++= Seq(LocalVarAssign(idle1r, FalseLit()())(),
+        LocalVarAssign(idle2r, FalseLit()())())
+      // assign inside loop body that the execution is idling
+      val idle1Assign = LocalVarAssign(idle1r,
+        And(ctrlVars.activeExecNormal(Some(p1)), Not(w.cond)())())()
+      val idle2Assign = LocalVarAssign(idle2r,
+        And(ctrlVars.activeExecPrime(Some(p2)), Not(translatePrime(w.cond, p1, p2))())())()
+      bodyPreamble ++= Seq(idle1Assign, idle2Assign)
+      // make all exhales of InhaleExhales dependent on not idling
+      newStdInvs = newStdInvs.map(inv => inv.transform{
+        case ie@InhaleExhaleExp(in, ex) => InhaleExhaleExp(in,
+          Implies(Not(idle1r)(), ex)())(ie.pos, ie.info, ie.errT)
+      })
+    }
+
+    // --- Terminates ---
+    var terminates: Option[SIFTerminatesExp] = None
+    w.invs.foreach(inv => inv.visit{
+      case t: SIFTerminatesExp => terminates = Some(t)
+    })
+    if (terminates.isDefined) {
+      stmts ++= terminationChannelsLowChecks(terminates.get, ctx)
+        .map(tc => Assert(tc)(tc.pos, tc.info, tc.errT))
+      val (cond1d, cond1r) = getNewBool("cond")
+      val (cond2d, cond2r) = getNewBool("cond")
+      primedNames.update(cond1r.name, cond2r.name)
+      newVarDecls ++= Seq(cond1d, cond2d)
+      stmts ++= Seq(If(p1, Seqn(Seq(LocalVarAssign(cond1r, terminates.get.cond)()), Seq())(), skip)(),
+        If(p2, Seqn(Seq(LocalVarAssign(cond2r, translatePrime(terminates.get.cond, p1, p2))()), Seq())(), skip)())
+      newStdInvs :+= Implies(Not(cond1r)(), w.cond)(
+        terminates.get.pos, terminates.get.info, ErrTrafo({
+          case _ => SIFTerminationChannelCheckFailed(terminates.get, SIFTermCondNotTight(terminates.get))
+        }))
+    }
+
+    val invCtx = ctx.copy(
+      p1 = And(p1, Not(bypass1r)())(),
+      p2 = And(p2, Not(bypass2r)())()
+    )
+    /*
+    val invCtx = ctx.copy(
+      p1 = ctrlVars.activeExecNoContNormal(Some(p1)),
+      p2 = ctrlVars.activeExecNoContPrime(Some(p2))
+    )
+     */
+    newStdInvs = simplifyConditions(newStdInvs.map(e => translateSIFAss(e, invCtx, invCtx)))
+    val newInvs: Seq[Exp] = newStdInvs ++
+      targetValEqualities1.map(e => Implies(bypass1r, e)()) ++
+      targetValEqualities2.map(e => Implies(bypass2r, e)())
+
+    val bodyRes = translateStatement(w.body, ctx.copy(p1 = p1r, p2 = p2r))
+    /*val bodyPostamble = Seq(
+      Inhale(Or(Not(p1)(), ctrlVars.activeExecNoContNormal(None))())(),
+      Inhale(Or(Not(p2)(), ctrlVars.activeExecNoContPrime(None))())()
+    )*/
+    stmts :+= While(newCond, newInvs, Seqn(bodyPreamble ++ Seq(bodyRes), Seq())())()
+
+    // loop reconstruction
+    if (recNeeded) {
+      val recCond1 = And(Not(bypass1r)(), Seq(ctrlVars.ret1r, ctrlVars.break1r, ctrlVars.except1r)
+        .collect({ case Some(x) => x })
+        .reduceRight[Exp]((x, y) => Or(x, y)())
+      )()
+      val recCond2 = And(Not(bypass2r)(), Seq(ctrlVars.ret2r, ctrlVars.break2r, ctrlVars.except2r)
+        .collect({ case Some(x) => x })
+        .reduceRight[Exp]((x, y) => Or(x, y)()))()
+      val recCond = Or(recCond1, recCond2)()
+      val ctrlVarAssigns: Seq[Stmt] = ctrlVars.declarations()
+        .map(d => d.localVar)
+        .map(v => LocalVarAssign(v, ctrlVarToOldMap(v))())
+      val recInhales: Seq[Stmt] = Seq() :+ //newStdInvs.map(i => Inhale(i)()) :+
+        Inhale(Implies(ctrlVars.activeExecNoContNormal(Some(p1)), w.cond)())() :+
+        Inhale(Implies(ctrlVars.activeExecNoContNormal(Some(p2)), translatePrime(w.cond, p1, p2))())()
+      val recKillInhales: Seq[Stmt] = Seq(
+        Inhale(Or(Not(p1r)(), Not(ctrlVars.activeExecNoContNormal(None))())())(),
+        Inhale(Or(Not(p2r)(), Not(ctrlVars.activeExecNoContPrime(None))())())()
+      )
+      val recThn = Seqn(
+        (ctrlVarAssigns ++ recInhales ++ bodyPreamble ++ Seq(bodyRes) ++ recKillInhales),
+        Seq())()
+      stmts :+= If(recCond, recThn, skip)(info=SimpleInfo(Seq("Loop Reconstruction.\n  ")))
+    }
+    if (Seq(ctrlVars.break1r, ctrlVars.cont1r).collect({case Some(x) => x}).nonEmpty) {
+      stmts ++= Seq(
+        If(Not(bypass1r)(), Seqn(Seq(ctrlVars.break1r, ctrlVars.cont1r)
+          .collect({ case Some(x) => x })
+          .map(v => LocalVarAssign(v, FalseLit()())()),
+          Seq())(), skip)(),
+        If(Not(bypass2r)(), Seqn(Seq(ctrlVars.break2r, ctrlVars.cont2r)
+          .collect({ case Some(x) => x })
+          .map(v => LocalVarAssign(v, FalseLit()())()),
+          Seq())(), skip)()
+      )
+    }
+    Seqn(stmts, newVarDecls)()
+  }
+
+  /** Translate a try/catch block into MPP.
+    */
+  private def translateTryCatchStmt(tryStmt: SIFTryCatchStmt, ctx: TranslationContext): Seqn = {
+    val p1 = ctx.p1; val p2 = ctx.p2; val ctrlVars = ctx.ctrlVars
+    var stmts: Seq[Stmt] = Seq()
+    var newVarDecls: Seq[LocalVarDecl] = Seq()
+    val hasFinally: Boolean = tryStmt.finallyBlock.isDefined
+    // bypass preamble
+    val (bypass1d, bypass1r) = getNewBool("bypass1")
+    val (bypass2d, bypass2r) = getNewBool("bypass2")
+    newVarDecls ++= Seq(bypass1d, bypass2d)
+    val bypassAssigns: Seq[Stmt] = bypassPreamble(p1, p2, ctrlVars, bypass1r, bypass2r)
+    stmts ++= bypassAssigns
+    // assigning old values of ret and except flags
+    def oldAssign(ctrl: Option[LocalVar], name: String): Option[LocalVar] = {
+      if (ctrl.isEmpty) return None
+      val (decl, v) = getNewBool(name)
+      newVarDecls :+= decl
+      stmts :+= LocalVarAssign(v, ctrl.get)()
+      Some(v)
+    }
+    var oldret1r, oldret2r, oldbreak1r, oldbreak2r, oldcont1r, oldcont2r,
+      oldexcept1r, oldexcept2r: Option[LocalVar] = None
+    if (hasFinally) {
+      oldret1r    = oldAssign(ctrlVars.ret1r,    name = "oldret1")
+      oldret2r    = oldAssign(ctrlVars.ret2r,    name = "oldret2")
+      oldbreak1r  = oldAssign(ctrlVars.break1r,  name = "oldbreak1")
+      oldbreak2r  = oldAssign(ctrlVars.break2r,  name = "oldbreak2")
+      oldcont1r   = oldAssign(ctrlVars.cont1r,   name = "oldcont1")
+      oldcont2r   = oldAssign(ctrlVars.cont2r,   name = "oldcont2")
+      oldexcept1r = oldAssign(ctrlVars.except1r, name = "oldexcept1")
+      oldexcept2r = oldAssign(ctrlVars.except2r, name = "oldexcept2")
+    }
+    // translate try body
+    stmts :+= translateStatement(tryStmt.body, ctx)
+    // create variable 'thisexcept', to express that we had an exception in this tryblock
+    val (thisexcept1d, thisexcept1r) = getNewBool("thisexcept1")
+    val (thisexcept2d, thisexcept2r) = getNewBool("thisexcept2")
+    newVarDecls ++= Seq(thisexcept1d, thisexcept2d)
+    stmts :+= LocalVarAssign(thisexcept1r, And(ctrlVars.except1r.get, Not(bypass1r)())())()
+    stmts :+= LocalVarAssign(thisexcept2r, And(ctrlVars.except2r.get, Not(bypass2r)())())()
+    // translate the exception handlers
+    for (handler <- tryStmt.catchBlocks) {
+      val (p1d, p1r) = getNewBool("p1")
+      val (p2d, p2r) = getNewBool("p2")
+      newVarDecls ++= Seq(p1d, p2d)
+      stmts = stmts :+
+        LocalVarAssign(p1r, And(p1, And(thisexcept1r, translateNormal(handler.exception, p1, p2))())())() :+
+        LocalVarAssign(p2r, And(p2, And(thisexcept2r, translatePrime(handler.exception, p1, p2))())())() :+
+        If(p1r, Seqn(Seq(LocalVarAssign(ctrlVars.except1r.get, FalseLit()())()), Seq())(), skip)() :+
+        If(p2r, Seqn(Seq(LocalVarAssign(ctrlVars.except2r.get, FalseLit()())()), Seq())(), skip)()
+      stmts :+= translateStatement(handler.body, TranslationContext(p1r, p2r, ctrlVars, ctx.currentMethod))
+      // assign null to error variable if exception was caught
+      stmts :+= translateStatement(LocalVarAssign(handler.errVar, NullLit()())(), ctx)
+    }
+    // translate the else block
+    if (tryStmt.elseBlock.isDefined) {
+      val (p1d2, p1r2) = getNewBool("p1")
+      val (p2d2, p2r2) = getNewBool("p2")
+      newVarDecls ++= Seq(p1d2, p2d2)
+      stmts :+= LocalVarAssign(p1r2, And(p1, Not(thisexcept1r)())())()
+      stmts :+= LocalVarAssign(p2r2, And(p2, Not(thisexcept2r)())())()
+      stmts :+= translateStatement(tryStmt.elseBlock.get, TranslationContext(p1r2, p2r2, ctrlVars, ctx.currentMethod))
+    }
+    // translate the finally block
+    if (hasFinally) {
+      def tmpAssigns(tuples: (LocalVar, Option[LocalVar], Option[LocalVar])*): Seq[Stmt] = {
+        tuples
+          .filter(tuple => tuple._2.isDefined)
+          .flatMap{
+            case (tmp: LocalVar, ctrl: Option[LocalVar], old: Option[LocalVar]) =>
+              Seq(LocalVarAssign(tmp, ctrl.get)(),
+                LocalVarAssign(ctrl.get, old.get)())
+          }
+      }
+      def tmpReAssigns(tuples: (LocalVar, Option[LocalVar], Option[Seq[Option[LocalVar]]])*): Seq[Stmt] = {
+        tuples
+          .filter(tuple => tuple._2.isDefined)
+          .flatMap{
+            case (tmp: LocalVar, ctrl: Option[LocalVar], None) =>
+              Seq(LocalVarAssign(ctrl.get, Or(ctrl.get, tmp)())())
+            case (tmp: LocalVar, ctrl: Option[LocalVar], Some(unless)) =>
+              val negatedUnless = unless.map{
+                case Some(v) => Some(Not(v)())
+                case None => None
+              }
+              Seq(LocalVarAssign(ctrl.get, Or(ctrl.get, And(tmp, _conjoinOptions(negatedUnless))())())())
+          }
+      }
+
+      // store ret and except in tmp variables
+      val (tmpret1d, tmpret1r) = getNewBool("tmp_ret1")
+      val (tmpret2d, tmpret2r) = getNewBool("tmp_ret2")
+      val (tmpbreak1d, tmpbreak1r) = getNewBool("tmp_break1")
+      val (tmpbreak2d, tmpbreak2r) = getNewBool("tmp_break2")
+      val (tmpcont1d, tmpcont1r) = getNewBool("tmp_cont1")
+      val (tmpcont2d, tmpcont2r) = getNewBool("tmp_cont2")
+      val (tmpexcept1d, tmpexcept1r) = getNewBool("tmp_except1")
+      val (tmpexcept2d, tmpexcept2r) = getNewBool("tmp_except2")
+      newVarDecls ++= Seq(tmpret1d, tmpret2d, tmpbreak1d, tmpbreak2d, tmpcont1d, tmpcont2d,
+        tmpexcept1d, tmpexcept2d)
+      val tmpAssigns1: Seq[Stmt] = tmpAssigns(
+        (tmpret1r, ctrlVars.ret1r, oldret1r),
+        (tmpbreak1r, ctrlVars.break1r, oldbreak1r),
+        (tmpcont1r, ctrlVars.cont1r, oldcont1r),
+        (tmpexcept1r, ctrlVars.except1r, oldexcept1r)
+      )
+      val tmpAssigns2: Seq[Stmt] = tmpAssigns(
+        (tmpret2r, ctrlVars.ret2r, oldret2r),
+        (tmpbreak2r, ctrlVars.break2r, oldbreak2r),
+        (tmpcont2r, ctrlVars.cont2r, oldcont2r),
+        (tmpexcept2r, ctrlVars.except2r, oldexcept2r)
+      )
+      stmts :+= If(p1, Seqn(tmpAssigns1, Seq())(), skip)()
+      stmts :+= If(p2, Seqn(tmpAssigns2, Seq())(), skip)()
+      stmts :+= translateStatement(tryStmt.finallyBlock.get, ctx)
+      val tmpReAssigns1 = tmpReAssigns(
+        (tmpexcept1r, ctrlVars.except1r, Some(Seq(ctrlVars.ret1r, ctrlVars.break1r))),
+        (tmpret1r, ctrlVars.ret1r, None),
+        (tmpbreak1r, ctrlVars.break1r, None),
+        (tmpcont1r, ctrlVars.cont1r, None)
+      )
+      val tmpReAssigns2 = tmpReAssigns(
+        (tmpexcept2r, ctrlVars.except2r, Some(Seq(ctrlVars.ret2r, ctrlVars.break2r))),
+        (tmpret2r, ctrlVars.ret2r, None),
+        (tmpbreak2r, ctrlVars.break2r, None),
+        (tmpcont2r, ctrlVars.cont2r, None)
+      )
+      stmts :+= If(p1, Seqn(tmpReAssigns1, Seq())(), skip)()
+      stmts :+= If(p2, Seqn(tmpReAssigns2, Seq())(), skip)()
+    }
+    Seqn(stmts, newVarDecls)(info = SimpleInfo(Seq("Try/catch block\n  ")))
+  }
+
+  def translateWandPackage(p: Package, ctx: TranslationContext): Stmt = {
+    val Package(w@MagicWand(left, right), proofScript) = p
+    // Package(
+    //   MagicWand(
+    //     translateSIFAss(left, ctx), 
+    //     translateSIFAss(right, ctx)
+    //   )(w.pos, w.info, w.errT), 
+    //   Seqn(Seq(translateStatement(proofScript, ctx)), Seq())()
+    // )(p.pos, p.info, p.errT)
+    val p1 = ctx.p1
+    val p2 = ctx.p2
+    lazy val act1: Exp = ctx.ctrlVars.activeExecNormal(Some(p1))
+    lazy val act2: Exp = ctx.ctrlVars.activeExecPrime(Some(p2))
+
+    val leftNormal = translateNormal(left, p1, p2)
+    val rightNormal = translateNormal(right, p1, p2)
+    val wandNormal = MagicWand(leftNormal, rightNormal)(w.pos, w.info, w.errT)
+    val proofScriptNormal = proofScript.transform{
+      case e: Exp => translateNormal(e, act1, act2)
+    }
+    val packageNormal = Package(wandNormal, proofScriptNormal)(p.pos, p.info, p.errT)
+    val ifNormal = If(act1, Seqn(Seq(packageNormal), Seq())(), skip)()
+
+    val leftPrime = translatePrime(left, p1, p2)
+    val rightPrime = translatePrime(right, p1, p2)
+    val wandPrime = MagicWand(leftPrime, rightPrime)(w.pos, w.info, w.errT)
+    val proofScriptPrime = proofScript.transform{
+      case e: Exp => translatePrime(e, act1, act2)
+    }
+    val packagePrime = Package(wandPrime, proofScriptPrime)(p.pos, p.info, p.errT)
+    val ifPrime = If(act2, Seqn(Seq(packagePrime), Seq())(), skip)()
+
+    Seqn(Seq(ifNormal, ifPrime), Seq())()
+  }
+
+  def translateWandApply(a: Apply, ctx: TranslationContext): Stmt = {
+    val Apply(w@MagicWand(left, right)) = a
+    // Apply(
+    //   MagicWand(
+    //     translateSIFAss(left, ctx), 
+    //     translateSIFAss(right, ctx)
+    //   )(w.pos, w.info, w.errT), 
+    // )(a.pos, a.info, a.errT)
+
+    val p1 = ctx.p1
+    val p2 = ctx.p2
+    lazy val act1: Exp = ctx.ctrlVars.activeExecNormal(Some(p1))
+    lazy val act2: Exp = ctx.ctrlVars.activeExecPrime(Some(p2))
+
+    val leftNormal = translateNormal(left, p1, p2)
+    val rightNormal = translateNormal(right, p1, p2)
+    val wandNormal = MagicWand(leftNormal, rightNormal)(w.pos, w.info, w.errT)
+    val applyNormal = Apply(wandNormal)(a.pos, a.info, a.errT)
+    val ifNormal = If(act1, Seqn(Seq(applyNormal), Seq())(), skip)()
+
+    val leftPrime = translatePrime(left, p1, p2)
+    val rightPrime = translatePrime(right, p1, p2)
+    val wandPrime = MagicWand(leftPrime, rightPrime)(w.pos, w.info, w.errT)
+    val applyPrime = Apply(wandPrime)(a.pos, a.info, a.errT)
+    val ifPrime = If(act2, Seqn(Seq(applyPrime), Seq())(), skip)()
+
+    Seqn(Seq(ifNormal, ifPrime), Seq())()
+  }
+
+  def translateStatement(s: Stmt, ctx: TranslationContext) : Stmt = {
+    val p1 = ctx.p1
+    val p2 = ctx.p2
+    val ctrlVars = ctx.ctrlVars
+    lazy val act1: Exp = ctx.ctrlVars.activeExecNormal(Some(p1))
+    lazy val act2: Exp = ctx.ctrlVars.activeExecPrime(Some(p2))
+
+    def executeConditionally(ift1: Seqn, ift2: Seqn): Stmt = {
+      val a1 = If(act1, ift1, skip)()
+      val a2 = If(act2, ift2, skip)()
+      Seqn(Seq(a1, a2, incrementTime(p1, p2)), Seq())()
+    }
+    def translateAssignment(to1: LocalVar, v1: Exp, to2: LocalVar, v2: Exp, orig: Stmt) : Stmt = {
+      executeConditionally(
+        Seqn(Seq(LocalVarAssign(to1, v1)(orig.pos, orig.info, orig.errT)), Seq())(),
+        Seqn(Seq(LocalVarAssign(to2, v2)(orig.pos, orig.info, orig.errT)), Seq())()
+      )
+    }
+
+    /** Return true if the statement can be bunched together with others, without doing the interleaving of the
+      * two executions, thus saving on the number of if-statements generated.
+      */
+    def isCompressible(s: Stmt): Boolean = {
+      s match {
+        case _: LocalVarAssign => true
+        case Inhale(e) => isUnary(e)
+        case Exhale(e) => isUnary(e)
+        case _: SIFReturnStmt => true
+        case _: SIFBreakStmt => true
+        case _: SIFContinueStmt => true
+        case _: Goto => false
+        case _: Label => false
+        case _ => false
+      }
+    }
+
+    /** Do the translation of a statement without wrapping it in an if statement. Just returns the two versions in a
+      * tuple, to allow putting multiple statements in an if block. Requires [[isCompressible(s)]].
+      */
+    def translateStmtPartial(s: Stmt): (Stmt, Stmt) = {
+      assert(isCompressible(s))
+      s match {
+        case l@LocalVarAssign(lhs, rhs) => (LocalVarAssign(translateNormal(lhs, p1, p2),
+          translateNormal(rhs, p1, p2))(l.pos, l.info, l.errT),
+          LocalVarAssign(translatePrime(lhs, p1, p2), translatePrime(rhs, p1, p2))(l.pos, l.info, l.errT))
+        case a@FieldAssign(lhs, rhs) => (a, FieldAssign(translatePrime(lhs, p1, p2),
+          translatePrime(rhs, p1, p2))(a.pos, a.info, a.errT))
+        case i@Inhale(e) => (Inhale(translateNormal(e, p1, p2))(i.pos, i.info, i.errT),
+          Inhale(translatePrime(e, p1, p2))(i.pos, i.info, i.errT))
+        case ex@Exhale(e) => (Exhale(translateNormal(e, p1, p2))(ex.pos, ex.info, ex.errT),
+          Exhale(translatePrime(e, p1, p2))(ex.pos, ex.info, ex.errT))
+        case b: SIFBreakStmt => {
+          // TODO
+          (LocalVarAssign(ctrlVars.break1r.get, TrueLit()())(b.pos, b.info, b.errT),
+            LocalVarAssign(ctrlVars.break2r.get, TrueLit()())(b.pos, b.info, b.errT))
+        }
+        case c: SIFContinueStmt => (LocalVarAssign(ctrlVars.cont1r.get, TrueLit()())(c.pos, c.info, c.errT),
+          LocalVarAssign(ctrlVars.cont2r.get, TrueLit()())(c.pos, c.info, c.errT))
+        case r@SIFReturnStmt(e, resVar) =>
+          {
+            // TODO
+            val assign1 = resVar match {
+              case Some(rv) => Seq(LocalVarAssign(translateNormal(rv, p1, p2),
+                translateNormal(e.get, p1, p2))(r.pos, r.info, r.errT))
+              case None => Seq()
+            }
+            val assign2 = resVar match {
+              case Some(rv) => Seq(LocalVarAssign(translatePrime(rv, p1, p2),
+                translatePrime(e.get, p1, p2))(r.pos, r.info, r.errT))
+              case None => Seq()
+            }
+            (Seqn(assign1 :+ LocalVarAssign(ctrlVars.ret1r.get, TrueLit()())(), Seq())(),
+              Seqn(assign2 :+ LocalVarAssign(ctrlVars.ret2r.get, TrueLit()())(), Seq())())
+          }
+
+        case _ => throw new IllegalArgumentException(s"The statement $s can't be translated partially")
+      }
+    }
+
+    def optimizeSequential(s: Seqn): Seq[Stmt] = {
+      def sequenceSplit(in: Seq[Stmt]): (Seq[Stmt], Seq[Stmt]) = {
+        // ensure that we make a split after return, break, continue, raise, because the ctrlVars will have changed
+        var stop: Boolean = false
+        def keepGoing(stmt: Stmt): Boolean = {
+          val oldStop = stop
+          stmt match {
+            case _: SIFReturnStmt   => stop = true
+            case _: SIFBreakStmt    => stop = true
+            case _: SIFContinueStmt => stop = true
+            case _: SIFRaiseStmt    => stop = true
+            case _ =>
+          }
+          !oldStop && isCompressible(stmt)
+        }
+        in.span(stmt => keepGoing(stmt))
+      }
+
+      var newStmts = Seq[Stmt]()
+      var (comp, rest) = sequenceSplit(s.ss)
+//      println("optimizing compressible statements:")
+      while (comp.nonEmpty || rest.nonEmpty) {
+//        println(s"split into comp: $comp and rest: $rest")
+        // collect all compressible statements we have until here
+        if (comp.nonEmpty) {
+          val (fstExComp, secExComp): (Seq[Stmt], Seq[Stmt]) = comp.map(stmt => translateStmtPartial(stmt)).unzip
+          newStmts :+= executeConditionally(Seqn(fstExComp, Seq())(), Seqn(secExComp, Seq())())
+        }
+        // translate all non-compressible statements
+        var split = rest.span(stmt => !isCompressible(stmt))
+        val nonComp = split._1
+        rest = split._2
+//        println(s"split into non-comp: $nonComp and rest: $rest")
+        nonComp.foreach(stmt => newStmts :+= translateStatement(stmt, ctx))
+        // start anew
+        split = sequenceSplit(rest)
+        comp = split._1
+        rest = split._2
+      }
+      newStmts
+    }
+
+    s match {
+      case l@LocalVarAssign(lhs, rhs)  => translateAssignment(translateNormal(lhs, p1, p2),
+        translateNormal(rhs, p1, p2), translatePrime(lhs, p1, p2), translatePrime(rhs, p1, p2), l)
+      case a@FieldAssign(lhs, rhs)  => executeConditionally(Seqn(Seq(a), Seq())(),
+          Seqn(Seq(FieldAssign(translatePrime(lhs, p1, p2),
+            translatePrime(rhs, p1, p2))(a.pos, a.info, a.errT)), Seq())())
+      case NewStmt(lhs, fields) => {
+        val allFields = fields ++ fields.map{f => newFields.find(f2 => f2.name == primedNames(f.name)).get}
+        val (tmpd, tmpr) = getNewVar("tmp", Ref)
+        val newNew = NewStmt(tmpr, allFields)()
+        /*val allFieldAssigns = allFields.map { f =>
+          val (hd, hr) = getNewVar("havoc", f.typ)
+          val fieldAcc = FieldAccess(tmpr, f)()
+          Seqn(Seq(FieldAssign(fieldAcc, hr)()), Seq(hd))()
+        }*/
+        val assign1 = If(act1, Seqn(Seq(LocalVarAssign(lhs, tmpr)()), Seq())(), skip)()
+        val assign2 = If(act2, Seqn(Seq(LocalVarAssign(translatePrime(lhs, p1, p2), tmpr)()),
+            Seq())(), skip)()
+        Seqn(Seq(newNew) ++  /*allFieldAssigns ++*/ Seq(assign1, assign2, incrementTime(p1, p2)), Seq(tmpd))()
+      }
+      case i@If(cond, thn, els) => {
+        val (p1d, p1r) = getNewBool("p1")
+        val (p2d, p2r) = getNewBool("p2")
+        val (p3d, p3r) = getNewBool("p3")
+        val (p4d, p4r) = getNewBool("p4")
+
+        val p1Assign = LocalVarAssign(p1r, And(act1, cond)())(i.pos)
+        val p2Assign = LocalVarAssign(p2r, And(act2, translatePrime(cond, p1, p2))())(i.pos)
+        val p3Assign = LocalVarAssign(p3r, And(act1, Not(cond)())())(i.pos)
+        val p4Assign = LocalVarAssign(p4r, And(act2, Not(translatePrime(cond, p1, p2))())())(i.pos)
+
+        val thnRes = translateStatement(thn, TranslationContext(p1r, p2r, ctrlVars, ctx.currentMethod))
+        val elsRes = translateStatement(els, TranslationContext(p3r, p4r, ctrlVars, ctx.currentMethod))
+        Seqn(Seq(p1Assign, p2Assign, p3Assign, p4Assign, incrementTime(p1, p2), thnRes, elsRes), Seq(p1d, p2d, p3d, p4d))()
+      }
+      case w: While => translateWhileStmt(w, ctx)
+      case mc@MethodCall(name, args, targets) => {
+        var argDecls = Seq[LocalVarDecl]()
+        var newArgs = Seq[Exp](act1, act2)
+        var argAssigns1 = Seq[LocalVarAssign]()
+        var argAssigns2 = Seq[LocalVarAssign]()
+
+        if (timing){
+          newArgs ++= Seq(time.get, translatePrime(time.get, p1, p2))
+        }
+
+        for (a <- args){
+          val (tmp1d, tmp1r) = getNewVar("tmp1", a.typ)
+          val (tmp2d, tmp2r) = getNewVar("tmp2", a.typ)
+          argDecls ++= Seq(tmp1d, tmp2d)
+          newArgs ++= Seq(tmp1r, tmp2r)
+          argAssigns1 :+= LocalVarAssign(tmp1r, a)()
+          argAssigns2 :+= LocalVarAssign(tmp2r, translatePrime(a, p1, p2))()
+        }
+        val argAssignsConditional: Seq[Stmt] = Seq(
+          If(act1, Seqn(argAssigns1, Seq())(), skip)(),
+          If(act2, Seqn(argAssigns2, Seq())(), skip)()
+        )
+
+        var targetDecls = Seq[LocalVarDecl]()
+        var newTargets = Seq[LocalVar]()
+        var targetAssigns1 = Seq[LocalVarAssign]()
+        var targetAssigns2 = Seq[LocalVarAssign]()
+
+        if (timing){
+          newTargets ++= Seq(time.get, translatePrime(time.get, p1, p2))
+        }
+
+        for (t <- targets){
+          val (tmp1d, tmp1r) = getNewVar("tmp1", t.typ)
+          val (tmp2d, tmp2r) = getNewVar("tmp2", t.typ)
+          targetDecls ++= Seq(tmp1d, tmp2d)
+          newTargets ++= Seq(tmp1r, tmp2r)
+          targetAssigns1 :+= LocalVarAssign(t, tmp1r)()
+          targetAssigns2 :+= LocalVarAssign(translatePrime(t, p1, p2), tmp2r)()
+        }
+        val targetAssignsConditional = if (targets.nonEmpty) Seq[Stmt](
+          If(act1, Seqn(targetAssigns1, Seq())(), skip)(),
+          If(act2, Seqn(targetAssigns2, Seq())(), skip)()
+        ) else Seq()
+
+        val call = MethodCall(name, newArgs, newTargets)(mc.pos, mc.info, mc.errT)
+        If(Or(act1, act2)(),
+          Seqn(argAssignsConditional ++ Seq(call) ++ targetAssignsConditional, argDecls ++ targetDecls)(),
+          skip
+        )(info = SimpleInfo(Seq(s"Method call: $name\n  ")))
+      }
+      case s: Seqn => {
+        val seq = if (Config.optimizeSequential) flattenSeqn(s) else s
+        var newDecls = Seq[Declaration]()
+        for (d <- seq.scopedDecls.filter(d => d.isInstanceOf[LocalVarDecl])){
+          val newName = getName(d.name)
+          primedNames.update(d.name, newName)
+          val newD = LocalVarDecl(newName, d.asInstanceOf[LocalVarDecl].typ)()
+          newDecls ++= Seq(d, newD)
+        }
+        newDecls ++= seq.scopedDecls.filter(d => d.isInstanceOf[Label])
+        val newStmts = if (Config.optimizeSequential) optimizeSequential(seq)
+          else seq.ss.map{stmt => translateStatement(stmt, ctx)}
+        Seqn(newStmts, newDecls)()
+      }
+      case a@Assert(e1) =>
+        val newCtx = a.info.getUniqueInfo[SIFInfo] match {
+          case Some(info) if info.continueUnaware => ctx.copy(p1 = ctrlVars.activeExecNoContNormal(Some(p1)),
+            p2 = ctrlVars.activeExecNoContPrime(Some(p2)))
+          case _ => ctx.copy(p1 = act1, p2 = act2)
+        }
+        Assert(translateSIFAss(e1, newCtx))(s.pos, errT= fwTs(s, s))
+      case i@Inhale(FalseLit()) => i
+      case Assume(e1) => Assume(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, errT= fwTs(s, s))
+      case Inhale(e1) => Inhale(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, errT= fwTs(s, s))
+      case Exhale(e1) => Exhale(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, errT= fwTs(s, s))
+      case d : LocalVarDeclStmt => d
+      case u@Unfold(acc) =>
+        val predicate2 = PredicateAccess(acc.loc.args.map(a => translatePrime(a, p1, p2)),
+          acc.loc.predicateName)()
+        val (lowFunc, lhs) = getPredicateLowFuncExp(acc.loc.predicateName, ctx)
+        val assert = lowFunc match {
+          case Some(f) =>
+            val et = ErrTrafo({case _: AssertFailed => errors.UnfoldFailed(u, SIFUnfoldNotLow(u))})
+            Assert(Implies(
+              lhs,
+              Implies(
+                And(
+                  PermGeCmp(CurrentPerm(acc.loc)(), FullPerm()())(),
+                  PermGeCmp(CurrentPerm(predicate2)(), FullPerm()())()
+                )(),
+                FuncApp(f, acc.loc.args ++ acc.loc.args.map(a => translatePrime(a, p1, p2)))()
+              )())()
+            )(u.pos, u.info, errT = et)
+          case None => skip
+        }
+        val if1 = If(act1, Seqn(Seq(u), Seq())(), skip)()
+        val if2 = If(act2, Seqn(Seq(
+          Unfold(PredicateAccessPredicate(predicate2, translatePrime(acc.perm, p1, p2))())(u.pos, u.info, u.errT)
+        ), Seq())(), skip)()
+        Seqn(Seq(assert, if1, if2), Seq())()
+      case f@Fold(acc) =>
+        val if1 = If(act1, Seqn(Seq(f), Seq())(), skip)()
+        val if2 = If(act2, Seqn(Seq(
+          Fold(PredicateAccessPredicate(
+            PredicateAccess(acc.loc.args.map(a => translatePrime(a, p1, p2)),
+              acc.loc.predicateName)(), translatePrime(acc.perm, p1, p2))())(f.pos, f.info, f.errT)
+        ), Seq())(), skip)()
+        val (lowFunc, lhs) = getPredicateLowFuncExp(acc.loc.predicateName, ctx)
+        val assert: Stmt = lowFunc match {
+          case Some(func) =>
+            val et = ErrTrafo({case AssertFailed(_,_,_) => errors.FoldFailed(f, SIFFoldNotLow(f))})
+            Assert(Implies(
+              lhs,
+              FuncApp(func.copy()(func.pos, func.info, errT = et),
+                acc.loc.args ++ acc.loc.args.map(a => translatePrime(a, p1, p2)))()
+            )())(f.pos, f.info, errT = et)
+          case None => skip
+        }
+        Seqn(Seq(if1, if2, assert), Seq())()
+      case r: SIFReturnStmt => {
+        // TODO
+        val (first, second) = translateStmtPartial(r).asInstanceOf[(Seqn, Seqn)]
+        val r1 = If(act1, first, skip)()
+        val r2 = If(act2, second, skip)()
+        Seqn(Seq(r1, r2, incrementTime(p1, p2)), Seq())()
+      }
+      case b@SIFBreakStmt() => {
+        // TODO
+        translateAssignment(ctrlVars.break1r.get, TrueLit()(),
+          ctrlVars.break2r.get, TrueLit()(), b)
+      }
+      case c@SIFContinueStmt() => translateAssignment(ctrlVars.cont1r.get, TrueLit()(),
+        ctrlVars.cont2r.get, TrueLit()(), c)
+      case tryCatch: SIFTryCatchStmt => translateTryCatchStmt(tryCatch, ctx)
+      case SIFRaiseStmt(assignment) =>
+        var stmts = Seq[Stmt]()
+        val assign1 = assignment match {
+          case Some(a) => Some(LocalVarAssign(translateNormal(a.lhs, p1, p2),
+            translateNormal(a.rhs, p1, p2))())
+          case None => None
+        }
+        val assign2 = assignment match {
+          case Some(a) => Some(LocalVarAssign(translatePrime(a.lhs, p1, p2),
+            translatePrime(a.rhs, p1, p2))())
+          case None => None
+        }
+        stmts :+= If(act1,
+          Seqn(Seq(assign1, Some(LocalVarAssign(ctrlVars.except1r.get, TrueLit()())()))
+            .collect({case Some(x) => x}), Seq())(),
+          skip)()
+        stmts :+= If(act2,
+          Seqn(Seq(assign2, Some(LocalVarAssign(ctrlVars.except2r.get, TrueLit()())()))
+            .collect({case Some(x) => x}), Seq())(),
+          skip)()
+        Seqn(stmts, Seq())()
+      case d@SIFDeclassifyStmt(e) => Inhale(Implies(
+        And(act1, act2)(), EqCmp(translateNormal(e, p1, p2), translatePrime(e, p1, p2))()
+      )())(d.pos, d.info, d.errT)
+      case SIFAssertNoException() =>
+        val exp: Exp = if (ctrlVars.except1r.isDefined) And(
+          Implies(p1, Not(ctrlVars.except1r.get)())(s.pos, s.info, s.errT),
+          Implies(p2, Not(ctrlVars.except2r.get)())(s.pos, s.info, s.errT)
+        )(s.pos, s.info, s.errT)
+        else TrueLit()()
+        Exhale(exp)(s.pos, s.info, s.errT)
+      case SIFInlinedCallStmt(stmts) =>
+        val newCtrlVars = createControlFlowVars(stmts)
+        val inlinedCtx = TranslationContext(p1, p2, newCtrlVars, ctx.currentMethod)
+        Seqn(newCtrlVars.initAssigns() :+ translateStatement(stmts, inlinedCtx), newCtrlVars.declarations())()
+      case Goto(l) => {
+        val varName1 = ctrlVars.labelNames.get(l).get
+        val varName2 = primedNames.get(varName1).get
+        val assign1 = If(act1, Seqn(Seq(LocalVarAssign(LocalVar(varName1, Bool)(), TrueLit()())()), Seq())(), Seqn(Seq(), Seq())())()
+        val assign2 = If(act2, Seqn(Seq(LocalVarAssign(LocalVar(varName2, Bool)(), TrueLit()())()), Seq())(), Seqn(Seq(), Seq())())()
+        Seqn(Seq(assign1, assign2), Seq())()
+      }
+      case lb@Label(l, _) if ctrlVars.labelNames.contains(l) => {
+        val varName1 = ctrlVars.labelNames.get(l).get
+        val varName2 = primedNames.get(varName1).get
+        val thisAct1 = ctx.ctrlVars.activeExecNormalExceptLabel(Some(p1), varName1)
+        val thisAct2 = ctx.ctrlVars.activeExecPrimeExceptLabel(Some(p2), varName2)
+        val assign1 = If(thisAct1, Seqn(Seq(LocalVarAssign(LocalVar(varName1, Bool)(), FalseLit()())()), Seq())(), Seqn(Seq(), Seq())())()
+        val assign2 = If(thisAct2, Seqn(Seq(LocalVarAssign(LocalVar(varName2, Bool)(), FalseLit()())()), Seq())(), Seqn(Seq(), Seq())())()
+        Seqn(Seq(lb, assign1, assign2), Seq())()
+      }
+      case lb : Label => lb
+      case p: Package => translateWandPackage(p, ctx)
+      case a: Apply => translateWandApply(a, ctx)
+      case other => throw new IllegalArgumentException("unexpected: " + other)
+    }
+  }
+
+  def getNewVar(name: String, typ: Type) : (LocalVarDecl, LocalVar) = {
+    val newName = getName(name)
+    (LocalVarDecl(newName, typ)(), LocalVar(newName, typ)())
+  }
+
+  def getNewBool(name: String) : (LocalVarDecl, LocalVar) = {
+    getNewVar(name, Bool)
+  }
+
+  def isRelational(e: Exp): Boolean = {
+    !isUnary(e)
+  }
+
+  def isUnary(e: Exp): Boolean = {
+    val relVars = e.filter{
+      case _: SIFLowExp => true
+      case _: SIFLowEventExp => true
+      case DomainFuncApp("Low", _, _) => true
+      case _ => false
+    }
+    relVars.isEmpty
+  }
+
+  def translateSIFExp1(e: Exp, p1: Exp, p2: Exp): Exp = {
+    e match {
+      case re if isRelational(e) => Implies(And(p1, p2)(), translateNormal(e, p1, p2))(e.pos, errT = fwTs(re, re))
+      case _ if isUnary(e) => translateNormal(e, p1, p2)
+    }
+  }
+
+  def translateSIFExp2(e: Exp, p1: Exp, p2: Exp): Exp = {
+    e match {
+      case re if isRelational(e) => TrueLit()(e. pos, errT = fwTs(re, re))
+      case _ => translatePrime(e, p1, p2)
+    }
+  }
+
+  def translateSIFLowExpComparison(l: SIFLowExp, p1: Exp, p2: Exp): Exp = {
+    val primedExp = translatePrime(l.exp, p1, p2)
+    l.comparator match {
+      case None => EqCmp(l.exp, primedExp)(l.pos, errT = fwTs(l, l))
+      case Some(str) =>
+        _program.findDomainFunctionOptionally(str) match {
+          case Some(df) => DomainFuncApp(df, Seq(l.exp, primedExp), l.typVarMap)(l.pos, l.info, errT = fwTs(l, l))
+          case None => _program.findFunctionOptionally(str) match {
+            case Some(f) => FuncApp(f, Seq(l.exp, primedExp))(l.pos, l.info, errT = fwTs(l, l))
+            case None => sys.error(s"Unknown comparator $str.")
+          }
+        }
+    }
+  }
+
+  def translateAssDefault(e: Exp, p1: Exp, p2: Exp): And = {
+    And(Implies(p1, translateSIFExp1(e, p1, p2))(e.pos, errT = fwTs(e, e)),
+      Implies(p2, translateSIFExp2(e, p1, p2))(e.pos, errT = fwTs(e, e)))(e.pos, errT = fwTs(e, e))
+  }
+
+  def fwTs(t: TransformableErrors, node: ErrorNode) = {
+    Trafos(t.errT.eTransformations, t.errT.rTransformations, Some(node))
+  }
+
+  def translateSIFAss(e: Exp, ctx: TranslationContext, relAssertCtx: TranslationContext = null): Exp = {
+    val p1 = ctx.p1
+    val p2 = ctx.p2
+    val relCtx = if (relAssertCtx == null) ctx else relAssertCtx
+    def bothExecutions(e: Exp, pos: Position = NoPosition, info: Info = NoInfo,
+                       errT: ErrorTrafo = NoTrafos): Exp = {
+      Implies(And(relCtx.p1, relCtx.p2)(), e)(pos, info, errT)
+    }
+
+    e match {
+      case And(e1, e2) => And(translateSIFAss(e1, ctx, relAssertCtx), translateSIFAss(e2, ctx, relAssertCtx))(e.pos, errT = fwTs(e, e))
+      case i@Implies(e1, e2) if !isUnary(i) => {
+        Implies(translateSIFAss(e1, ctx, relAssertCtx), translateSIFAss(e2, ctx, relAssertCtx))(e.pos, errT = fwTs(e, e))
+      }
+      case Implies(e1, e2) if e2.exists({
+        case PredicateAccess(_, name) => predLowFuncs(name).isDefined
+        case _ => false
+      }) =>
+        And(translateAssDefault(e, p1, p2), Implies(
+          translateSIFAss(e1, ctx, relAssertCtx),
+          translatePredLowFuncOnly(e2, p1, p2)
+        )())(e.pos, e.info, e.errT)
+      case fa@Forall(vars, triggers, exp) =>  {
+        if (fa.isPure){
+          for (v <- vars){
+            if (primedNames.contains(v.name)){
+              primedNames.remove(v.name)
+            }
+          }
+          /*var varEqs: Exp = TrueLit()()
+          val pvars = vars.map { v =>
+            val primeName = getName(v.name)
+            primedNames.update(v.name, primeName)
+            varEqs = And(varEqs, EqCmp(v.localVar, LocalVar(primeName)(v.typ))())()
+            LocalVarDecl(primedNames.get(v.name).get, v.typ)()
+          }*/
+          val newTriggers = triggers.map{t => Trigger(t.exps.map{e => translatePrime(e, p1, p2)})()}
+          //val res = Forall(vars ++ pvars, newTriggers, Implies(varEqs, translateSIFAss(exp, p1, p2))(e.pos, errT = NodeTrafo(e)))(e.pos, errT = NodeTrafo(e))
+          val res = Forall(vars, triggers ++ newTriggers,
+            translateSIFAss(exp, ctx, relAssertCtx))(e.pos, errT = fwTs(e, e)).autoTrigger
+          res
+        } else {
+          val normal = translateNormal(fa, p1, p2)
+          val prime = translatePrime(fa, p1, p2)
+          And(Implies(p1, normal)(e.pos, errT = fwTs(e, e)), Implies(p2, prime)(e.pos, errT = fwTs(e, e)))(e.pos, errT = fwTs(e, e))
+        }
+      }
+      case l: SIFLowEventExp =>
+        val act1 = ctx.ctrlVars.activeExecNormal(Some(p1))
+        val act2 = ctx.ctrlVars.activeExecPrime(Some(p2))
+        val dynCheckInfo = l.info.getUniqueInfo[SIFDynCheckInfo]
+        dynCheckInfo match {
+          case None => EqCmp(act1, act2)(e.pos, errT = fwTs(e, e))
+          case Some(dci) => And(EqCmp(act1, act2)(e.pos, errT = fwTs(e, e)), Implies(act1,
+            EqCmp(translateNormal(dci.dynCheck, p1, p2),
+              translatePrime(dci.dynCheck, p1, p2))())())(e.pos, errT = fwTs(e, e))
+        }
+      case _: SIFLowExitExp =>
+        val act1 = ctx.ctrlVars.activeExecNoContNormal(None)
+        val act2 = ctx.ctrlVars.activeExecNoContPrime(None)
+        Implies(And(relCtx.p1, relCtx.p2)(), EqCmp(act1, act2)(e.pos, errT = fwTs(e, e)))(e.pos, errT = fwTs(e, e))
+      case l@SIFLowExp(_, _, _) =>
+        val comparison = translateSIFLowExpComparison(l, relCtx.p1, relCtx.p2)
+        val dynCheckInfo = l.info.getUniqueInfo[SIFDynCheckInfo]
+        dynCheckInfo match {
+          case None => bothExecutions(comparison, e.pos)
+          case Some(dci) =>
+            val inhalePart = bothExecutions(Implies(
+              EqCmp(translateNormal(dci.dynCheck, relCtx.p1, relCtx.p2), translatePrime(dci.dynCheck, relCtx.p1, relCtx.p2))(), comparison
+            )(), e.pos)
+            if (dci.onlyDynVersion) {
+              inhalePart
+            } else {
+              InhaleExhaleExp(inhalePart, bothExecutions(comparison, e.pos)
+              )(l.pos, l.info, errT = fwTs(l, l))
+            }
+        }
+      // for the domain method low, used e.g. for list resource
+      case f@DomainFuncApp("Low", args, _) => translateSIFAss(
+        SIFLowExp(args.head, None)(f.pos, f.info, f.errT), ctx, relAssertCtx)
+      case pap@PredicateAccessPredicate(pred, _) =>
+        val (lowFunc, lhs) = getPredicateLowFuncExp(pred.predicateName, ctx)
+        lowFunc match {
+          case Some(f: Function) =>
+            val lowFuncApp = Implies(lhs,
+              FuncApp(f, pred.args ++ pred.args.map(a => translatePrime(a, p1, p2)))(pap.pos, pap.info, pap.errT)
+            )()
+            val dynCheckInfo = pap.info.getUniqueInfo[SIFDynCheckInfo]
+            val lowPart: Exp = dynCheckInfo match {
+              case Some(dfi) =>
+                val inhalePart = Implies(
+                  EqCmp(translateNormal(dfi.dynCheck, p1, p2), translatePrime(dfi.dynCheck, p1, p2))(),
+                  lowFuncApp
+                )(e.pos, e.info, e.errT)
+                if (dfi.onlyDynVersion) inhalePart
+                else InhaleExhaleExp(inhalePart, lowFuncApp)(e.pos, e.info, e.errT)
+              case None => lowFuncApp
+            }
+            And(translateAssDefault(pap, p1, p2), lowPart)(e.pos, errT = fwTs(e, e))
+          case None => translateAssDefault(pap, p1, p2)
+        }
+      case o@Old(oldExp) => Old(translateSIFAss(oldExp, ctx, relAssertCtx))(o.pos, o.info, o.errT)
+      case FuncApp(name, _) if predAllLowFuncs.values.exists(v => v.isDefined && v.get.name == name) =>
+        bothExecutions(e)
+      case Unfolding(predAcc, body) if !isUnary(body) => bothExecutions(Unfolding(
+        translateNormal(predAcc, relCtx.p1, relCtx.p2),
+        Unfolding(translatePrime(predAcc, relCtx.p1, relCtx.p2),
+          translateSIFAss(body, ctx, relAssertCtx))(e.pos, e.info, e.errT))(e.pos, e.info, e.errT),
+        e.pos, e.info, e.errT)
+      // case w@MagicWand(left, right) => 
+      // case Let(decl, e1, e2) => ???
+      case _: SIFTerminatesExp => TrueLit()()
+      case _ => translateAssDefault(e, p1, p2)
+    }
+  }
+
+  def translatePrime[T <: Exp](e: T, p1: Exp, p2: Exp) : T = {
+    e.transform{
+      case d: LocalVarDecl if primedNames.contains(d.name) =>
+        d.copy(name = primedNames(d.name))(d.pos, d.info, d.errT)
+      case l: LocalVar if primedNames.contains(l.name) =>
+        l.copy(name = primedNames(l.name))(l.pos, l.info, l.errT)
+      case l: LocalVar if !primedNames.contains(l.name) => l
+      case FieldAccess(rcv, field) =>
+        FieldAccess(translatePrime(rcv, p1, p2), field)(e.pos)
+      case f@FuncApp(name, _) if Config.primedFuncAppReplacements.keySet.contains(name) =>
+        Config.primedFuncAppReplacements(name)(f, p1, p2)
+      case f@FuncApp(name, args) => FuncApp(name,
+        args.map(a => translatePrime(a, p1, p2)))(f.pos, f.info, f.typ, f.errT)
+      case DomainFuncApp("Low", _, _) => TrueLit()()
+      case df@DomainFuncApp(name, args, typVarMap) =>
+        DomainFuncApp(
+          name, args.map(a => translatePrime(a, p1, p2)), typVarMap)(
+          df.pos, df.info, df.typ, df.domainName, df.errT)
+      case pa@PredicateAccess(args, "MayJoin") => PredicateAccess(args.map(a => translatePrime(a, p1, p2)), "MayJoinP")(pa.pos, pa.info, pa.errT)
+      case pa@PredicateAccess(args, name) => PredicateAccess(args.map(a => translatePrime(a, p1, p2)),
+        name)(pa.pos, pa.info, pa.errT)
+      case l: SIFLowExp => Implies(And(p1, p2)(), translateSIFLowExpComparison(l, p1, p2))()
+      case f@ForPerm(vars, location, body) => ForPerm(vars,
+        translateResourceAccess(location),
+        translatePrime(body, p1, p2))(f.pos, f.info, f.errT)
+    }
+  }
+
+  def translateNormal[T <: Exp](e: T, p1: Exp, p2: Exp): T = {
+    e.transform{
+      case l: SIFLowExp => Implies(And(p1, p2)(), translateSIFLowExpComparison(l, p1, p2))()
+      case DomainFuncApp("Low", args, _) => Implies(And(p1, p2)(), translateSIFLowExpComparison(SIFLowExp(args.head)(), p1, p2))()
+    }
+  }
+
+  def translateToUnary(e: Option[Exp]): Option[Exp] = {
+    e match {
+      case Some(x) => Some(translateToUnary(x))
+      case None => None
+    }
+  }
+
+  /** Translate an expression getting rid of all the relational parts. */
+  def translateToUnary(e: Exp): Exp = {
+    val transformed = e.transform{
+      case _: SIFLowExp => TrueLit()()
+      case DomainFuncApp("Low", _, _) => TrueLit()()
+      case Implies(_: SIFLowExp, _: SIFLowExp) => TrueLit()()
+      case i@Implies(lhs, rhs) => Implies(lhs, translateToUnary(rhs))(i.pos, i.info, i.errT)
+    }
+    Simplifier.simplify(transformed)
+  }
+
+  /** Translate only the relational parts of an expression. All unary parts are translated to True.
+    * @param e The expression to translate.
+    * @return The translation of the relational parts of `e`.
+    */
+  def translatePredLowFuncBody(e: Exp): Exp = {
+    val translated = e match {
+      case l: SIFLowExp => translateSIFLowExpComparison(l, null, null)
+      case p@PredicateAccessPredicate(loc, _) =>
+        val (lowFName, _, _) = predLowFuncInfo(loc.predicateName).get
+        FuncApp(lowFName,
+          loc.args ++ loc.args.map(a => translatePrime(a, null, null)))(
+          p.pos, NoInfo, Bool, p.errT)
+      case a@And(left, right) => And(translatePredLowFuncBody(left),
+        translatePredLowFuncBody(right))(a.pos, a.info, a.errT)
+      case o@Or(left, right) => Or(translatePredLowFuncBody(left),
+        translatePredLowFuncBody(right))(o.pos, o.info, o.errT)
+      case i@Implies(left, right) => Implies(And(translateNormal(left, null, null),
+        translatePrime(left, null, null))(),
+        translatePredLowFuncBody(right)
+      )(i.pos, i.info, i.errT)
+      case _ => TrueLit()()
+    }
+    Simplifier.simplify(translated)
+  }
+
+  def translatePredAllLowFuncBody(e: Exp): Exp = {
+    val translated = e match {
+      case FieldAccessPredicate(loc, _) => EqCmp(loc, translatePrime(loc, null, null))()
+      case p@PredicateAccessPredicate(loc, _) =>
+        if (predAllLowFuncInfo(loc.predicateName).isDefined){
+          val (lowFName, _, _) = predAllLowFuncInfo(loc.predicateName).get
+          FuncApp(lowFName,
+            loc.args ++ loc.args.map(a => translatePrime(a, null, null)))(
+            p.pos, NoInfo, Bool, p.errT)
+        }else{
+          TrueLit()()
+        }
+
+      case a@And(left, right) => And(translatePredAllLowFuncBody(left),
+        translatePredAllLowFuncBody(right))(a.pos, a.info, a.errT)
+      case o@Or(left, right) => Or(translatePredAllLowFuncBody(left),
+        translatePredAllLowFuncBody(right))(o.pos, o.info, o.errT)
+      case i@Implies(left, right) => Implies(And(translateNormal(left, null, null),
+        translatePrime(left, null, null))(),
+        translatePredAllLowFuncBody(right)
+      )(i.pos, i.info, i.errT)
+      case _ => TrueLit()()
+    }
+    Simplifier.simplify(translated)
+  }
+
+  def translatePredLowFuncOnly(e: Exp, p1: Exp, p2: Exp): Exp = {
+    val translated: Exp = e match {
+      case PredicateAccessPredicate(pred, _) =>
+        predLowFuncs(pred.predicateName) match {
+          case Some(f: Function) => Implies(And(p1, p2)(),
+            FuncApp(f, pred.args ++ pred.args.map(a => translatePrime(a, p1, p2)))(e.pos, e.info, e.errT)
+          )()
+          case None => TrueLit()()
+        }
+      case a@And(left, right) => And(translatePredLowFuncOnly(left, p1, p2),
+        translatePredLowFuncOnly(right, p1, p2))(a.pos, a.info, a.errT)
+      case o@Or(left, right) => Or(translatePredLowFuncOnly(left, p1, p2),
+        translatePredLowFuncOnly(right, p1, p2))(o.pos, o.info, o.errT)
+      case i@Implies(left, right) => Implies(And(translateNormal(left, null, null),
+        translatePrime(left, null, null))(),
+        translatePredLowFuncOnly(right, p1, p2)
+      )(i.pos, i.info, i.errT)
+      case _ => TrueLit()()
+    }
+    Simplifier.simplify(translated)
+  }
+
+  def translateResourceAccess(ra: ResourceAccess): ResourceAccess = {
+    ra match {
+      case FieldAccess(rcv, field) => {
+        FieldAccess(rcv, field)(ra.pos, ra.info, ra.errT)
+      }
+      case PredicateAccess(args, name) => {
+        PredicateAccess(args, name)(ra.pos, ra.info, ra.errT)
+      }
+      case _ => sys.error("Unsupported")
+    }
+  }
+
+  def getPredicateLowFunction(predName: String, m: Method): Option[Function] = {
+    if (allLowMethods.contains(m.name) || preservesLowMethods.contains(m.name))
+      predAllLowFuncs(predName)
+    else
+      predLowFuncs(predName)
+  }
+
+  def getPredicateLowFuncExp(predName: String, ctx: TranslationContext): (Option[Function], Exp) = {
+    val lowFunc = getPredicateLowFunction(predName, ctx.currentMethod)
+    lazy val act1: Exp = ctx.ctrlVars.activeExecNormal(Some(ctx.p1))
+    lazy val act2: Exp = ctx.ctrlVars.activeExecPrime(Some(ctx.p2))
+    lazy val isInPreservesLow: Boolean = preservesLowMethods.contains(ctx.currentMethod.name)
+    lowFunc match {
+      case Some(f) =>
+        var lhs = And(act1, act2)()
+        if (isInPreservesLow) {
+          val allStateLow = translateSIFAss(allVarsAndStateLow(ctx.currentMethod, ctx.currentMethod.formalArgs,
+            old = !ctx.translatingPrecond, predicateSrc = ctx.currentMethod.pres), ctx)
+          lhs = And(lhs, allStateLow)()
+        }
+        (Some(f), lhs)
+      case None => (None, TrueLit()())
+    }
+  }
+
+  def simplifyConditions(in: Seq[Exp]): Seq[Exp] = {
+    val simplified = in.map(e => e.transform{
+      case x: Exp if x.isPure => Simplifier.simplify(x)
+    })
+    simplified.filter(e => !e.isInstanceOf[TrueLit])
+  }
+
+  def flattenSeqn(in: Seqn): Seqn = {
+    var newDecls: Seq[Declaration] = in.scopedDecls
+    val newSS: Seq[Stmt] = in.ss.flatMap({
+      case s: Seqn =>
+        val innerFlat = flattenSeqn(s)
+        newDecls ++= innerFlat.scopedDecls
+        innerFlat.ss
+      case x: Stmt => Seq(x)
+    })
+    Seqn(newSS, newDecls)(in.pos, in.info, in.errT)
+  }
+
+  case class TranslationContext(p1: Exp, p2: Exp,
+                                ctrlVars: MethodControlFlowVars,
+                                currentMethod: Method,
+                                translatingPrecond: Boolean = false
+                               ) {}
+
+  class MethodControlFlowVars(hasRet: Boolean, hasBreak: Boolean, hasCont: Boolean, hasExcept: Boolean, labels: Set[Label]) {
+    var ret1d, ret2d, break1d, break2d, cont1d, cont2d, except1d, except2d: Option[LocalVarDecl] = None
+    var ret1r, ret2r, break1r, break2r, cont1r, cont2r, except1r, except2r: Option[LocalVar] = None
+    val labelRefs1 : ListBuffer[LocalVar] = new ListBuffer[LocalVar]()
+    val labelDecls1 : ListBuffer[LocalVarDecl] = new ListBuffer[LocalVarDecl]()
+    val labelRefs2 : ListBuffer[LocalVar] = new ListBuffer[LocalVar]()
+    val labelDecls2 : ListBuffer[LocalVarDecl] = new ListBuffer[LocalVarDecl]()
+    val labelNames : mutable.HashMap[String, String] = new mutable.HashMap[String, String]()
+
+    if (hasRet)    {val t = getNewBool("ret1");    ret1d = Some(t._1);    ret1r = Some(t._2)}
+    if (hasRet)    {val t = getNewBool("ret2");    ret2d = Some(t._1);    ret2r = Some(t._2)}
+    if (hasBreak)  {val t = getNewBool("break1");  break1d = Some(t._1);  break1r = Some(t._2)}
+    if (hasBreak)  {val t = getNewBool("break2");  break2d = Some(t._1);  break2r = Some(t._2)}
+    if (hasCont)   {val t = getNewBool("cont1");   cont1d = Some(t._1);   cont1r = Some(t._2)}
+    if (hasCont)   {val t = getNewBool("cont2");   cont2d = Some(t._1);   cont2r = Some(t._2)}
+    if (hasExcept) {val t = getNewBool("except1"); except1d = Some(t._1); except1r = Some(t._2)}
+    if (hasExcept) {val t = getNewBool("except2"); except2d = Some(t._1); except2r = Some(t._2)}
+    if (hasRet)    primedNames.update(ret1r.get.name, ret2r.get.name)
+    if (hasBreak)  primedNames.update(break1r.get.name, break2r.get.name)
+    if (hasCont)   primedNames.update(cont1r.get.name, cont2r.get.name)
+    if (hasExcept) primedNames.update(except1r.get.name, except2r.get.name)
+    for (label <- labels){
+      val t1 = getNewBool(label.name + "1")
+      labelRefs1.append(t1._2)
+      labelDecls1.append(t1._1)
+      labelNames.update(label.name, t1._2.name)
+      val t2 = getNewBool(label.name + "2")
+      labelRefs2.append(t2._2)
+      labelDecls2.append(t2._1)
+      primedNames.update(t1._2.name, t2._2.name)
+    }
+
+    def declarations(): Seq[LocalVarDecl] = {
+      Seq(ret1d, ret2d, break1d, break2d, cont1d, cont2d, except1d, except2d)
+        .filter(v => v.isDefined)
+        .map(v => v.get) ++ labelDecls1 ++ labelDecls2
+    }
+
+    def initAssigns(): Seq[Stmt] = {
+      (Seq(ret1r, ret2r, break1r, break2r, cont1r, cont2r, except1r, except2r)
+        .filter(v => v.isDefined)
+        .map(v => LocalVarAssign(v.get, FalseLit()())())) ++
+      (labelRefs1 ++ labelRefs2).map(v => LocalVarAssign(v, FalseLit()())())
+    }
+
+    private def conjoinVars(s: Seq[Exp]): Option[Exp] = {
+      val negations: Seq[Exp] = s.map(x => Not(x)())
+      if (negations.nonEmpty)
+        Some(negations.reduceRight[Exp]((x, y) => And(x, y)()))
+      else
+        None
+    }
+
+    private def activeExecHelper(p: Option[Exp], s: Seq[Exp]): Exp = {
+      val controls: Option[Exp] = conjoinVars(s)
+      val expressions: Seq[Exp] = Seq(p, controls).collect({case Some(x) => x})
+      expressions match {
+        case Nil => TrueLit()()
+        case Seq(head) => head
+        case _ => expressions.reduceRight[Exp]((x, y) => And(x, y)())
+      }
+    }
+
+    def removeOptions(s: Seq[Option[Exp]]) : Seq[Exp] = {
+      s.filter(v => v.isDefined).map(v => v.get)
+    }
+
+    def activeExecNormalExceptLabel(p1: Option[Exp], labelName: String): Exp = {
+      activeExecHelper(p1, removeOptions(Seq(ret1r, break1r, cont1r, except1r)) ++ labelRefs1.filter(v => !v.name.equals(labelName)))
+    }
+
+    def activeExecPrimeExceptLabel(p2: Option[Exp], labelNamePrime: String): Exp = {
+      activeExecHelper(p2, removeOptions(Seq(ret2r, break2r, cont2r, except2r)) ++ labelRefs2.filter(v => !v.name.equals(labelNamePrime)))
+    }
+
+    def activeExecNormal(p1: Option[Exp]): Exp = {
+      activeExecHelper(p1, removeOptions(Seq(ret1r, break1r, cont1r, except1r)) ++ labelRefs1)
+    }
+    def activeExecPrime(p2: Option[Exp]): Exp = {
+      activeExecHelper(p2, removeOptions(Seq(ret2r, break2r, cont2r, except2r)) ++ labelRefs2)
+    }
+
+    def activeExecNoContNormal(p1: Option[Exp]): Exp = {
+      activeExecHelper(p1, removeOptions(Seq(ret1r, break1r, except1r)) ++ labelRefs1)
+    }
+    def activeExecNoContPrime(p2: Option[Exp]): Exp = {
+      activeExecHelper(p2, removeOptions(Seq(ret2r, break2r, except2r)) ++ labelRefs2)
+    }
+  }
+
+  object EmptyControlFlowVars {
+    def apply(): MethodControlFlowVars = {
+      new MethodControlFlowVars(false, false, false, false, Set())
+    }
+  }
+}
+
+object SIFExtendedTransformer extends SIFExtendedTransformer

--- a/docs/dev-guide/src/config/flags.md
+++ b/docs/dev-guide/src/config/flags.md
@@ -59,6 +59,7 @@
 | [`SERVER_ADDRESS`](#server_address) | `Option<String>` | `None` | A |
 | [`SERVER_MAX_CONCURRENCY`](#server_max_concurrency) | `Option<usize>` | `None` | A |
 | [`SERVER_MAX_STORED_VERIFIERS`](#server_max_stored_verifiers) | `Option<usize>` | `None` | A |
+| [`SIF`](#sif) | `bool` | `false`| A |
 | [`SIMPLIFY_ENCODING`](#simplify_encoding) | `bool` | `true` | A |
 | [`SKIP_UNSUPPORTED_FEATURES`](#skip_unsupported_features) | `bool` | `false` | A |
 | [`SMT_QI_BOUND_GLOBAL`](#smt_qi_bound_global) | `Option<u64>` | `None` | A |
@@ -372,6 +373,10 @@ Maximum amount of verification requests the server will work on concurrently. If
 Maximum amount of instantiated Viper verifiers the server will keep around for reuse. If not set, defaults to `SERVER_MAX_CONCURRENT_VERIFICATION_OPERATIONS`. It also doesn't make much sense to set this option to less than that, since then the server will likely have to keep creating new verifiers, reducing the performance gained from reuse.
 
 > **Note:** This does _not_ limit how many verification requests the server handles concurrently, only the size of what is essentially its verifier cache.
+
+## `SIF`
+
+When enabled, check the program for secure information flow.
 
 ## `SIMPLIFY_ENCODING`
 

--- a/prusti-common/src/vir/optimizations/folding/expressions.rs
+++ b/prusti-common/src/vir/optimizations/folding/expressions.rs
@@ -399,6 +399,13 @@ impl ast::FallibleExprFolder for ExprOptimizer {
         Err(())
     }
 
+    fn fallible_fold_low(
+        &mut self,
+        _expr: vir::polymorphic::Low,
+    ) -> Result<vir::polymorphic::Expr, Self::Error> {
+        Err(())
+    }
+
     fn fallible_fold_predicate_access_predicate(
         &mut self,
         _predicate_access_predicate: ast::PredicateAccessPredicate,

--- a/prusti-common/src/vir/optimizations/functions/simplifier.rs
+++ b/prusti-common/src/vir/optimizations/functions/simplifier.rs
@@ -19,11 +19,9 @@ impl Simplifier for ast::Function {
     /// <https://github.com/viperproject/silicon/issues/387>
     #[tracing::instrument(level = "debug", skip(self), fields(self = %self), ret(Display))]
     fn simplify(mut self) -> Self {
-        trace!("[enter] simplify = {}", self);
         self.body = self.body.map(|b| b.simplify());
         self.posts = self.posts.into_iter().map(|p| p.simplify()).collect();
         self.pres = self.pres.into_iter().map(|p| p.simplify()).collect();
-        trace!("[exit] simplify = {}", self);
         self
     }
 }
@@ -31,10 +29,8 @@ impl Simplifier for ast::Function {
 impl Simplifier for ast::Expr {
     #[must_use]
     fn simplify(self) -> Self {
-        trace!("[enter] simplify = {:?}", self);
         let mut folder = ExprSimplifier {};
         let res = folder.fold(self);
-        trace!("[exit] simplify = {:?}", res);
         res
     }
 }

--- a/prusti-common/src/vir/optimizations/methods/mod.rs
+++ b/prusti-common/src/vir/optimizations/methods/mod.rs
@@ -13,6 +13,7 @@ mod purifier;
 mod quantifier_fixer;
 mod unfolding_fixer;
 mod var_remover;
+mod simplifier;
 
 use super::log_method;
 use crate::{config::Optimizations, vir::polymorphic_vir::cfg::CfgMethod};
@@ -20,7 +21,7 @@ use crate::{config::Optimizations, vir::polymorphic_vir::cfg::CfgMethod};
 use self::{
     assert_remover::remove_trivial_assertions, cfg_cleaner::clean_cfg,
     empty_if_remover::remove_empty_if, purifier::purify_vars, quantifier_fixer::fix_quantifiers,
-    unfolding_fixer::fix_unfoldings, var_remover::remove_unused_vars,
+    simplifier::simplify_exprs, unfolding_fixer::fix_unfoldings, var_remover::remove_unused_vars,
 };
 
 #[allow(clippy::let_and_return)]
@@ -58,6 +59,7 @@ pub fn optimize_method_encoding(
     };
     let cfg = apply!(fix_unfoldings, cfg);
     let cfg = apply!(fix_quantifiers, cfg);
+    let cfg = apply!(simplify_exprs, cfg);
     let cfg = apply!(remove_empty_if, cfg);
     let cfg = apply!(remove_unused_vars, cfg);
     let cfg = apply!(remove_trivial_assertions, cfg);

--- a/prusti-common/src/vir/optimizations/methods/simplifier.rs
+++ b/prusti-common/src/vir/optimizations/methods/simplifier.rs
@@ -1,0 +1,45 @@
+// © 2022, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use log::debug;
+use std::mem;
+use vir::polymorphic::*;
+
+use crate::vir::optimizations::functions::Simplifier;
+
+/// This optimization simplifies all expressions in a method.
+/// It is required when resource access predicates appear on the RHS of
+/// implications as implications are transformed into ors which need to be
+/// transformed back into implications otherwise, we would have an impure
+/// expression in ors which is disallowed in Viper.
+
+pub fn simplify_exprs(mut cfg: CfgMethod) -> CfgMethod {
+    debug!("Simplifying exprs in {}", cfg.name());
+    let mut sentinel_stmt = Stmt::comment("moved out stmt");
+    for block in &mut cfg.basic_blocks {
+        for stmt in &mut block.stmts {
+            mem::swap(&mut sentinel_stmt, stmt);
+            sentinel_stmt = sentinel_stmt.simplify();
+            mem::swap(&mut sentinel_stmt, stmt);
+        }
+    }
+    cfg
+}
+
+struct StmtSimplifier;
+
+impl Simplifier for Stmt {
+    fn simplify(self) -> Self {
+        let mut folder = StmtSimplifier;
+        folder.fold(self)
+    }
+}
+
+impl StmtFolder for StmtSimplifier {
+    fn fold_expr(&mut self, expr: Expr) -> Expr {
+        expr.simplify()
+    }
+}

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -338,7 +338,7 @@ impl<'v> ToViper<'v, viper::Stmt<'v>> for Stmt {
                 // Skip
                 ast.comment(&self.to_string())
             }
-            Stmt::Declassify(e) => ast.declassify(e),
+            Stmt::Declassify(e) => ast.declassify(e.to_viper(context, ast)),
         }
     }
 }
@@ -752,7 +752,7 @@ impl<'v> ToViper<'v, viper::Expr<'v>> for Expr {
                 }
             },
             Expr::Low(expr, position) => {
-                ast.low(expr.to_viper(context, ast), position.to_viper(context, ast))
+                ast.low_with_pos(expr.to_viper(context, ast), position.to_viper(context, ast))
             }
         };
         if config::simplify_encoding() {

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -753,6 +753,7 @@ impl<'v> ToViper<'v, viper::Expr<'v>> for Expr {
             Expr::Low(expr, position) => {
                 ast.low_with_pos(expr.to_viper(context, ast), position.to_viper(context, ast))
             }
+            Expr::LowEvent => ast.low_event(),
         };
         if config::simplify_encoding() {
             ast.simplified_expression(expr)

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -338,6 +338,7 @@ impl<'v> ToViper<'v, viper::Stmt<'v>> for Stmt {
                 // Skip
                 ast.comment(&self.to_string())
             }
+            Stmt::Declassify(e) => ast.declassify(e),
         }
     }
 }
@@ -750,6 +751,9 @@ impl<'v> ToViper<'v, viper::Expr<'v>> for Expr {
                     ast.int_to_backend_bv(size, base.to_viper(context, ast))
                 }
             },
+            Expr::Low(expr, position) => {
+                ast.low(expr.to_viper(context, ast), position.to_viper(context, ast))
+            }
         };
         if config::simplify_encoding() {
             ast.simplified_expression(expr)

--- a/prusti-common/src/vir/to_viper.rs
+++ b/prusti-common/src/vir/to_viper.rs
@@ -338,7 +338,6 @@ impl<'v> ToViper<'v, viper::Stmt<'v>> for Stmt {
                 // Skip
                 ast.comment(&self.to_string())
             }
-            Stmt::Declassify(e) => ast.declassify(e.to_viper(context, ast)),
         }
     }
 }

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -378,4 +378,9 @@ pub fn low<T>(_t: T) -> bool {
     true
 }
 
+/// Check that all execusion must either all reach this point or none
+pub fn low_event() -> bool {
+    true
+}
+
 pub use private::*;

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -365,4 +365,13 @@ pub fn snapshot_equality<T>(_l: T, _r: T) -> bool {
     true
 }
 
+/// Mark the given expression as low security level
+pub fn low<T>(_t: T) -> bool {
+    true
+}
+
+/// Declassify the given expression, making it low
+#[ensures(low(t))]
+pub fn declassify<T>(t: T) {}
+
 pub use private::*;

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -322,6 +322,14 @@ mod private {
             panic!()
         }
     }
+
+    /// Declassify the given expression, making it low
+    #[macro_export]
+    macro_rules! declassify {
+        ($base:expr) => {
+            $crate::prusti_assume!($crate::low($base))
+        };
+    }
 }
 
 /// This function is used to evaluate an expression in the context just
@@ -369,9 +377,5 @@ pub fn snapshot_equality<T>(_l: T, _r: T) -> bool {
 pub fn low<T>(_t: T) -> bool {
     true
 }
-
-/// Declassify the given expression, making it low
-#[ensures(low(t))]
-pub fn declassify<T>(t: T) {}
 
 pub use private::*;

--- a/prusti-server/src/backend.rs
+++ b/prusti-server/src/backend.rs
@@ -21,7 +21,14 @@ impl<'a> Backend<'a> {
 
                 ast_utils.with_local_frame(16, || {
                     let ast_factory = context.new_ast_factory();
-                    let viper_program = program.to_viper(LoweringContext::default(), &ast_factory);
+                    let mut viper_program =
+                        program.to_viper(LoweringContext::default(), &ast_factory);
+
+                        if config::sif() {
+                        let sif_transformer = context.new_sif_transformer();
+                        stopwatch.start_next("sif translation");
+                        viper_program = sif_transformer.sif_transformation(viper_program);
+                    }
 
                     if config::dump_viper_program() {
                         stopwatch.start_next("dumping viper program");

--- a/prusti-server/src/backend.rs
+++ b/prusti-server/src/backend.rs
@@ -24,7 +24,15 @@ impl<'a> Backend<'a> {
                     let mut viper_program =
                         program.to_viper(LoweringContext::default(), &ast_factory);
 
-                        if config::sif() {
+                    if config::sif() {
+                        if config::dump_viper_program() {
+                            stopwatch.start_next("dumping viper program before sif transformation");
+                            dump_viper_program(
+                                &ast_utils,
+                                viper_program,
+                                &format!("{}_before_sif", program.get_name_with_check_mode()),
+                            );
+                        }
                         let sif_transformer = context.new_sif_transformer();
                         stopwatch.start_next("sif translation");
                         viper_program = sif_transformer.sif_transformation(viper_program);

--- a/prusti-tests/tests/parse/pass/sif/declassify.rs
+++ b/prusti-tests/tests/parse/pass/sif/declassify.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+fn declassify_int(i: i32) {
+    declassify!(i);
+}
+
+fn declassify_bool(b: bool) {
+    declassify!(b);
+}
+
+fn declassify_mod(i: i32) {
+    declassify!(i % 2);
+}
+
+fn main() {}

--- a/prusti-tests/tests/parse/pass/sif/low.rs
+++ b/prusti-tests/tests/parse/pass/sif/low.rs
@@ -1,0 +1,22 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[requires(low(n))]
+fn foo(n: i32) -> i32 {
+    n
+}
+
+#[ensures(low(result))]
+fn bar() -> i32 {
+    42
+}
+
+fn baz() -> i32 {
+    let x = 1;
+    let y = 2;
+    prusti_assert!(low(x + y));
+    x + y
+}
+
+fn main() {}

--- a/prusti-tests/tests/parse/pass/sif/low.rs
+++ b/prusti-tests/tests/parse/pass/sif/low.rs
@@ -19,4 +19,12 @@ fn baz() -> i32 {
     x + y
 }
 
+fn l(n: u32) {
+    let mut i = 0;
+    while i < n {
+        body_invariant!(low_event());
+        i += 1;
+    }
+}
+
 fn main() {}

--- a/prusti-tests/tests/verify/fail/sif/arrays.rs
+++ b/prusti-tests/tests/verify/fail/sif/arrays.rs
@@ -1,0 +1,69 @@
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
+
+use prusti_contracts::*;
+
+#[requires(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])))]
+#[ensures(low(result))]
+fn sum_array_low(ts: &[i32]) -> i32 {
+    let mut i = 0;
+    let mut res = 0;
+
+    while i < ts.len() {
+        res += ts[i];
+        i += 1;
+    }
+
+    res
+}
+
+#[ensures(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])) ==> low(result))]
+fn sum_array(ts: &[i32]) -> i32 {
+    let mut i = 0;
+    let mut res = 0;
+
+    while i < ts.len() {
+        res += ts[i];
+        i += 1;
+    }
+
+    res
+}
+
+#[ensures(low(result))]
+fn produce_low() -> i32 {
+    42
+}
+
+#[ensures(forall(|i: usize| 0 <= i && i < array.len() ==> low(array[i])))]
+fn fill_with_low(array: &mut [i32]) {
+    let mut i = 0;
+    while i < array.len() {
+        array[i] = produce_low();
+        i += 1;
+    }
+}
+
+fn produce_high() -> i32 {
+    12
+}
+
+fn foo() {
+    let mut array = [1, 2, 3, 4, 5];
+    fill_with_low(&mut array);
+
+    array[2] = produce_high();
+
+    let res2 = sum_array(&array);
+    prusti_assert!(low(res2)); //~ERROR the asserted expression might not hold
+}
+
+fn main() {
+    let mut array = [1, 2, 3, 4, 5];
+    fill_with_low(&mut array);
+
+    array[2] = produce_high();
+
+    let res1 = sum_array_low(&array); //~ERROR precondition might not hold
+}

--- a/prusti-tests/tests/verify/fail/sif/functions.rs
+++ b/prusti-tests/tests/verify/fail/sif/functions.rs
@@ -1,0 +1,22 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[requires(low(i))]
+#[ensures(low(result))]
+fn foo(i: i32) -> i32 {
+    i + 42
+}
+
+#[requires(low(n))]
+fn bar(n: i32) {}
+
+fn baz_safe() -> i32 {
+    42
+}
+
+fn main() {
+    let i = baz_safe();
+    let j = foo(i); //~ERROR precondition might not hold
+    bar(j);
+}

--- a/prusti-tests/tests/verify/fail/sif/functions.rs
+++ b/prusti-tests/tests/verify/fail/sif/functions.rs
@@ -1,4 +1,6 @@
-// compile-flags: -Psif=true
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/fail/sif/ifs.rs
+++ b/prusti-tests/tests/verify/fail/sif/ifs.rs
@@ -1,0 +1,30 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[requires(low(l))]
+#[ensures(!b ==> low(result))]
+fn choose(b: bool, h: i32, l: i32) -> i32 {
+    if b {
+        h
+    } else {
+        l
+    }
+}
+
+fn produce_high() -> i32 {
+    42
+}
+
+#[ensures(low(result))]
+fn produce_low() -> i32 {
+    12
+}
+
+fn main() {
+    let l = produce_low();
+    let h = produce_high();
+
+    let res = choose(true, h, l);
+    prusti_assert!(low(res)); //~ERROR the asserted expression might not hold
+}

--- a/prusti-tests/tests/verify/fail/sif/ifs.rs
+++ b/prusti-tests/tests/verify/fail/sif/ifs.rs
@@ -14,6 +14,16 @@ fn choose(b: bool, h: i32, l: i32) -> i32 {
     }
 }
 
+#[requires(low(l1) && low(l2))]
+#[ensures(low(result))] //~EROOR postcondition might not hold.
+fn choose2(b: bool, l1: i32, l2: i32) -> i32 {
+    if b {
+        l1
+    } else {
+        l2
+    }
+}
+
 fn produce_high() -> i32 {
     42
 }

--- a/prusti-tests/tests/verify/fail/sif/ifs.rs
+++ b/prusti-tests/tests/verify/fail/sif/ifs.rs
@@ -1,4 +1,6 @@
-// compile-flags: -Psif=true
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/fail/sif/impl.rs
+++ b/prusti-tests/tests/verify/fail/sif/impl.rs
@@ -1,4 +1,6 @@
-// compile-flags: -Psif=true
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/fail/sif/impl.rs
+++ b/prusti-tests/tests/verify/fail/sif/impl.rs
@@ -1,0 +1,56 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[ensures(low(i1) && low(i2) ==> low(result))]
+fn add(i1: i32, i2: i32) -> i32 {
+    i1 + i2
+}
+
+#[ensures(low(result))]
+fn produce_low() -> i32 {
+    40
+}
+
+fn produce_high() -> i32 {
+    2
+}
+
+#[requires(low(i))]
+fn requires_low(i: i32) {}
+
+fn requires_high(_i: i32) {}
+
+fn add_low_high() {
+    let i1_low = produce_low();
+    let i2_high = produce_high();
+
+    requires_low(add(i1_low, i2_high)); //~ERROR precondition might not hold.
+}
+
+fn add_high_low() {
+    let i1_high = produce_high();
+    let i2_low = produce_low();
+
+    requires_low(add(i1_high, i2_low)); //~ERROR precondition might not hold.
+}
+
+fn add_high_high() {
+    let i1_high = produce_high();
+    let i2_high = produce_high();
+
+    requires_low(add(i1_high, i2_high)); //~ERROR precondition might not hold.
+}
+
+fn main() {
+    let i1_low = produce_low();
+    let i2_low = produce_low();
+    let i1_high = produce_high();
+    let i2_high = produce_high();
+
+    requires_low(add(i1_low, i2_low));
+    requires_high(add(i1_low, i2_low)); // low values can be used in as high
+    requires_high(add(i1_low, i2_high));
+    requires_high(add(i1_high, i2_low));
+    requires_high(add(i1_high, i2_high));
+}

--- a/prusti-tests/tests/verify/fail/sif/loops.rs
+++ b/prusti-tests/tests/verify/fail/sif/loops.rs
@@ -4,66 +4,45 @@
 
 use prusti_contracts::*;
 
-#[requires(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])))]
-#[ensures(low(result))]
-fn sum_array_low(ts: &[i32]) -> i32 {
-    let mut i = 0;
-    let mut res = 0;
-
-    while i < ts.len() {
-        res += ts[i];
-        i += 1;
+#[requires(low(x))]
+#[ensures(low(result))] //~ERROR postcondition might not hold.
+fn loop_max(x: i32, y: i32) -> i32 {
+    let mut res = x;
+    while res < y {
+        body_invariant!(low(res));
+        res += 1;
     }
-
     res
 }
 
-#[ensures(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])) ==> low(result))]
-fn sum_array(ts: &[i32]) -> i32 {
-    let mut i = 0;
-    let mut res = 0;
-
-    while i < ts.len() {
-        res += ts[i];
-        i += 1;
+#[requires(low(y))]
+#[ensures(low(result))] //~ERROR postcondition might not hold.
+fn loop_max2(x: i32, y: i32) -> i32 {
+    let mut res = x;
+    while res < y {
+        res += 1;
     }
-
     res
 }
 
+#[requires(low(y))]
 #[ensures(low(result))]
-fn produce_low() -> i32 {
-    42
-}
-
-#[ensures(forall(|i: usize| 0 <= i && i < array.len() ==> low(array[i])))]
-fn fill_with_low(array: &mut [i32]) {
-    let mut i = 0;
-    while i < array.len() {
-        array[i] = produce_low();
-        i += 1;
+fn loop_max3(x: i32, y: i32) -> i32 {
+    let mut res = x;
+    while res < y {
+        body_invariant!(low(res)); //~ERROR loop invariant might not hold in the first loop iteration.
+        res += 1;
     }
+    res
 }
 
-fn produce_high() -> i32 {
-    12
+#[ensures(low(result))] //~ERROR postcondition might not hold.
+fn test(n: u32) -> u32 {
+    let mut res = 0;
+    while res < n {
+        res += 1;
+    }
+    res
 }
 
-fn foo() {
-    let mut array = [1, 2, 3, 4, 5];
-    fill_with_low(&mut array);
-
-    array[2] = produce_high();
-
-    let res2 = sum_array(&array);
-    prusti_assert!(low(res2)); //~ERROR the asserted expression might not hold
-}
-
-fn main() {
-    let mut array = [1, 2, 3, 4, 5];
-    fill_with_low(&mut array);
-
-    array[2] = produce_high();
-
-    let res1 = sum_array_low(&array); //~ERROR precondition might not hold
-}
+fn main() {}

--- a/prusti-tests/tests/verify/fail/sif/loops.rs
+++ b/prusti-tests/tests/verify/fail/sif/loops.rs
@@ -1,0 +1,67 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[requires(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])))]
+#[ensures(low(result))]
+fn sum_array_low(ts: &[i32]) -> i32 {
+    let mut i = 0;
+    let mut res = 0;
+
+    while i < ts.len() {
+        res += ts[i];
+        i += 1;
+    }
+
+    res
+}
+
+#[ensures(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])) ==> low(result))]
+fn sum_array(ts: &[i32]) -> i32 {
+    let mut i = 0;
+    let mut res = 0;
+
+    while i < ts.len() {
+        res += ts[i];
+        i += 1;
+    }
+
+    res
+}
+
+#[ensures(low(result))]
+fn produce_low() -> i32 {
+    42
+}
+
+#[ensures(forall(|i: usize| 0 <= i && i < array.len() ==> low(array[i])))]
+fn fill_with_low(array: &mut [i32]) {
+    let mut i = 0;
+    while i < array.len() {
+        array[i] = produce_low();
+        i += 1;
+    }
+}
+
+fn produce_high() -> i32 {
+    12
+}
+
+fn foo() {
+    let mut array = [1, 2, 3, 4, 5];
+    fill_with_low(&mut array);
+
+    array[2] = produce_high();
+
+    let res2 = sum_array(&array);
+    prusti_assert!(low(res2)); //~ERROR the asserted expression might not hold
+}
+
+fn main() {
+    let mut array = [1, 2, 3, 4, 5];
+    fill_with_low(&mut array);
+
+    array[2] = produce_high();
+
+    let res1 = sum_array_low(&array); //~ERROR precondition might not hold
+}

--- a/prusti-tests/tests/verify/fail/sif/loops.rs
+++ b/prusti-tests/tests/verify/fail/sif/loops.rs
@@ -1,4 +1,6 @@
-// compile-flags: -Psif=true
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/fail/sif/loops_encoding.rs
+++ b/prusti-tests/tests/verify/fail/sif/loops_encoding.rs
@@ -1,0 +1,21 @@
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
+
+use prusti_contracts::*;
+
+#[trusted]
+#[requires(low(i))]
+fn print(i: u32) {}
+
+fn foo(y: u32) {
+    let mut i = 0;
+    while i < y + 1 {
+        body_invariant!(low(i));
+        i += 1;
+    }
+    print(i);
+    print(y);
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/fail/sif/low_event.rs
+++ b/prusti-tests/tests/verify/fail/sif/low_event.rs
@@ -1,0 +1,19 @@
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
+
+use prusti_contracts::*;
+
+#[trusted]
+#[requires(low(i) && low_event())]
+fn print_int(i: i32) {}
+
+fn foo(b: bool) {
+    if b {
+        print_int(0);
+    } else {
+        print_int(1);
+    }
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/pass/sif/arrays.rs
+++ b/prusti-tests/tests/verify/pass/sif/arrays.rs
@@ -1,0 +1,88 @@
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
+
+use prusti_contracts::*;
+
+// #[requires(low(ts))]
+// #[ensures(low(result))]
+// fn sum_array_low(ts: &[i32]) -> i32 {
+//     let mut i = 0;
+//     let mut res = 0;
+
+//     while i < ts.len() {
+//         body_invariant!(low(i));
+//         body_invariant!(low(res));
+//         res += ts[i];
+//         i += 1;
+//     }
+
+//     res
+// }
+
+// #[requires(forall(|i: usize| low(ts[i])))]
+// #[ensures(low(result))]
+// fn sum_array_low2(ts: &[i32]) -> i32 {
+//     let mut i = 0;
+//     let mut res = 0;
+
+//     while i < ts.len() {
+//         body_invariant!(low(i));
+//         body_invariant!(low(res));
+//         res += ts[i];
+//         i += 1;
+//     }
+
+//     res
+// }
+
+// #[ensures(low(ts) ==> low(result))]
+// fn sum_array(ts: &[i32]) -> i32 {
+//     let mut i = 0;
+//     let mut res = 0;
+
+//     while i < ts.len() {
+//         body_invariant!(low(i));
+//         body_invariant!(low(ts) ==> low(res));
+//         res += ts[i];
+//         i += 1;
+//     }
+
+//     res
+// }
+
+#[trusted]
+#[ensures(low(result))]
+fn produce_low() -> i32 {
+    todo!()
+}
+
+// #[requires(0 <= i && i < array.len())]
+// #[ensures(low(array[i]))]
+// fn replace_low(array: &mut [i32], i: usize) {
+//     array[i] = produce_low();
+// }
+
+#[requires(low(array.len()))]
+#[ensures(forall(|i: usize| i < array.len() ==> low(array[i])))]
+fn fill_with_low(array: &mut [i32]) {
+    let mut i = 0;
+    while i < array.len() {
+        body_invariant!(low(i));
+        body_invariant!(forall(|j: usize| j < i ==> low(array[j])));
+        array[i] = produce_low();
+        // replace_low(array, i);
+        i += 1;
+    }
+}
+
+fn main() {
+    // let mut low_array = [1, 2, 3, 4, 5];
+    // fill_with_low(&mut low_array);
+
+    // let res1 = sum_array_low(&low_array);
+    // prusti_assert!(low(res1));
+
+    // let res2 = sum_array(&low_array);
+    // prusti_assert!(low(res2));
+}

--- a/prusti-tests/tests/verify/pass/sif/arrays.rs
+++ b/prusti-tests/tests/verify/pass/sif/arrays.rs
@@ -69,7 +69,7 @@ fn fill_with_low(array: &mut [i32]) {
     let mut i = 0;
     while i < array.len() {
         body_invariant!(low(i));
-        body_invariant!(forall(|j: usize| j < i ==> low(array[j])));
+        body_invariant!(forall(|j: usize| 0 <= j && j < i ==> low(array[j])));
         array[i] = produce_low();
         // replace_low(array, i);
         i += 1;

--- a/prusti-tests/tests/verify/pass/sif/examples/banerjee.rs
+++ b/prusti-tests/tests/verify/pass/sif/examples/banerjee.rs
@@ -1,0 +1,66 @@
+// compile-flags: -Psif=true -Pserver_address=MOCK
+
+// Example from "Secure Information Flow and Pointer Confinement in a Java-like Language"
+// A. Banerjee and D. A. Naumann
+// CSFW 2002
+
+use prusti_contracts::*;
+
+// ignore-test: rust's borrow checker makes this example hard to translate without too much modification
+
+// HIV is high, name is low
+struct Patient {
+    name: String,
+    hiv: String,
+}
+
+impl Patient {
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    #[requires(low(name))]
+    #[ensures(low(&self.name))]
+    fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+
+    fn get_hiv(&self) -> &str {
+        &self.hiv
+    }
+
+    fn set_hiv(&mut self, hiv: String) {
+        self.hiv = hiv;
+    }
+}
+
+#[trusted]
+#[ensures(low(result))]
+#[ensures(low(&result.name))]
+fn read_file() -> Patient {
+    Patient {
+        name: String::new(),
+        hiv: String::new(),
+    }
+}
+
+// the result is high
+#[trusted]
+fn read_from_trusted_channel() -> String {
+    String::new()
+}
+
+fn main() {
+    let lbuf: &str;
+    let mut hbuf: &str;
+    let mut lp = read_file();
+    let mut xp = Patient {
+        name: String::new(),
+        hiv: String::new(),
+    };
+    lbuf = lp.get_name();
+    hbuf = lp.get_name();
+    xp.set_name(lbuf);
+    hbuf = read_from_trusted_channel();
+    xp.set_hiv(hbuf);
+}

--- a/prusti-tests/tests/verify/pass/sif/examples/constanzo.rs
+++ b/prusti-tests/tests/verify/pass/sif/examples/constanzo.rs
@@ -1,0 +1,25 @@
+// compile-flags: -Psif=true -Pserver_address=MOCK
+
+// Example from "A Separation Logic for Enforcing Declarative Information Flow Control Policies"
+// D. Costanzo and Z. Shao
+// POST 2014
+
+use prusti_contracts::*;
+
+#[trusted]
+#[requires(low(n))]
+fn print(n: usize) {}
+
+#[requires(forall(|i: usize| 0 <= i && i < schedule.len() ==> (schedule[i] == 0 ==> low(i))))]
+fn print_availibility(schedule: &[u32]) {
+    let mut i = 0;
+    while i < schedule.len() {
+        let x = schedule[i];
+        if x == 0 {
+            print(i);
+        }
+        i += 1;
+    }
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/pass/sif/functions.rs
+++ b/prusti-tests/tests/verify/pass/sif/functions.rs
@@ -1,0 +1,23 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[requires(low(i))]
+#[ensures(low(result))]
+fn foo(i: i32) -> i32 {
+    i + 42
+}
+
+#[requires(low(n))]
+fn bar(n: i32) {}
+
+#[ensures(low(result))]
+fn baz() -> i32 {
+    42
+}
+
+fn main() {
+    let i = baz();
+    let j = foo(i);
+    bar(j);
+}

--- a/prusti-tests/tests/verify/pass/sif/functions.rs
+++ b/prusti-tests/tests/verify/pass/sif/functions.rs
@@ -1,4 +1,6 @@
-// compile-flags: -Psif=true
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/sif/ifs.rs
+++ b/prusti-tests/tests/verify/pass/sif/ifs.rs
@@ -14,6 +14,22 @@ fn choose(b: bool, h: i32, l: i32) -> i32 {
     }
 }
 
+#[requires(low(l))]
+#[ensures(low(result))]
+fn foo(b: bool, l: i32) -> i32 {
+    let res;
+    if b {
+        res = l + 3;
+    } else {
+        res = l - 3;
+    }
+    if b {
+        res - 3
+    } else {
+        res + 3
+    }
+}
+
 fn produce_high() -> i32 {
     42
 }

--- a/prusti-tests/tests/verify/pass/sif/ifs.rs
+++ b/prusti-tests/tests/verify/pass/sif/ifs.rs
@@ -1,4 +1,6 @@
-// compile-flags: -Psif=true
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/sif/ifs.rs
+++ b/prusti-tests/tests/verify/pass/sif/ifs.rs
@@ -1,0 +1,30 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[requires(low(l))]
+#[ensures(!b ==> low(result))]
+fn choose(b: bool, h: i32, l: i32) -> i32 {
+    if b {
+        h
+    } else {
+        l
+    }
+}
+
+fn produce_high() -> i32 {
+    42
+}
+
+#[ensures(low(result))]
+fn produce_low() -> i32 {
+    12
+}
+
+fn main() {
+    let l = produce_low();
+    let h = produce_high();
+
+    let res = choose(false, h, l);
+    prusti_assert!(low(res));
+}

--- a/prusti-tests/tests/verify/pass/sif/impl.rs
+++ b/prusti-tests/tests/verify/pass/sif/impl.rs
@@ -1,4 +1,6 @@
-// compile-flags: -Psif=true
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/sif/impl.rs
+++ b/prusti-tests/tests/verify/pass/sif/impl.rs
@@ -1,0 +1,35 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[ensures(low(i1) && low(i2) ==> low(result))]
+fn add(i1: i32, i2: i32) -> i32 {
+    i1 + i2
+}
+
+#[ensures(low(result))]
+fn produce_low() -> i32 {
+    40
+}
+
+fn produce_high() -> i32 {
+    2
+}
+
+#[requires(low(i))]
+fn requires_low(i: i32) {}
+
+fn requires_high(_i: i32) {}
+
+fn main() {
+    let i1_low = produce_low();
+    let i2_low = produce_low();
+    let i1_high = produce_high();
+    let i2_high = produce_high();
+
+    requires_low(add(i1_low, i2_low));
+    requires_high(add(i1_low, i2_low)); // low values can be used in as high
+    requires_high(add(i1_low, i2_high));
+    requires_high(add(i1_high, i2_low));
+    requires_high(add(i1_high, i2_high));
+}

--- a/prusti-tests/tests/verify/pass/sif/loop_encoding.rs
+++ b/prusti-tests/tests/verify/pass/sif/loop_encoding.rs
@@ -6,18 +6,25 @@ use prusti_contracts::*;
 
 #[trusted]
 #[requires(low(i))]
-#[requires(low_event())]
 fn print(i: u32) {}
 
+#[requires(low(y))]
 #[requires(low_event())]
 fn foo(y: u32) {
     let mut i = 0;
-    while i < y + 1 {
-        body_invariant!(low(i)); //~ERROR loop invariant might not hold after a loop iteration
+    while i < y {
+        body_invariant!(low(i));
         i += 1;
     }
     print(i);
-    print(y);
+}
+
+fn bar(x: u32) -> u32 {
+    let mut i = 0;
+    while i < x {
+        i += 1;
+    }
+    i
 }
 
 fn main() {}

--- a/prusti-tests/tests/verify/pass/sif/loops.rs
+++ b/prusti-tests/tests/verify/pass/sif/loops.rs
@@ -1,0 +1,55 @@
+// compile-flags: -Psif=true
+
+use prusti_contracts::*;
+
+#[requires(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])))]
+#[ensures(low(result))]
+fn sum_array_low(ts: &[i32]) -> i32 {
+    let mut i = 0;
+    let mut res = 0;
+
+    while i < ts.len() {
+        res += ts[i];
+        i += 1;
+    }
+
+    res
+}
+
+#[ensures(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])) ==> low(result))]
+fn sum_array(ts: &[i32]) -> i32 {
+    let mut i = 0;
+    let mut res = 0;
+
+    while i < ts.len() {
+        res += ts[i];
+        i += 1;
+    }
+
+    res
+}
+
+#[ensures(low(result))]
+fn produce_low() -> i32 {
+    42
+}
+
+#[ensures(forall(|i: usize| 0 <= i && i < array.len() ==> low(array[i])))]
+fn fill_with_low(array: &mut [i32]) {
+    let mut i = 0;
+    while i < array.len() {
+        array[i] = produce_low();
+        i += 1;
+    }
+}
+
+fn main() {
+    let mut low_array = [1, 2, 3, 4, 5];
+    fill_with_low(&mut low_array);
+
+    let res1 = sum_array_low(&low_array);
+    prusti_assert!(low(res1));
+
+    let res2 = sum_array(&low_array);
+    prusti_assert!(low(res2));
+}

--- a/prusti-tests/tests/verify/pass/sif/loops.rs
+++ b/prusti-tests/tests/verify/pass/sif/loops.rs
@@ -1,4 +1,6 @@
-// compile-flags: -Psif=true
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/sif/loops.rs
+++ b/prusti-tests/tests/verify/pass/sif/loops.rs
@@ -4,54 +4,25 @@
 
 use prusti_contracts::*;
 
-#[requires(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])))]
+#[requires(low(x) && low(y))]
+#[ensures(result == x || result == y)]
 #[ensures(low(result))]
-fn sum_array_low(ts: &[i32]) -> i32 {
-    let mut i = 0;
-    let mut res = 0;
-
-    while i < ts.len() {
-        res += ts[i];
-        i += 1;
+fn loop_max(x: i32, y: i32) -> i32 {
+    let mut res = x;
+    while res < y {
+        res += 1;
     }
-
-    res
-}
-
-#[ensures(forall(|i: usize| 0 <= i && i < ts.len() ==> low(ts[i])) ==> low(result))]
-fn sum_array(ts: &[i32]) -> i32 {
-    let mut i = 0;
-    let mut res = 0;
-
-    while i < ts.len() {
-        res += ts[i];
-        i += 1;
-    }
-
     res
 }
 
 #[ensures(low(result))]
-fn produce_low() -> i32 {
-    42
-}
-
-#[ensures(forall(|i: usize| 0 <= i && i < array.len() ==> low(array[i])))]
-fn fill_with_low(array: &mut [i32]) {
-    let mut i = 0;
-    while i < array.len() {
-        array[i] = produce_low();
-        i += 1;
+fn test(n: u32) -> u32 {
+    let mut res = 0;
+    while res < n {
+        res += 1;
     }
+    declassify!(res);
+    res
 }
 
-fn main() {
-    let mut low_array = [1, 2, 3, 4, 5];
-    fill_with_low(&mut low_array);
-
-    let res1 = sum_array_low(&low_array);
-    prusti_assert!(low(res1));
-
-    let res2 = sum_array(&low_array);
-    prusti_assert!(low(res2));
-}
+fn main() {}

--- a/prusti-tests/tests/verify/pass/sif/loops.rs
+++ b/prusti-tests/tests/verify/pass/sif/loops.rs
@@ -25,4 +25,14 @@ fn test(n: u32) -> u32 {
     res
 }
 
+#[ensures(low(n))]
+fn l(n: u32) {
+    let mut i = 0;
+    while i < n {
+        body_invariant!(low_event());
+        body_invariant!(low(i));
+        i += 1;
+    }
+}
+
 fn main() {}

--- a/prusti-tests/tests/verify/pass/sif/reborrow.rs
+++ b/prusti-tests/tests/verify/pass/sif/reborrow.rs
@@ -1,0 +1,39 @@
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
+
+use prusti_contracts::*;
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[ensures(low(old(pt.x)) ==> low(*result))]
+#[after_expiry(result => pt.x == *before_expiry(result))]
+fn get_mut_x<'a>(pt: &'a mut Point) -> &'a mut i32 {
+    &mut pt.x
+}
+
+#[trusted]
+#[ensures(low(result))]
+fn produces_low() -> i32 {
+    12
+}
+
+#[trusted]
+#[requires(low(n))]
+fn requires_low(n: i32) {}
+
+fn main() {
+    let mut p = Point {
+        x: produces_low(),
+        y: 42,
+    };
+    {
+        let x = get_mut_x(&mut p);
+        requires_low(*x);
+        *x = 19;
+    }
+    prusti_assert!(p.x == 19);
+}

--- a/prusti-tests/tests/verify/pass/sif/wand.rs
+++ b/prusti-tests/tests/verify/pass/sif/wand.rs
@@ -1,0 +1,33 @@
+// compile-flags: -Psif=true -Pserver_address=MOCK
+// The sif flag is used in the server which, during the compiletest is only spawned with the default config.
+// So we need to start a new server with this test config to make it work.
+
+use prusti_contracts::*;
+
+struct Wrapper<T>(T);
+
+impl<T: Copy + PartialEq> Wrapper<T> {
+    #[pure]
+    fn get(&self) -> &T {
+        &self.0
+    }
+
+    // #[after_expiry(low(before_expiry(*result)) ==> low(self.get()))]
+    #[after_expiry(before_expiry(*result) == *self.get())]
+    fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+#[trusted]
+#[ensures(low(result))]
+fn produce_low() -> u32 {
+    todo!()
+}
+
+fn main() {
+    let mut m = Wrapper(42);
+
+    *m.get_mut() = produce_low();
+    prusti_assert!(low(m.get()));
+}

--- a/prusti-utils/src/config.rs
+++ b/prusti-utils/src/config.rs
@@ -115,6 +115,7 @@ lazy_static::lazy_static! {
         settings.set_default("optimizations", "all").unwrap();
         settings.set_default("intern_names", true).unwrap();
         settings.set_default("enable_purification_optimization", false).unwrap();
+        settings.set_default("sif", false).unwrap();
         // settings.set_default("enable_manual_axiomatization", false).unwrap();
         settings.set_default("unsafe_core_proof", false).unwrap();
         settings.set_default("verify_core_proof", true).unwrap();
@@ -868,6 +869,11 @@ pub fn log_smt_wrapper_interaction() -> bool {
 /// **Note:** This option is currently very incomplete.
 pub fn unsafe_core_proof() -> bool {
     read_setting("unsafe_core_proof")
+}
+
+/// When enabled, checks the program for secure information flow
+pub fn sif() -> bool {
+    read_setting("sif")
 }
 
 /// Whether the core proof (memory safety) should be verified.

--- a/prusti-utils/src/config.rs
+++ b/prusti-utils/src/config.rs
@@ -705,6 +705,7 @@ pub fn verify_only_basic_block_path() -> Vec<String> {
 /// - `"optimize_folding"`
 /// - `"remove_empty_if"`
 /// - `"purify_vars"`
+/// - `"simplify_exprs"`
 /// - `"fix_quantifiers"`
 /// - `"fix_unfoldings"`
 /// - `"remove_unused_vars"`
@@ -724,6 +725,7 @@ pub fn optimizations() -> Optimizations {
             "optimize_folding" => opt.optimize_folding = true,
             "remove_empty_if" => opt.remove_empty_if = true,
             "purify_vars" => opt.purify_vars = true,
+            "simplify_exprs" => opt.simplify_exprs = true,
             "fix_quantifiers" => opt.fix_quantifiers = true,
             "fix_unfoldings" => opt.fix_unfoldings = true,
             "remove_unused_vars" => opt.remove_unused_vars = true,

--- a/prusti-utils/src/config.rs
+++ b/prusti-utils/src/config.rs
@@ -22,6 +22,7 @@ pub struct Optimizations {
     pub optimize_folding: bool,
     pub remove_empty_if: bool,
     pub purify_vars: bool,
+    pub simplify_exprs: bool,
     pub fix_quantifiers: bool,
     pub fix_unfoldings: bool,
     pub remove_unused_vars: bool,
@@ -37,6 +38,7 @@ impl Optimizations {
             optimize_folding: false,
             remove_empty_if: false,
             purify_vars: false,
+            simplify_exprs: false,
             fix_quantifiers: false,
             fix_unfoldings: false,
             remove_unused_vars: false,
@@ -52,6 +54,7 @@ impl Optimizations {
             optimize_folding: true,
             remove_empty_if: true,
             purify_vars: true,
+            simplify_exprs: true,
             fix_quantifiers: true,
             // Disabled because https://github.com/viperproject/prusti-dev/issues/892 has been fixed
             fix_unfoldings: false,

--- a/prusti-viper/src/encoder/foldunfold/footprint.rs
+++ b/prusti-viper/src/encoder/foldunfold/footprint.rs
@@ -176,6 +176,7 @@ impl ExprFootprintGetter for vir::Expr {
             vir::Expr::SnapApp(vir::SnapApp { ref base, .. }) => base.get_footprint(predicates),
 
             vir::Expr::Cast(vir::Cast { ref base, .. }) => base.get_footprint(predicates),
+            vir::Expr::Low(vir::Low { ref base, .. }) => base.get_footprint(predicates),
         }
     }
 }

--- a/prusti-viper/src/encoder/foldunfold/footprint.rs
+++ b/prusti-viper/src/encoder/foldunfold/footprint.rs
@@ -177,6 +177,7 @@ impl ExprFootprintGetter for vir::Expr {
 
             vir::Expr::Cast(vir::Cast { ref base, .. }) => base.get_footprint(predicates),
             vir::Expr::Low(vir::Low { ref base, .. }) => base.get_footprint(predicates),
+            vir::Expr::LowEvent => FxHashSet::default(),
         }
     }
 }

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
@@ -584,6 +584,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                             | "prusti_contracts::call_description"
                             | "prusti_contracts::snap"
                             | "prusti_contracts::low"
+                            | "prusti_contracts::low_event"
                             | "prusti_contracts::snapshot_equality" => {
                                 let expr = self.encoder.encode_prusti_operation(
                                     full_func_proc_name,

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
@@ -583,6 +583,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                             | "prusti_contracts::specification_entailment"
                             | "prusti_contracts::call_description"
                             | "prusti_contracts::snap"
+                            | "prusti_contracts::low"
                             | "prusti_contracts::snapshot_equality" => {
                                 let expr = self.encoder.encode_prusti_operation(
                                     full_func_proc_name,

--- a/prusti-viper/src/encoder/mir/pure/specifications/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/interface.rs
@@ -266,6 +266,16 @@ impl<'v, 'tcx: 'v> SpecificationEncoderInterface<'tcx> for crate::encoder::Encod
                     .with_span(span)
                 }
             }
+            "prusti_contracts::low_event" => {
+                if config::sif() {
+                    Ok(vir_poly::Expr::LowEvent)
+                } else {
+                    Err(EncodingError::incorrect(
+                        "Found low specification when sif option is disabled!",
+                    ))
+                    .with_span(span)
+                }
+            }
             _ => unimplemented!(),
         }
     }

--- a/prusti-viper/src/encoder/mir/pure/specifications/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/specifications/interface.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::encoder::{
-    errors::{SpannedEncodingResult, WithSpan},
+    errors::{EncodingError, SpannedEncodingResult, WithSpan},
     mir::{
         places::PlacesEncoderInterface,
         pure::{
@@ -27,6 +27,7 @@ use crate::encoder::{
     mir_encoder::{MirEncoder, PlaceEncoder, PRECONDITION_LABEL},
     snapshot::interface::SnapshotEncoderInterface,
 };
+use prusti_common::config;
 use prusti_rustc_interface::{
     hir::def_id::DefId,
     middle::{mir, ty::subst::SubstsRef},
@@ -255,6 +256,16 @@ impl<'v, 'tcx: 'v> SpecificationEncoderInterface<'tcx> for crate::encoder::Encod
                 vir_poly::Expr::snap_app(encoded_args[0].clone()),
                 vir_poly::Expr::snap_app(encoded_args[1].clone()),
             )),
+            "prusti_contracts::low" => {
+                if config::sif() {
+                    Ok(vir_poly::Expr::low(encoded_args[0].clone()))
+                } else {
+                    Err(EncodingError::incorrect(
+                        "Found low specification when sif option is disabled!",
+                    ))
+                    .with_span(span)
+                }
+            }
             _ => unimplemented!(),
         }
     }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5554,6 +5554,10 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 }
             }
         }
+        if encoded_specs.iter().any(|e| e.is_relational()) {
+            encoded_specs.push(vir::Expr::LowEvent);
+        }
+
         Ok((encoded_specs, MultiSpan::from_spans(encoded_spec_spans)))
     }
 

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -75,7 +75,7 @@ use prusti_rustc_interface::{
     target::abi::Integer,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::{collections::BTreeMap, convert::TryInto};
+use std::{collections::BTreeMap, convert::TryInto, fmt::Debug};
 use vir_crate::polymorphic::{
     self as vir, borrows::Borrow, collect_assigned_vars, compute_identifier, CfgBlockIndex,
     ExprIterator, Float, Successor, Type,
@@ -237,11 +237,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 mir::Rvalue::Aggregate(box mir::AggregateKind::Closure(cl_def_id, cl_substs), _),
             )) = stmt.kind
             {
-                if self
-                    .encoder
-                    .get_prusti_assumption(cl_def_id.to_def_id())
-                    .is_none()
-                {
+                if self.encoder.get_prusti_assumption(cl_def_id).is_none() {
                     return Ok(false);
                 }
                 let assume_expr =
@@ -5554,10 +5550,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 }
             }
         }
-        if encoded_specs.iter().any(|e| e.is_relational()) {
-            encoded_specs.push(vir::Expr::LowEvent);
-        }
-
         Ok((encoded_specs, MultiSpan::from_spans(encoded_spec_spans)))
     }
 

--- a/viper-sys/build.rs
+++ b/viper-sys/build.rs
@@ -699,6 +699,51 @@ fn main() {
             java_class!("viper.silver.ast.WildcardPerm", vec![
                 constructor!(),
             ]),
+            java_class!("viper.silver.sif.SIFReturnStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFBreakStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFContinueStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFRaiseStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFExceptionHandler", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFTryCatchStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFDeclassifyStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFInlinedCallStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFAssertNoException", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFLowExp", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFLowEventExp", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFLowExitExp", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFTerminatesExp", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFInfo", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFDynCheckInfo", vec![
+                constructor!(),
+            ]),
             java_class!("viper.silver.verifier.AbortedExceptionally", vec![
                 constructor!(),
                 method!("cause"),

--- a/viper-sys/build.rs
+++ b/viper-sys/build.rs
@@ -699,51 +699,6 @@ fn main() {
             java_class!("viper.silver.ast.WildcardPerm", vec![
                 constructor!(),
             ]),
-            java_class!("viper.silver.sif.SIFReturnStmt", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFBreakStmt", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFContinueStmt", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFRaiseStmt", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFExceptionHandler", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFTryCatchStmt", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFDeclassifyStmt", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFInlinedCallStmt", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFAssertNoException", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFLowExp", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFLowEventExp", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFLowExitExp", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFTerminatesExp", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFInfo", vec![
-                constructor!(),
-            ]),
-            java_class!("viper.silver.sif.SIFDynCheckInfo", vec![
-                constructor!(),
-            ]),
             java_class!("viper.silver.verifier.AbortedExceptionally", vec![
                 constructor!(),
                 method!("cause"),
@@ -858,6 +813,56 @@ fn main() {
                 method!("field"),
                 method!("perm"),
                 method!("entry"),
+            ]),
+            // SIF
+            java_class!("viper.silver.sif.SIFExtendedTransformer$", vec![
+                object_getter!(),                
+                method!("transform"),
+            ]),
+            java_class!("viper.silver.sif.SIFReturnStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFBreakStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFContinueStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFRaiseStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFExceptionHandler", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFTryCatchStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFDeclassifyStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFInlinedCallStmt", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFAssertNoException", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFLowExp", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFLowEventExp", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFLowExitExp", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFTerminatesExp", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFInfo", vec![
+                constructor!(),
+            ]),
+            java_class!("viper.silver.sif.SIFDynCheckInfo", vec![
+                constructor!(),
             ])
         ])
         .generate(&generated_dir)

--- a/viper-sys/build.rs
+++ b/viper-sys/build.rs
@@ -816,7 +816,7 @@ fn main() {
             ]),
             // SIF
             java_class!("viper.silver.sif.SIFExtendedTransformer$", vec![
-                object_getter!(),                
+                object_getter!(),
                 method!("transform"),
             ]),
             java_class!("viper.silver.sif.SIFReturnStmt", vec![

--- a/viper/src/ast_factory/expression.rs
+++ b/viper/src/ast_factory/expression.rs
@@ -1501,4 +1501,8 @@ impl<'a> AstFactory<'a> {
             pos.to_jobject()
         )
     }
+
+    pub fn low_event(&self) -> Expr<'a> {
+        build_ast_node!(self, Expr, sif::SIFLowEventExp)
+    }
 }

--- a/viper/src/ast_factory/expression.rs
+++ b/viper/src/ast_factory/expression.rs
@@ -1489,4 +1489,14 @@ impl<'a> AstFactory<'a> {
         );
         Expr::new(obj)
     }
+
+    pub fn low(&self, expr: Expr, pos: Position) -> Expr<'a> {
+        build_ast_node_with_pos!(
+            self,
+            Expr,
+            ast::SIFLowExpr,
+            expr.to_jobject(),
+            pos.to_jobject()
+        )
+    }
 }

--- a/viper/src/ast_factory/expression.rs
+++ b/viper/src/ast_factory/expression.rs
@@ -7,7 +7,7 @@ use crate::ast_factory::{
     AstFactory,
 };
 use jni::objects::JObject;
-use viper_sys::wrappers::viper::silver::ast;
+use viper_sys::wrappers::viper::silver::{ast, sif};
 
 // Floating-Point Operations
 #[derive(Debug, Clone, Copy)]
@@ -1490,12 +1490,14 @@ impl<'a> AstFactory<'a> {
         Expr::new(obj)
     }
 
-    pub fn low(&self, expr: Expr, pos: Position) -> Expr<'a> {
+    pub fn low_with_pos(&self, expr: Expr, pos: Position) -> Expr<'a> {
         build_ast_node_with_pos!(
             self,
             Expr,
-            ast::SIFLowExpr,
+            sif::SIFLowExp,
             expr.to_jobject(),
+            self.jni.new_option(None),
+            self.jni.new_map(&[]),
             pos.to_jobject()
         )
     }

--- a/viper/src/ast_factory/statement.rs
+++ b/viper/src/ast_factory/statement.rs
@@ -7,7 +7,7 @@ use crate::ast_factory::{
     AstFactory,
 };
 use jni::objects::JObject;
-use viper_sys::wrappers::viper::silver::{ast, sif};
+use viper_sys::wrappers::viper::silver::ast;
 
 impl<'a> AstFactory<'a> {
     pub fn new_stmt(&self, lhs: Expr, fields: &[Field]) -> Stmt<'a> {
@@ -247,9 +247,5 @@ impl<'a> AstFactory<'a> {
 
     pub fn goto(&self, target: &str) -> Stmt<'a> {
         build_ast_node!(self, Stmt, ast::Goto, self.jni.new_string(target))
-    }
-
-    pub fn declassify(&self, expr: Expr) -> Stmt<'a> {
-        build_ast_node!(self, Stmt, sif::SIFDeclassifyStmt, expr.to_jobject())
     }
 }

--- a/viper/src/ast_factory/statement.rs
+++ b/viper/src/ast_factory/statement.rs
@@ -7,7 +7,7 @@ use crate::ast_factory::{
     AstFactory,
 };
 use jni::objects::JObject;
-use viper_sys::wrappers::viper::silver::ast;
+use viper_sys::wrappers::viper::silver::{ast, sif};
 
 impl<'a> AstFactory<'a> {
     pub fn new_stmt(&self, lhs: Expr, fields: &[Field]) -> Stmt<'a> {
@@ -250,6 +250,6 @@ impl<'a> AstFactory<'a> {
     }
 
     pub fn declassify(&self, expr: Expr) -> Stmt<'a> {
-        build_ast_node!(self, Stmt, ast::SIFDeclassifyStmt, expr.to_jobject())
+        build_ast_node!(self, Stmt, sif::SIFDeclassifyStmt, expr.to_jobject())
     }
 }

--- a/viper/src/ast_factory/statement.rs
+++ b/viper/src/ast_factory/statement.rs
@@ -248,4 +248,8 @@ impl<'a> AstFactory<'a> {
     pub fn goto(&self, target: &str) -> Stmt<'a> {
         build_ast_node!(self, Stmt, ast::Goto, self.jni.new_string(target))
     }
+
+    pub fn declassify(&self, expr: Expr) -> Stmt<'a> {
+        build_ast_node!(self, Stmt, ast::SIFDeclassifyStmt, expr.to_jobject())
+    }
 }

--- a/viper/src/lib.rs
+++ b/viper/src/lib.rs
@@ -21,6 +21,7 @@ mod verification_backend;
 mod verification_context;
 mod verification_result;
 mod verifier;
+pub mod sif_transformer;
 mod viper;
 
 pub use crate::{

--- a/viper/src/sif_transformer.rs
+++ b/viper/src/sif_transformer.rs
@@ -4,27 +4,27 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::jni_utils::JniUtils;
-use crate::ast_utils::AstUtils;
-use crate::ast_factory::Program;
+use crate::{ast_factory::Program, ast_utils::AstUtils, jni_utils::JniUtils};
 use jni::JNIEnv;
 use log::debug;
 use viper_sys::wrappers::viper::silver;
 
 pub struct SIFTransformer<'a> {
-	env: &'a JNIEnv<'a>,
+    env: &'a JNIEnv<'a>,
     jni: JniUtils<'a>,
     ast_utils: AstUtils<'a>,
 }
 
 impl<'a> SIFTransformer<'a> {
-	pub fn new(
-		env: &'a JNIEnv,
-	) -> Self {
-		let jni = JniUtils::new(env);
-		let ast_utils = AstUtils::new(env);
-		SIFTransformer { env, jni, ast_utils }
-	}
+    pub fn new(env: &'a JNIEnv) -> Self {
+        let jni = JniUtils::new(env);
+        let ast_utils = AstUtils::new(env);
+        SIFTransformer {
+            env,
+            jni,
+            ast_utils,
+        }
+    }
 
     #[must_use]
     pub fn sif_transformation(self, program: Program<'a>) -> Program<'a> {
@@ -32,7 +32,7 @@ impl<'a> SIFTransformer<'a> {
             debug!("Program before transformation:\n{}", self.ast_utils.pretty_print(program));
 
             let sif_transformer = silver::sif::SIFExtendedTransformer_object::with(self.env);
-            
+
             run_timed!("SIF transformation", debug, 
                 let tranformed_program = Program::new(self.jni.unwrap_result(
                     sif_transformer
@@ -41,6 +41,6 @@ impl<'a> SIFTransformer<'a> {
             );
             debug!("Program after transformation:\n{}", self.ast_utils.pretty_print(tranformed_program));
             tranformed_program
-        })   
+        })
     }
 }

--- a/viper/src/sif_transformer.rs
+++ b/viper/src/sif_transformer.rs
@@ -1,0 +1,46 @@
+// © 2023, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::jni_utils::JniUtils;
+use crate::ast_utils::AstUtils;
+use crate::ast_factory::Program;
+use jni::JNIEnv;
+use log::debug;
+use viper_sys::wrappers::viper::silver;
+
+pub struct SIFTransformer<'a> {
+	env: &'a JNIEnv<'a>,
+    jni: JniUtils<'a>,
+    ast_utils: AstUtils<'a>,
+}
+
+impl<'a> SIFTransformer<'a> {
+	pub fn new(
+		env: &'a JNIEnv,
+	) -> Self {
+		let jni = JniUtils::new(env);
+		let ast_utils = AstUtils::new(env);
+		SIFTransformer { env, jni, ast_utils }
+	}
+
+    #[must_use]
+    pub fn sif_transformation(self, program: Program<'a>) -> Program<'a> {
+         self.ast_utils.with_local_frame(16, || {
+            debug!("Program before transformation:\n{}", self.ast_utils.pretty_print(program));
+
+            let sif_transformer = silver::sif::SIFExtendedTransformer_object::with(self.env);
+            
+            run_timed!("SIF transformation", debug, 
+                let tranformed_program = Program::new(self.jni.unwrap_result(
+                    sif_transformer
+                        .call_transform(self.jni.unwrap_result(sif_transformer.singleton()), program.to_jobject(), false),
+                ));
+            );
+            debug!("Program after transformation:\n{}", self.ast_utils.pretty_print(tranformed_program));
+            tranformed_program
+        })   
+    }
+}

--- a/viper/src/verification_context.rs
+++ b/viper/src/verification_context.rs
@@ -5,7 +5,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::{
-    ast_factory::*, ast_utils::*, verification_backend::VerificationBackend, verifier::Verifier,
+    ast_factory::*, ast_utils::*, sif_transformer::SIFTransformer,
+    verification_backend::VerificationBackend, verifier::Verifier,
 };
 use jni::AttachGuard;
 use log::{debug, info};
@@ -98,5 +99,9 @@ impl<'a> VerificationContext<'a> {
         Verifier::new(&self.env, backend, report_path, smt_manager)
             .parse_command_line(&verifier_args)
             .start()
+    }
+
+    pub fn new_sif_transformer(&self) -> SIFTransformer {
+        SIFTransformer::new(&self.env)
     }
 }

--- a/vir/defs/polymorphic/ast/expr_transformers.rs
+++ b/vir/defs/polymorphic/ast/expr_transformers.rs
@@ -388,6 +388,10 @@ pub trait ExprFolder: Sized {
         })
     }
 
+    fn fold_low_event(&mut self) -> Expr {
+        Expr::LowEvent
+    }
+
     fn fold_snap_app(&mut self, expr: SnapApp) -> Expr {
         let SnapApp { base, position } = expr;
         Expr::SnapApp(SnapApp {
@@ -479,6 +483,7 @@ pub fn default_fold_expr<T: ExprFolder>(this: &mut T, e: Expr) -> Expr {
         Expr::Map(map) => this.fold_map(map),
         Expr::Cast(cast) => this.fold_cast(cast),
         Expr::Low(low) => this.fold_low(low),
+        Expr::LowEvent => this.fold_low_event(),
     }
 }
 
@@ -678,6 +683,8 @@ pub trait ExprWalker: Sized {
         self.walk(base);
     }
 
+    fn walk_low_event(&mut self) {}
+
     fn walk_snap_app(&mut self, expr: &SnapApp) {
         let SnapApp { base, .. } = expr;
         self.walk(base);
@@ -744,6 +751,7 @@ pub fn default_walk_expr<T: ExprWalker>(this: &mut T, e: &Expr) {
         Expr::Map(map) => this.walk_map(map),
         Expr::Cast(cast) => this.walk_cast(cast),
         Expr::Low(low) => this.walk_low(low),
+        Expr::LowEvent => this.walk_low_event(),
     }
 }
 
@@ -1092,6 +1100,10 @@ pub trait FallibleExprFolder: Sized {
         }))
     }
 
+    fn fallible_fold_low_event(&mut self) -> Result<Expr, Self::Error> {
+        Ok(Expr::LowEvent)
+    }
+
     fn fallible_fold_snap_app(&mut self, expr: SnapApp) -> Result<Expr, Self::Error> {
         let SnapApp { base, position } = expr;
         Ok(Expr::SnapApp(SnapApp {
@@ -1197,6 +1209,7 @@ pub fn default_fallible_fold_expr<U, T: FallibleExprFolder<Error = U>>(
         Expr::Map(map) => this.fallible_fold_map(map),
         Expr::Cast(cast) => this.fallible_fold_cast(cast),
         Expr::Low(low) => this.fallible_fold_low(low),
+        Expr::LowEvent => this.fallible_fold_low_event(),
     }
 }
 
@@ -1414,6 +1427,10 @@ pub trait FallibleExprWalker: Sized {
         self.fallible_walk(base)
     }
 
+    fn fallible_walk_low_event(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     fn fallible_walk_snap_app(&mut self, expr: &SnapApp) -> Result<(), Self::Error> {
         let SnapApp { base, .. } = expr;
         self.fallible_walk(base)
@@ -1484,5 +1501,6 @@ pub fn default_fallible_walk_expr<U, T: FallibleExprWalker<Error = U>>(
         Expr::Map(map) => this.fallible_walk_map(map),
         Expr::Cast(cast) => this.fallible_walk_cast(cast),
         Expr::Low(low) => this.fallible_walk_low(low),
+        Expr::LowEvent => this.fallible_walk_low_event(),
     }
 }

--- a/vir/defs/polymorphic/ast/expr_transformers.rs
+++ b/vir/defs/polymorphic/ast/expr_transformers.rs
@@ -380,6 +380,14 @@ pub trait ExprFolder: Sized {
         })
     }
 
+    fn fold_low(&mut self, expr: Low) -> Expr {
+        let Low { base, position } = expr;
+        Expr::Low(Low {
+            base: self.fold_boxed(base),
+            position,
+        })
+    }
+
     fn fold_snap_app(&mut self, expr: SnapApp) -> Expr {
         let SnapApp { base, position } = expr;
         Expr::SnapApp(SnapApp {
@@ -470,6 +478,7 @@ pub fn default_fold_expr<T: ExprFolder>(this: &mut T, e: Expr) -> Expr {
         Expr::Seq(seq) => this.fold_seq(seq),
         Expr::Map(map) => this.fold_map(map),
         Expr::Cast(cast) => this.fold_cast(cast),
+        Expr::Low(low) => this.fold_low(low),
     }
 }
 
@@ -663,6 +672,12 @@ pub trait ExprWalker: Sized {
         self.walk(base);
         self.walk(enum_place);
     }
+
+    fn walk_low(&mut self, expr: &Low) {
+        let Low { base, .. } = expr;
+        self.walk(base);
+    }
+
     fn walk_snap_app(&mut self, expr: &SnapApp) {
         let SnapApp { base, .. } = expr;
         self.walk(base);
@@ -728,6 +743,7 @@ pub fn default_walk_expr<T: ExprWalker>(this: &mut T, e: &Expr) {
         Expr::Seq(seq) => this.walk_seq(seq),
         Expr::Map(map) => this.walk_map(map),
         Expr::Cast(cast) => this.walk_cast(cast),
+        Expr::Low(low) => this.walk_low(low),
     }
 }
 
@@ -1068,6 +1084,14 @@ pub trait FallibleExprFolder: Sized {
         }))
     }
 
+    fn fallible_fold_low(&mut self, expr: Low) -> Result<Expr, Self::Error> {
+        let Low { base, position } = expr;
+        Ok(Expr::Low(Low {
+            base: self.fallible_fold_boxed(base)?,
+            position,
+        }))
+    }
+
     fn fallible_fold_snap_app(&mut self, expr: SnapApp) -> Result<Expr, Self::Error> {
         let SnapApp { base, position } = expr;
         Ok(Expr::SnapApp(SnapApp {
@@ -1172,6 +1196,7 @@ pub fn default_fallible_fold_expr<U, T: FallibleExprFolder<Error = U>>(
         Expr::Seq(seq) => this.fallible_fold_seq(seq),
         Expr::Map(map) => this.fallible_fold_map(map),
         Expr::Cast(cast) => this.fallible_fold_cast(cast),
+        Expr::Low(low) => this.fallible_fold_low(low),
     }
 }
 
@@ -1384,6 +1409,11 @@ pub trait FallibleExprWalker: Sized {
         Ok(())
     }
 
+    fn fallible_walk_low(&mut self, expr: &Low) -> Result<(), Self::Error> {
+        let Low { base, .. } = expr;
+        self.fallible_walk(base)
+    }
+
     fn fallible_walk_snap_app(&mut self, expr: &SnapApp) -> Result<(), Self::Error> {
         let SnapApp { base, .. } = expr;
         self.fallible_walk(base)
@@ -1453,5 +1483,6 @@ pub fn default_fallible_walk_expr<U, T: FallibleExprWalker<Error = U>>(
         Expr::Seq(seq) => this.fallible_walk_seq(seq),
         Expr::Map(map) => this.fallible_walk_map(map),
         Expr::Cast(cast) => this.fallible_walk_cast(cast),
+        Expr::Low(low) => this.fallible_walk_low(low),
     }
 }

--- a/vir/defs/polymorphic/ast/stmt.rs
+++ b/vir/defs/polymorphic/ast/stmt.rs
@@ -63,6 +63,8 @@ pub enum Stmt {
     /// * place to the enumeration instance
     /// * field that encodes the variant
     Downcast(Downcast),
+    /// Declassify the given expression
+    Declassify(Declassify),
 }
 
 impl fmt::Display for Stmt {
@@ -86,6 +88,7 @@ impl fmt::Display for Stmt {
             Stmt::ExpireBorrows(expire_borrows) => expire_borrows.fmt(f),
             Stmt::If(if_stmt) => if_stmt.fmt(f),
             Stmt::Downcast(downcast) => downcast.fmt(f),
+            Stmt::Declassify(declassify) => declassify.fmt(f),
         }
     }
 }
@@ -436,6 +439,17 @@ impl fmt::Display for Downcast {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Declassify {
+    pub expr: Expr,
+}
+
+impl fmt::Display for Declassify {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "declassify {}", self.expr)
+    }
+}
+
 impl Stmt {
     pub fn is_comment(&self) -> bool {
         matches!(self, Stmt::Comment(_))
@@ -459,6 +473,10 @@ impl Stmt {
 
     pub fn exhale(expr: Expr, position: Position) -> Self {
         Stmt::Exhale(Exhale { expr, position })
+    }
+
+    pub fn declassify(expr: Expr) -> Self {
+        Stmt::Declassify(Declassify { expr })
     }
 
     pub fn package_magic_wand(
@@ -561,6 +579,7 @@ pub trait StmtFolder {
             Stmt::ExpireBorrows(expire_borrows) => self.fold_expire_borrows(expire_borrows),
             Stmt::If(if_stmt) => self.fold_if(if_stmt),
             Stmt::Downcast(downcast) => self.fold_downcast(downcast),
+            Stmt::Declassify(declassify) => self.fold_declassify(declassify),
         }
     }
 
@@ -624,6 +643,7 @@ pub trait StmtFolder {
             kind,
         })
     }
+
     fn fold_fold(&mut self, statement: Fold) -> Stmt {
         let Fold {
             predicate,
@@ -738,6 +758,13 @@ pub trait StmtFolder {
             field,
         })
     }
+
+    fn fold_declassify(&mut self, statement: Declassify) -> Stmt {
+        let Declassify { expr } = statement;
+        Stmt::Declassify(Declassify {
+            expr: self.fold_expr(expr),
+        })
+    }
 }
 
 pub trait FallibleStmtFolder {
@@ -769,6 +796,7 @@ pub trait FallibleStmtFolder {
             }
             Stmt::If(if_stmt) => self.fallible_fold_if(if_stmt),
             Stmt::Downcast(downcast) => self.fallible_fold_downcast(downcast),
+            Stmt::Declassify(declassify) => self.fallible_fold_declassify(declassify),
         }
     }
 
@@ -977,6 +1005,13 @@ pub trait FallibleStmtFolder {
             field,
         }))
     }
+
+    fn fallible_fold_declassify(&mut self, statement: Declassify) -> Result<Stmt, Self::Error> {
+        let Declassify { expr } = statement;
+        Ok(Stmt::Declassify(Declassify {
+            expr: self.fallible_fold_expr(expr)?,
+        }))
+    }
 }
 
 pub trait StmtWalker {
@@ -1002,6 +1037,7 @@ pub trait StmtWalker {
             Stmt::ExpireBorrows(expire_borrows) => self.walk_expire_borrows(expire_borrows),
             Stmt::If(if_stmt) => self.walk_if(if_stmt),
             Stmt::Downcast(downcast) => self.walk_downcast(downcast),
+            Stmt::Declassify(declassify) => self.walk_declassify(declassify),
         }
     }
 
@@ -1125,6 +1161,11 @@ pub trait StmtWalker {
         let Downcast { base, .. } = statement;
         self.walk_expr(base);
     }
+
+    fn walk_declassify(&mut self, statement: &Declassify) {
+        let Declassify { expr } = statement;
+        self.walk_expr(expr);
+    }
 }
 
 pub trait FallibleStmtWalker {
@@ -1156,6 +1197,7 @@ pub trait FallibleStmtWalker {
             }
             Stmt::If(if_stmt) => self.fallible_walk_if(if_stmt),
             Stmt::Downcast(downcast) => self.fallible_walk_downcast(downcast),
+            Stmt::Declassify(declassify) => self.fallible_walk_declassify(declassify),
         }
     }
 
@@ -1322,6 +1364,12 @@ pub trait FallibleStmtWalker {
     fn fallible_walk_downcast(&mut self, statement: &Downcast) -> Result<(), Self::Error> {
         let Downcast { base, .. } = statement;
         self.fallible_walk_expr(base)?;
+        Ok(())
+    }
+
+    fn fallible_walk_declassify(&mut self, statement: &Declassify) -> Result<(), Self::Error> {
+        let Declassify { expr } = statement;
+        self.fallible_walk_expr(expr)?;
         Ok(())
     }
 }

--- a/vir/src/converter/polymorphic_to_legacy.rs
+++ b/vir/src/converter/polymorphic_to_legacy.rs
@@ -409,6 +409,7 @@ impl From<polymorphic::Expr> for legacy::Expr {
             polymorphic::Expr::Low(low) => {
                 legacy::Expr::Low(Box::new((*low.base).into()), low.position.into())
             }
+            polymorphic::Expr::LowEvent => legacy::Expr::LowEvent,
         }
     }
 }

--- a/vir/src/converter/polymorphic_to_legacy.rs
+++ b/vir/src/converter/polymorphic_to_legacy.rs
@@ -693,9 +693,6 @@ impl From<polymorphic::Stmt> for legacy::Stmt {
             polymorphic::Stmt::Downcast(downcast) => {
                 legacy::Stmt::Downcast(downcast.base.into(), downcast.field.into())
             }
-            polymorphic::Stmt::Declassify(declassify) => {
-                legacy::Stmt::Declassify(declassify.expr.into())
-            }
         }
     }
 }

--- a/vir/src/converter/polymorphic_to_legacy.rs
+++ b/vir/src/converter/polymorphic_to_legacy.rs
@@ -406,6 +406,9 @@ impl From<polymorphic::Expr> for legacy::Expr {
                 Box::new((*cast.base).into()),
                 cast.position.into(),
             ),
+            polymorphic::Expr::Low(low) => {
+                legacy::Expr::Low(Box::new((*low.base).into()), low.position.into())
+            }
         }
     }
 }
@@ -689,6 +692,9 @@ impl From<polymorphic::Stmt> for legacy::Stmt {
             ),
             polymorphic::Stmt::Downcast(downcast) => {
                 legacy::Stmt::Downcast(downcast.base.into(), downcast.field.into())
+            }
+            polymorphic::Stmt::Declassify(declassify) => {
+                legacy::Stmt::Declassify(declassify.expr.into())
             }
         }
     }

--- a/vir/src/converter/type_substitution.rs
+++ b/vir/src/converter/type_substitution.rs
@@ -170,6 +170,7 @@ impl Generic for Expr {
             Expr::SnapApp(snap_app) => Expr::SnapApp(snap_app.substitute(map)),
             Expr::Cast(cast) => Expr::Cast(cast.substitute(map)),
             Expr::Low(low) => Expr::Low(low.substitute(map)),
+            Expr::LowEvent => Expr::LowEvent,
         }
     }
 }

--- a/vir/src/converter/type_substitution.rs
+++ b/vir/src/converter/type_substitution.rs
@@ -169,6 +169,7 @@ impl Generic for Expr {
             Expr::Downcast(down_cast) => Expr::Downcast(down_cast.substitute(map)),
             Expr::SnapApp(snap_app) => Expr::SnapApp(snap_app.substitute(map)),
             Expr::Cast(cast) => Expr::Cast(cast.substitute(map)),
+            Expr::Low(low) => Expr::Low(low.substitute(map)),
         }
     }
 }
@@ -437,6 +438,13 @@ impl Generic for Cast {
     }
 }
 
+impl Generic for Low {
+    fn substitute(mut self, map: &FxHashMap<TypeVar, Type>) -> Self {
+        *self.base = self.base.substitute(map);
+        self
+    }
+}
+
 // function
 impl Generic for Function {
     fn substitute(self, map: &FxHashMap<TypeVar, Type>) -> Self {
@@ -541,6 +549,7 @@ impl Generic for Stmt {
             }
             Stmt::If(if_stmt) => Stmt::If(if_stmt.substitute(map)),
             Stmt::Downcast(downcast) => Stmt::Downcast(downcast.substitute(map)),
+            Stmt::Declassify(declassify) => Stmt::Declassify(declassify.substitute(map)),
         }
     }
 }
@@ -737,6 +746,14 @@ impl Generic for Downcast {
         downcast.base = downcast.base.substitute(map);
         downcast.field = downcast.field.substitute(map);
         downcast
+    }
+}
+
+impl Generic for Declassify {
+    fn substitute(self, map: &FxHashMap<TypeVar, Type>) -> Self {
+        let mut declassify = self;
+        declassify.expr = declassify.expr.substitute(map);
+        declassify
     }
 }
 

--- a/vir/src/converter/type_substitution.rs
+++ b/vir/src/converter/type_substitution.rs
@@ -549,7 +549,6 @@ impl Generic for Stmt {
             }
             Stmt::If(if_stmt) => Stmt::If(if_stmt.substitute(map)),
             Stmt::Downcast(downcast) => Stmt::Downcast(downcast.substitute(map)),
-            Stmt::Declassify(declassify) => Stmt::Declassify(declassify.substitute(map)),
         }
     }
 }
@@ -746,14 +745,6 @@ impl Generic for Downcast {
         downcast.base = downcast.base.substitute(map);
         downcast.field = downcast.field.substitute(map);
         downcast
-    }
-}
-
-impl Generic for Declassify {
-    fn substitute(self, map: &FxHashMap<TypeVar, Type>) -> Self {
-        let mut declassify = self;
-        declassify.expr = declassify.expr.substitute(map);
-        declassify
     }
 }
 

--- a/vir/src/legacy/ast/expr.rs
+++ b/vir/src/legacy/ast/expr.rs
@@ -75,6 +75,8 @@ pub enum Expr {
     /// Snapshot call to convert from a Ref to a snapshot value
     SnapApp(Box<Expr>, Position),
     Cast(CastKind, Box<Expr>, Position),
+    /// check that the given expression is at the low security level
+    Low(Box<Expr>, Position),
 }
 
 /// A component that can be used to represent a place as a vector.
@@ -306,6 +308,7 @@ impl fmt::Display for Expr {
 
             Expr::SnapApp(ref expr, _) => write!(f, "snap({expr})"),
             Expr::Cast(ref kind, ref base, _) => write!(f, "cast<{kind:?}>({base})"),
+            Expr::Low(ref base, _) => write!(f, "low({base})"),
         }
     }
 }
@@ -388,6 +391,7 @@ impl Expr {
             | Expr::Seq(_, _, p)
             | Expr::Map(_, _, p)
             | Expr::Cast(_, _, p)
+            | Expr::Low(_, p)
             | Expr::SnapApp(_, p) => *p,
             // TODO Expr::DomainFuncApp(_, _, _, _, _, p) => p,
             Expr::Downcast(box ref base, ..) => base.pos(),
@@ -1243,7 +1247,7 @@ impl Expr {
                 assert_eq!(typ1, typ2, "expr: {self:?}");
                 typ1?
             }
-            Expr::ForAll(..) | Expr::Exists(..) => &Type::Bool,
+            Expr::ForAll(..) | Expr::Exists(..) | Expr::Low(..) => &Type::Bool,
             Expr::MagicWand(..)
             | Expr::PredicateAccessPredicate(..)
             | Expr::FieldAccessPredicate(..)
@@ -1716,6 +1720,7 @@ impl Expr {
                     | Expr::Seq(..)
                     | Expr::Map(..)
                     | Expr::SnapApp(..)
+                    | Expr::Low(..)
                     | Expr::Cast(..) => true.into(),
                 }
             }

--- a/vir/src/legacy/ast/expr.rs
+++ b/vir/src/legacy/ast/expr.rs
@@ -77,6 +77,8 @@ pub enum Expr {
     Cast(CastKind, Box<Expr>, Position),
     /// check that the given expression is at the low security level
     Low(Box<Expr>, Position),
+    /// check that both execution reach this point or none
+    LowEvent,
 }
 
 /// A component that can be used to represent a place as a vector.
@@ -309,6 +311,7 @@ impl fmt::Display for Expr {
             Expr::SnapApp(ref expr, _) => write!(f, "snap({expr})"),
             Expr::Cast(ref kind, ref base, _) => write!(f, "cast<{kind:?}>({base})"),
             Expr::Low(ref base, _) => write!(f, "low({base})"),
+            Expr::LowEvent => write!(f, "low_event"),
         }
     }
 }
@@ -395,6 +398,7 @@ impl Expr {
             | Expr::SnapApp(_, p) => *p,
             // TODO Expr::DomainFuncApp(_, _, _, _, _, p) => p,
             Expr::Downcast(box ref base, ..) => base.pos(),
+            Expr::LowEvent => Position::default(),
         }
     }
 
@@ -1247,7 +1251,7 @@ impl Expr {
                 assert_eq!(typ1, typ2, "expr: {self:?}");
                 typ1?
             }
-            Expr::ForAll(..) | Expr::Exists(..) | Expr::Low(..) => &Type::Bool,
+            Expr::ForAll(..) | Expr::Exists(..) | Expr::Low(..) | Expr::LowEvent => &Type::Bool,
             Expr::MagicWand(..)
             | Expr::PredicateAccessPredicate(..)
             | Expr::FieldAccessPredicate(..)
@@ -1721,6 +1725,7 @@ impl Expr {
                     | Expr::Map(..)
                     | Expr::SnapApp(..)
                     | Expr::Low(..)
+                    | Expr::LowEvent
                     | Expr::Cast(..) => true.into(),
                 }
             }

--- a/vir/src/legacy/ast/expr_transformers.rs
+++ b/vir/src/legacy/ast/expr_transformers.rs
@@ -345,6 +345,10 @@ pub trait ExprFolder: Sized {
         Expr::Low(self.fold_boxed(expr), self.fold_position(p))
     }
 
+    fn fold_low_event(&mut self) -> Expr {
+        Expr::LowEvent
+    }
+
     fn fold_position(&mut self, p: Position) -> Position {
         p
     }
@@ -383,6 +387,7 @@ pub fn default_fold_expr<T: ExprFolder>(this: &mut T, e: Expr) -> Expr {
         Expr::Map(x, y, p) => this.fold_map(x, y, p),
         Expr::Cast(kind, base, p) => this.fold_cast(kind, base, p),
         Expr::Low(e, p) => this.fold_low(e, p),
+        Expr::LowEvent => this.fold_low_event(),
     }
 }
 
@@ -616,6 +621,8 @@ pub trait ExprWalker: Sized {
         self.walk_position(pos);
     }
 
+    fn walk_low_event(&mut self) {}
+
     fn walk_position(&mut self, _pos: &Position) {}
 }
 
@@ -652,6 +659,7 @@ pub fn default_walk_expr<T: ExprWalker>(this: &mut T, e: &Expr) {
         Expr::Map(ref ty, ref elems, ref p) => this.walk_map(ty, elems, p),
         Expr::Cast(ref kind, ref base, ref p) => this.walk_cast(kind, base, p),
         Expr::Low(ref expr, ref p) => this.walk_low(expr, p),
+        Expr::LowEvent => this.walk_low_event(),
     }
 }
 
@@ -979,6 +987,10 @@ pub trait FallibleExprFolder: Sized {
     fn fallible_fold_low(&mut self, expr: Box<Expr>, p: Position) -> Result<Expr, Self::Error> {
         Ok(Expr::Low(self.fallible_fold_boxed(expr)?, p))
     }
+
+    fn fallible_fold_low_event(&mut self) -> Result<Expr, Self::Error> {
+        Ok(Expr::LowEvent)
+    }
 }
 
 pub fn default_fallible_fold_expr<U, T: FallibleExprFolder<Error = U>>(
@@ -1017,5 +1029,6 @@ pub fn default_fallible_fold_expr<U, T: FallibleExprFolder<Error = U>>(
         Expr::Map(x, y, p) => this.fallible_fold_map(x, y, p),
         Expr::Cast(kind, base, p) => this.fallible_fold_cast(kind, base, p),
         Expr::Low(expr, p) => this.fallible_fold_low(expr, p),
+        Expr::LowEvent => this.fallible_fold_low_event(),
     }
 }


### PR DESCRIPTION
The sif extension jar must be copied into the `viper_tools/backends/` directory before compiling Prusti otherwise the compilation will fail. 

To generate the extension jar file:
1. copy the updated transformation from the file [SIFExtendedTransformer.scala](SIFExtendedTransformer.scala) inside the [source directory of the extension](https://github.com/viperproject/silver-sif-extension/tree/master/src/main/scala).
2. run the `sbt package` command from the extension's root directory to generate the jar file.