### PR TITLE
Update dependencies (rustc nightly-2023-06-01, viper v-2023-05-17-0733)

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-04-01"
+channel = "nightly-2023-06-01"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-std", "rustfmt", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
* [x] Update Viper version to `v-2023-05-17-0733`.
* [x] Update rustc version to `nightly-2023-06-01`.
* [ ] Run `cargo audit` and fix the issues.
* [ ] Manualy update outdated dependencies (see the list below).
* [ ] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ mv prusti-contracts/Cargo.toml prusti-contracts/Cargo_disabled.toml
$ cargo outdated --root-deps-only --workspace

info: syncing channel updates for 'nightly-2023-06-01-x86_64-unknown-linux-gnu'
info: latest update on 2023-06-01, rust version 1.72.0-nightly (871b59520 2023-05-31)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'llvm-tools'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustc-dev'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'llvm-tools'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustc-dev'
info: installing component 'rustfmt'
    Updating git repository `https://github.com/rust-lang/cargo.git`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_implicit_namesrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/lib_already_exists_nosrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/inferred_lib_with_git/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/creates_library_when_instructed_and_has_bin_file/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/fossil_autodetect/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/ignores_failure_to_format_source/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_lib/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_explicit/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_hg/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/pijul_autodetect/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_git/out`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/git_autodetect/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/creates_binary_when_both_binlib_present/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_hg_ignore_exists/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_implicit_nosrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/auto_git/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/lib_already_exists_src/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/explicit_bin_with_git/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_explicit_nosrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/creates_binary_when_instructed_and_has_lib_file/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_implicit_namenosrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/mercurial_autodetect/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/formats_source/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_bin/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_implicit/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_git_ignore_exists/out`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/add-basic.in`
warning: skipping duplicate package `your-face` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_name_noop/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_git_with_path/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_dev/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_dev/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/registry/in`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/change_rename_target/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/features_preserve/in`
warning: skipping duplicate package `your-face` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_name_dev_noop/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_optional/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path_no_default/in/primary`
warning: skipping duplicate package `your-face` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path_no_default/in/dependency`
warning: skipping duplicate package `optional-dep` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path_no_default/in/optional`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/require_weak/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/deprecated_section/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_no_default_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inline_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/preserve_unsorted/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_default_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_with_rename/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_version_with_git/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_path_name/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_path_name/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/unknown_inherited_feature/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/unknown_inherited_feature/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/dev_prefer_existing_version/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_rename_with_rename/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/in`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/detect_workspace_inherit_optional/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/detect_workspace_inherit_optional/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/detect_workspace_inherit/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/detect_workspace_inherit/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_name/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_name/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/merge_activated_features/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/merge_activated_features/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_version_with_path/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_version_with_path/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/git_registry/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_path_with_version/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_path_with_version/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_features/in`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_inherit_dependency/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_inherit_dependency/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/deprecated_default_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path/in/primary`
warning: skipping duplicate package `your-face` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path/in/dependency`
warning: skipping duplicate package `optional-dep` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path/in/optional`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_noop/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_noop/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_features_noop/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_features_noop/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/preserve_sorted/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_path/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_path/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_normalized_name/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_normalized_name/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_inferred_name/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_inferred_name/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_workspace_dep_features/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_workspace_dep_features/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_no_optional/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_path_dev/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_path_dev/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/build_prefer_existing_version/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/manifest_path_package/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/manifest_path_package/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_workspace_dep/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_workspace_dep/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/in`
error: failed to select a version for `git2`.
    ... required by package `rustwide v0.16.0`
    ... which satisfies dependency `rustwide = "^0.16.0"` of package `test-crates v0.1.0 (/tmp/cargo-outdatedIHj4K3/test-crates)`
versions that meet the requirements `^0.17.0` are: 0.17.2, 0.17.1, 0.17.0

the package `git2` links to the native library `git2`, but it conflicts with a previous package which links to `git2` as well:
package `git2 v0.14.2`
    ... which satisfies dependency `git2 = "^0.14.2"` of package `cargo-test-support v0.1.0 (https://github.com/rust-lang/cargo.git?rev=17f8088#17f8088d)`
    ... which satisfies git dependency `cargo-test-support` (locked to 0.1.0) of package `prusti-tests v0.2.0 (/tmp/cargo-outdatedIHj4K3/prusti-tests)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='git2' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `git2` which could resolve this conflict
cargo outdated failed to execute

$ mv prusti-contracts/Cargo_disabled.toml prusti-contracts/Cargo.toml
```
</details>

@Aurel300 could you take care of this?