### PR TITLE
Update dependencies (rustc nightly-2023-06-15, viper v-2023-05-17-0733)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -85,15 +85,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -187,7 +187,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.37.23",
  "slab",
  "socket2",
  "waker-fn",
@@ -215,7 +215,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.37.23",
  "signal-hook",
  "windows-sys 0.48.0",
 ]
@@ -256,13 +256,13 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -305,18 +305,24 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -329,6 +335,12 @@ name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bencher"
@@ -350,6 +362,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block-buffer"
@@ -396,50 +414,54 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "cargo-test-macro"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/cargo.git?rev=17f8088#17f8088d6eafd82349630a8de8cc6efe03abf5fb"
+source = "git+https://github.com/rust-lang/cargo.git?rev=ec8a8a0#ec8a8a0cabb0e0cadef58902470f6c7ee7868bdc"
 
 [[package]]
 name = "cargo-test-support"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/cargo.git?rev=17f8088#17f8088d6eafd82349630a8de8cc6efe03abf5fb"
+source = "git+https://github.com/rust-lang/cargo.git?rev=ec8a8a0#ec8a8a0cabb0e0cadef58902470f6c7ee7868bdc"
 dependencies = [
  "anyhow",
  "cargo-test-macro",
  "cargo-util",
+ "crates-io",
  "filetime",
  "flate2",
  "git2",
  "glob",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
- "remove_dir_all 0.5.3",
+ "pasetors",
+ "serde",
  "serde_json",
  "snapbox",
  "tar",
  "termcolor",
- "toml_edit 0.14.4",
+ "time",
+ "toml 0.7.6",
  "url",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "cargo-util"
-version = "0.1.4"
-source = "git+https://github.com/rust-lang/cargo.git?rev=17f8088#17f8088d6eafd82349630a8de8cc6efe03abf5fb"
+version = "0.2.4"
+source = "git+https://github.com/rust-lang/cargo.git?rev=ec8a8a0#ec8a8a0cabb0e0cadef58902470f6c7ee7868bdc"
 dependencies = [
  "anyhow",
  "core-foundation",
- "crypto-hash",
  "filetime",
- "hex 0.4.3",
+ "hex",
  "jobserver",
  "libc",
  "log",
- "miow",
+ "miow 0.5.0",
  "same-file",
+ "sha2",
  "shell-escape",
  "tempfile",
  "walkdir",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -477,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.4"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -488,13 +510,12 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.4"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "strsim",
 ]
@@ -508,7 +529,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -545,28 +566,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "commoncrypto"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
-dependencies = [
- "commoncrypto-sys",
-]
-
-[[package]]
-name = "commoncrypto-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "compiletest_rs"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70489bbb718aea4f92e5f48f2e3b5be670c2051de30e57cb6e5377b4aa08b372"
+checksum = "7225fee1bcf9247bb3a1b1a2d7ecfe2f7a990e549a09d766a257a4ae30dac0d6"
 dependencies = [
  "diff",
  "filetime",
@@ -574,7 +577,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "regex",
  "rustfix",
  "serde",
@@ -583,23 +586,6 @@ dependencies = [
  "tester",
  "winapi",
 ]
-
-[[package]]
-name = "concolor"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
-dependencies = [
- "atty",
- "bitflags",
- "concolor-query",
-]
-
-[[package]]
-name = "concolor-query"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
 
 [[package]]
 name = "concurrent-queue"
@@ -628,6 +614,12 @@ dependencies = [
  "toml 0.5.11",
  "yaml-rust",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
 
 [[package]]
 name = "content_inspector"
@@ -662,11 +654,24 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crates-io"
+version = "0.36.0"
+source = "git+https://github.com/rust-lang/cargo.git?rev=ec8a8a0#ec8a8a0cabb0e0cadef58902470f6c7ee7868bdc"
+dependencies = [
+ "anyhow",
+ "curl",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -722,6 +727,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,18 +746,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-hash"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
-dependencies = [
- "commoncrypto",
- "hex 0.3.2",
- "openssl",
- "winapi",
 ]
 
 [[package]]
@@ -765,6 +770,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
+
+[[package]]
 name = "ctrlc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,10 +786,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.63+curl-8.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb0fef7046022a1e2ad67a004978f0e3cacb9e3123dc62ce768f92197b771dc"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi",
+]
+
+[[package]]
 name = "datafrog"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0afaad2b26fa326569eb264b1363e8ae3357618c43982b3f285f0774ce76b69"
+
+[[package]]
+name = "der"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "derivative"
@@ -826,7 +878,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -863,10 +917,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519-compact"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -889,6 +987,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "errno"
@@ -959,6 +1063,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+
+[[package]]
 name = "filetime"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,7 +1098,7 @@ checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1092,7 +1212,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1133,6 +1253,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1151,8 +1272,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1163,11 +1286,11 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "git2"
-version = "0.14.4"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -1195,10 +1318,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.19"
+name = "group"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -1206,7 +1340,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1223,13 +1357,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "headers"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -1264,30 +1404,33 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1331,9 +1474,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1355,10 +1498,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -1415,7 +1559,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1433,26 +1587,25 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "hermit-abi 0.3.2",
+ "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]
 
@@ -1466,10 +1619,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.6"
+name = "itertools"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jni"
@@ -1533,15 +1695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kstring"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,15 +1711,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.5+1.4.5"
+version = "0.15.2+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
 dependencies = [
  "cc",
  "libc",
@@ -1578,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",
@@ -1615,6 +1768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+
+[[package]]
 name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,7 +1788,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1689,15 +1848,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -1723,6 +1873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
+dependencies = [
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1768,7 +1927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -1781,7 +1940,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
@@ -1826,19 +1985,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -1851,11 +2010,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1872,7 +2031,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1883,9 +2042,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -1900,7 +2059,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "orion"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11468cc6afd61a126fe3f91cc4cc8a0dbe7917d0a4b5e8357ba91cc47444462"
+dependencies = [
+ "fiat-crypto",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1910,16 +2080,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
+name = "pasetors"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba765699a309908d55950919a3445e9491453e89b2587b1b2abe4143a48894c0"
+dependencies = [
+ "ct-codecs",
+ "ed25519-compact",
+ "getrandom",
+ "orion",
+ "p384",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "time",
+ "zeroize",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1929,9 +2141,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1939,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1949,22 +2161,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -1973,35 +2185,45 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2016,7 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -2032,6 +2254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "primeorder"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-tracing"
 version = "0.1.0"
 dependencies = [
@@ -2042,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2071,7 +2302,7 @@ name = "prusti-common"
 version = "0.1.0"
 dependencies = [
  "config",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "prusti-utils",
@@ -2160,7 +2391,7 @@ dependencies = [
 name = "prusti-specs"
 version = "0.1.9"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "rustc-hash",
@@ -2188,13 +2419,13 @@ version = "0.1.0"
 dependencies = [
  "config",
  "ctrlc",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "nix 0.26.2",
  "rustc-hash",
  "serde",
- "toml 0.7.4",
+ "toml 0.7.6",
  "uuid",
  "walkdir",
  "winapi",
@@ -2207,7 +2438,7 @@ dependencies = [
  "backtrace",
  "derive_more",
  "diffy",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "num-traits",
@@ -2227,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -2292,7 +2523,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2301,7 +2532,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2317,13 +2548,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.2",
+ "regex-syntax 0.7.3",
 ]
 
 [[package]]
@@ -2336,6 +2568,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.3",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,18 +2586,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "remove_dir_all"
@@ -2409,6 +2643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,7 +2674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -2479,35 +2723,48 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.1",
  "sct",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
@@ -2523,16 +2780,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.12"
+name = "rustls-webpki"
+version = "0.101.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
 name = "rustwide"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b0070cdf593a5b66ba6160974bbfb504a837f8c06f3357a623c9a7b6619c64"
+checksum = "4f77082ac67ce0958dca987d10f5a994114cd98ee0a81afa6f5bc44fb2e416f0"
 dependencies = [
  "attohttpc",
  "base64 0.13.1",
@@ -2547,7 +2814,7 @@ dependencies = [
  "log",
  "nix 0.25.1",
  "percent-encoding",
- "remove_dir_all 0.7.0",
+ "remove_dir_all",
  "scopeguard",
  "serde",
  "serde_json",
@@ -2563,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "same-file"
@@ -2578,11 +2845,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2608,12 +2875,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2638,29 +2919,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa",
  "ryu",
@@ -2669,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
 ]
@@ -2745,6 +3026,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smt-log-analyzer"
@@ -2775,11 +3066,12 @@ dependencies = [
 
 [[package]]
 name = "snapbox"
-version = "0.2.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767a1d5da232b6959cd1bd5c9e8db8a7cce09c3038e89deedb49a549a2aefd93"
+checksum = "f6bccd62078347f89a914e3004d94582e13824d4e3d8a816317862884c423835"
 dependencies = [
- "concolor",
+ "anstream",
+ "anstyle",
  "content_inspector",
  "dunce",
  "filetime",
@@ -2788,14 +3080,16 @@ dependencies = [
  "snapbox-macros",
  "tempfile",
  "walkdir",
- "yansi",
 ]
 
 [[package]]
 name = "snapbox-macros"
-version = "0.2.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01dea7e04cbb27ef4c86e9922184608185f7cd95c1763bc30d727cda4a5e930"
+checksum = "eaaf09df9f0eeae82be96290918520214530e738a7fe5a351b0f24cf77c0ca31"
+dependencies = [
+ "anstream",
+]
 
 [[package]]
 name = "socket2"
@@ -2820,6 +3114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,6 +3134,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2844,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2899,7 +3209,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
 
@@ -2938,7 +3248,7 @@ dependencies = [
  "prusti-launch",
  "rustwide",
  "serde",
- "toml 0.7.4",
+ "toml 0.7.6",
 ]
 
 [[package]]
@@ -2956,22 +3266,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2982,6 +3292,33 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -3001,11 +3338,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -3074,45 +3412,32 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.10",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.14.4"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
- "combine",
- "indexmap",
- "itertools",
- "kstring",
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
-dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3148,13 +3473,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3240,9 +3565,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -3261,9 +3586,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -3294,16 +3619,16 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b45063f47caea744e48f5baa99169bd8bd9b882d80a99941141327bbb00f99"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
 dependencies = [
  "base64 0.21.2",
  "flate2",
  "log",
  "once_cell",
  "rustls",
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
  "url",
  "webpki-roots 0.23.1",
 ]
@@ -3333,9 +3658,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 dependencies = [
  "getrandom",
 ]
@@ -3348,9 +3673,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
+checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
 name = "vcpkg"
@@ -3412,7 +3737,7 @@ dependencies = [
  "derivative",
  "derive_more",
  "index_vec",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "proc-macro2",
@@ -3522,7 +3847,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -3556,7 +3881,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3602,7 +3927,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
 ]
 
 [[package]]
@@ -3648,7 +3973,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -3681,18 +4006,42 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -3819,9 +4168,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
 ]
@@ -3854,7 +4203,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "yansi"
-version = "0.5.1"
+name = "zeroize"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "prusti-specs"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "prusti-specs"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,49 +70,58 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query 0.3.3",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "async-attributes"
@@ -247,7 +262,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -298,7 +313,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -311,9 +326,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bencher"
@@ -362,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -450,21 +465,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "num-integer",
  "num-traits",
  "winapi",
 ]
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -473,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
 dependencies = [
  "anstream",
  "anstyle",
@@ -486,31 +501,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "color-backtrace"
@@ -522,6 +527,12 @@ dependencies = [
  "backtrace",
  "termcolor",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -581,29 +592,14 @@ checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
 dependencies = [
  "atty",
  "bitflags",
- "concolor-query 0.0.5",
+ "concolor-query",
 ]
-
-[[package]]
-name = "concolor-override"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
 
 [[package]]
 name = "concolor-query"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -666,9 +662,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -705,22 +701,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -749,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
  "csv-core",
  "itoa",
@@ -769,67 +765,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ctrlc"
-version = "3.2.5"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
 dependencies = [
  "nix 0.26.2",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.14",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.14",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -879,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -916,9 +858,9 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dunce"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
@@ -1030,13 +972,13 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -1062,9 +1004,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -1150,7 +1092,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1204,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1215,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "git2"
@@ -1254,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -1389,9 +1331,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1413,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
@@ -1426,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1440,19 +1382,18 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1488,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -1573,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1617,9 +1558,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libgit2-sys"
@@ -1651,23 +1592,14 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1678,17 +1610,16 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 dependencies = [
- "cfg-if",
  "value-bag",
 ]
 
@@ -1727,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -1766,15 +1697,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.6"
+name = "miniz_oxide"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1787,17 +1726,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiparty"
-version = "0.1.0"
+name = "multer"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1ec6589a6d4a1e0b33b4c0a3f6ee96dfba88ebdb3da51403fd7cf0a24a4b04"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
  "bytes",
- "futures-core",
+ "encoding_rs",
+ "futures-util",
+ "http",
  "httparse",
+ "log",
  "memchr",
- "pin-project-lite",
- "try-lock",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]
@@ -1873,16 +1816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,24 +1836,24 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1939,7 +1872,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1950,9 +1883,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
  "cc",
  "libc",
@@ -1990,15 +1923,15 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2006,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2016,22 +1949,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
@@ -2040,22 +1973,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2072,15 +2005,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "polling"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be1c66a6add46bff50935c313dae30a5030cf8385c5206e8a95e9e9def974aa"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags",
@@ -2109,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -2261,7 +2194,7 @@ dependencies = [
  "nix 0.26.2",
  "rustc-hash",
  "serde",
- "toml 0.7.3",
+ "toml 0.7.4",
  "uuid",
  "walkdir",
  "winapi",
@@ -2294,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -2384,13 +2317,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -2399,7 +2332,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2407,6 +2340,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "remove_dir_all"
@@ -2432,11 +2371,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2465,7 +2404,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -2478,7 +2417,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -2507,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -2540,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
@@ -2554,14 +2493,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -2570,7 +2509,17 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2649,12 +2598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2679,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2695,29 +2638,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",
@@ -2726,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
@@ -2758,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2871,6 +2814,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2895,9 +2844,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2942,15 +2891,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2988,14 +2938,14 @@ dependencies = [
  "prusti-launch",
  "rustwide",
  "serde",
- "toml 0.7.3",
+ "toml 0.7.4",
 ]
 
 [[package]]
 name = "tester"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0639d10d8f4615f223a57275cf40f9bdb7cfbb806bcb7f7cc56e3beb55a576eb"
+checksum = "89e8bf7e0eb2dd7b4228cc1b6821fc5114cd6841ae59f652a85488c016091e5f"
 dependencies = [
  "cfg-if",
  "getopts",
@@ -3021,7 +2971,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3051,9 +3001,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3063,25 +3013,24 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3102,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3125,21 +3074,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.8",
+ "toml_edit 0.19.10",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
@@ -3159,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "serde",
@@ -3199,13 +3148,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3221,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3242,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3312,9 +3261,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -3345,25 +3294,25 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.6.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+checksum = "d4b45063f47caea744e48f5baa99169bd8bd9b882d80a99941141327bbb00f99"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "flate2",
  "log",
  "once_cell",
  "rustls",
+ "rustls-webpki",
  "url",
- "webpki",
- "webpki-roots",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3384,9 +3333,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
  "getrandom",
 ]
@@ -3399,13 +3348,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor",
- "version_check",
-]
+checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 
 [[package]]
 name = "vcpkg"
@@ -3512,19 +3457,18 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
 [[package]]
 name = "warp"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e1a710288f0f91a98dd8a74f05b76a10768db245ce183edf64dc1afdc3016c"
+checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3535,7 +3479,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multiparty",
+ "multer",
  "percent-encoding",
  "pin-project",
  "rustls-pemfile",
@@ -3559,9 +3503,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3569,24 +3513,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3596,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3606,28 +3550,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3650,6 +3594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]
@@ -3695,7 +3648,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3728,35 +3681,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3890,9 +3819,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
 exclude = [
     "docs/dummy"
 ]
+resolver = "2"
 
 [profile.dev]
 debug = 1

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -15,7 +15,7 @@ prusti-rustc-interface = { path = "../prusti-rustc-interface" }
 tracing = { path = "../tracing" }
 
 [dev-dependencies]
-compiletest_rs = "0.9"
+compiletest_rs = "0.10"
 glob = "0.3"
 
 [package.metadata.rust-analyzer]

--- a/analysis/src/bin/analysis-driver.rs
+++ b/analysis/src/bin/analysis-driver.rs
@@ -13,14 +13,14 @@ use analysis::{
 };
 use prusti_rustc_interface::{
     ast::ast,
-    borrowck::BodyWithBorrowckFacts,
+    borrowck::consumers::{self, BodyWithBorrowckFacts},
     data_structures::fx::FxHashMap,
     driver::Compilation,
     hir::def_id::{DefId, LocalDefId},
     interface::{interface, Config, Queries},
     middle::{
         ty,
-        ty::query::{query_values::mir_borrowck, ExternProviders, Providers},
+        query::{queries::mir_borrowck::ProvidedValue, ExternProviders, Providers},
     },
     polonius_engine::{Algorithm, Output},
     session::{Attribute, Session},
@@ -116,10 +116,11 @@ mod mir_storage {
 }
 
 #[allow(clippy::needless_lifetimes)]
-fn mir_borrowck<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: LocalDefId) -> mir_borrowck<'tcx> {
-    let body_with_facts = prusti_rustc_interface::borrowck::consumers::get_body_with_borrowck_facts(
+fn mir_borrowck<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: LocalDefId) -> ProvidedValue<'tcx> {
+    let body_with_facts = consumers::get_body_with_borrowck_facts(
         tcx,
-        ty::WithOptConstParam::unknown(def_id),
+        def_id,
+        consumers::ConsumerOptions::PoloniusOutputFacts,
     );
     // SAFETY: This is safe because we are feeding in the same `tcx` that is
     // going to be used as a witness when pulling out the data.
@@ -190,12 +191,12 @@ impl prusti_rustc_interface::driver::Callbacks for OurCompilerCalls {
                 // that was used to store the data.
                 let mut body_with_facts =
                     unsafe { self::mir_storage::retrieve_mir_body(tcx, local_def_id) };
-                body_with_facts.output_facts = Rc::new(Output::compute(
-                    &body_with_facts.input_facts,
+                body_with_facts.output_facts = Some(Rc::new(Output::compute(
+                    body_with_facts.input_facts.as_ref().unwrap(),
                     Algorithm::Naive,
                     true,
-                ));
-                assert!(!body_with_facts.input_facts.cfg_edge.is_empty());
+                )));
+                assert!(!body_with_facts.input_facts.as_ref().unwrap().cfg_edge.is_empty());
                 let body = &body_with_facts.body;
 
                 match abstract_domain {

--- a/analysis/src/bin/analysis-driver.rs
+++ b/analysis/src/bin/analysis-driver.rs
@@ -19,8 +19,8 @@ use prusti_rustc_interface::{
     hir::def_id::{DefId, LocalDefId},
     interface::{interface, Config, Queries},
     middle::{
-        ty,
         query::{queries::mir_borrowck::ProvidedValue, ExternProviders, Providers},
+        ty,
     },
     polonius_engine::{Algorithm, Output},
     session::{Attribute, Session},
@@ -196,7 +196,12 @@ impl prusti_rustc_interface::driver::Callbacks for OurCompilerCalls {
                     Algorithm::Naive,
                     true,
                 )));
-                assert!(!body_with_facts.input_facts.as_ref().unwrap().cfg_edge.is_empty());
+                assert!(!body_with_facts
+                    .input_facts
+                    .as_ref()
+                    .unwrap()
+                    .cfg_edge
+                    .is_empty());
                 let body = &body_with_facts.body;
 
                 match abstract_domain {

--- a/analysis/src/bin/gen-accessibility-driver.rs
+++ b/analysis/src/bin/gen-accessibility-driver.rs
@@ -13,8 +13,8 @@ use prusti_rustc_interface::{
     hir::def_id::LocalDefId,
     interface::{interface, Config, Queries},
     middle::{
-        ty,
         query::{queries::mir_borrowck::ProvidedValue, ExternProviders, Providers},
+        ty,
     },
     polonius_engine::{Algorithm, Output},
     session::Session,
@@ -176,7 +176,12 @@ impl prusti_rustc_interface::driver::Callbacks for OurCompilerCalls {
 
             // Generate and print the programs with the additional statements to check accessibility.
             for (num, (local_def_id, body_with_facts)) in def_ids_with_body.iter().enumerate() {
-                assert!(!body_with_facts.input_facts.as_ref().unwrap().cfg_edge.is_empty());
+                assert!(!body_with_facts
+                    .input_facts
+                    .as_ref()
+                    .unwrap()
+                    .cfg_edge
+                    .is_empty());
                 let body = &body_with_facts.body;
 
                 if num > 0 {

--- a/analysis/src/bin/gen-accessibility-driver.rs
+++ b/analysis/src/bin/gen-accessibility-driver.rs
@@ -6,7 +6,7 @@
 
 use analysis::domains::DefinitelyAccessibleAnalysis;
 use prusti_rustc_interface::{
-    borrowck::BodyWithBorrowckFacts,
+    borrowck::consumers::{self, BodyWithBorrowckFacts},
     data_structures::fx::FxHashMap,
     driver::Compilation,
     hir,
@@ -14,7 +14,7 @@ use prusti_rustc_interface::{
     interface::{interface, Config, Queries},
     middle::{
         ty,
-        ty::query::{query_values::mir_borrowck, ExternProviders, Providers},
+        query::{queries::mir_borrowck::ProvidedValue, ExternProviders, Providers},
     },
     polonius_engine::{Algorithm, Output},
     session::Session,
@@ -69,10 +69,11 @@ mod mir_storage {
 }
 
 #[allow(clippy::needless_lifetimes)]
-fn mir_borrowck<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: LocalDefId) -> mir_borrowck<'tcx> {
-    let body_with_facts = prusti_rustc_interface::borrowck::consumers::get_body_with_borrowck_facts(
+fn mir_borrowck<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: LocalDefId) -> ProvidedValue<'tcx> {
+    let body_with_facts = consumers::get_body_with_borrowck_facts(
         tcx,
-        ty::WithOptConstParam::unknown(def_id),
+        def_id,
+        consumers::ConsumerOptions::PoloniusOutputFacts,
     );
     // SAFETY: This is safe because we are feeding in the same `tcx` that is
     // going to be used as a witness when pulling out the data.
@@ -135,11 +136,11 @@ impl prusti_rustc_interface::driver::Callbacks for OurCompilerCalls {
                     // that was used to store the data.
                     let mut body_with_facts =
                         unsafe { self::mir_storage::retrieve_mir_body(tcx, local_def_id) };
-                    body_with_facts.output_facts = Rc::new(Output::compute(
-                        &body_with_facts.input_facts,
+                    body_with_facts.output_facts = Some(Rc::new(Output::compute(
+                        body_with_facts.input_facts.as_ref().unwrap(),
                         Algorithm::Naive,
                         true,
-                    ));
+                    )));
 
                     // Skip macro expansions
                     let mir_span = body_with_facts.body.span;
@@ -175,7 +176,7 @@ impl prusti_rustc_interface::driver::Callbacks for OurCompilerCalls {
 
             // Generate and print the programs with the additional statements to check accessibility.
             for (num, (local_def_id, body_with_facts)) in def_ids_with_body.iter().enumerate() {
-                assert!(!body_with_facts.input_facts.cfg_edge.is_empty());
+                assert!(!body_with_facts.input_facts.as_ref().unwrap().cfg_edge.is_empty());
                 let body = &body_with_facts.body;
 
                 if num > 0 {

--- a/analysis/src/domains/definitely_accessible/analysis.rs
+++ b/analysis/src/domains/definitely_accessible/analysis.rs
@@ -14,7 +14,7 @@ use crate::{
     PointwiseState,
 };
 use prusti_rustc_interface::{
-    borrowck::BodyWithBorrowckFacts,
+    borrowck::consumers::BodyWithBorrowckFacts,
     data_structures::fx::{FxHashMap, FxHashSet},
     middle::{mir, ty::TyCtxt},
     span::def_id::DefId,
@@ -48,8 +48,8 @@ impl<'mir, 'tcx: 'mir> DefinitelyAccessibleAnalysis<'mir, 'tcx> {
         let borrowed_analysis = MaybeBorrowedAnalysis::new(self.tcx, self.body_with_facts);
         let def_init = def_init_analysis.run_fwd_analysis()?;
         let borrowed = borrowed_analysis.run_analysis()?;
-        let location_table = &self.body_with_facts.location_table;
-        let borrowck_out_facts = self.body_with_facts.output_facts.as_ref();
+        let location_table = self.body_with_facts.location_table.as_ref().unwrap();
+        let borrowck_out_facts = self.body_with_facts.output_facts.as_ref().unwrap().as_ref();
         let var_live_on_entry: FxHashMap<_, _> = borrowck_out_facts
             .var_live_on_entry
             .iter()

--- a/analysis/src/domains/definitely_initialized/state.rs
+++ b/analysis/src/domains/definitely_initialized/state.rs
@@ -261,11 +261,12 @@ impl<'mir, 'tcx: 'mir> DefinitelyInitializedState<'mir, 'tcx> {
                 place,
                 target,
                 unwind,
+                ..
             } => {
                 new_state.set_place_uninitialised(place);
                 res_vec.push((target, new_state));
 
-                if let Some(bb) = unwind {
+                if let mir::UnwindAction::Cleanup(bb) = unwind {
                     // imprecision for error states
                     res_vec.push((bb, Self::new_top(self.def_id, self.mir, self.tcx)));
                 }
@@ -275,7 +276,7 @@ impl<'mir, 'tcx: 'mir> DefinitelyInitializedState<'mir, 'tcx> {
                 ref args,
                 destination,
                 target,
-                cleanup,
+                unwind,
                 ..
             } => {
                 for arg in args.iter() {
@@ -287,7 +288,7 @@ impl<'mir, 'tcx: 'mir> DefinitelyInitializedState<'mir, 'tcx> {
                     res_vec.push((bb, new_state));
                 }
 
-                if let Some(bb) = cleanup {
+                if let mir::UnwindAction::Cleanup(bb) = unwind {
                     // imprecision for error states
                     res_vec.push((bb, Self::new_top(self.def_id, self.mir, self.tcx)));
                 }
@@ -295,13 +296,13 @@ impl<'mir, 'tcx: 'mir> DefinitelyInitializedState<'mir, 'tcx> {
             mir::TerminatorKind::Assert {
                 ref cond,
                 target,
-                cleanup,
+                unwind,
                 ..
             } => {
                 new_state.apply_operand_effect(cond, move_out_copy_types);
                 res_vec.push((target, new_state));
 
-                if let Some(bb) = cleanup {
+                if let mir::UnwindAction::Cleanup(bb) = unwind {
                     // imprecision for error states
                     res_vec.push((bb, Self::new_top(self.def_id, self.mir, self.tcx)));
                 }

--- a/analysis/src/domains/framing/analysis.rs
+++ b/analysis/src/domains/framing/analysis.rs
@@ -11,7 +11,7 @@ use crate::{
     PointwiseState,
 };
 use prusti_rustc_interface::{
-    borrowck::BodyWithBorrowckFacts,
+    borrowck::consumers::BodyWithBorrowckFacts,
     middle::{
         mir,
         mir::visit::{NonMutatingUseContext, PlaceContext, Visitor},

--- a/analysis/src/domains/framing/analysis.rs
+++ b/analysis/src/domains/framing/analysis.rs
@@ -105,7 +105,6 @@ impl<'mir, 'tcx: 'mir> Visitor<'tcx> for ComputeFramingState<'mir, 'tcx> {
     ) {
         let place = (*place).into();
         match context {
-            PlaceContext::NonMutatingUse(NonMutatingUseContext::UniqueBorrow) => todo!(),
             PlaceContext::MutatingUse(_)
             | PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) => {
                 // No permission can be framed

--- a/analysis/src/domains/maybe_borrowed/analysis.rs
+++ b/analysis/src/domains/maybe_borrowed/analysis.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use log::{error, trace};
 use prusti_rustc_interface::{
-    borrowck::{consumers::RichLocation, BodyWithBorrowckFacts},
+    borrowck::consumers::{BodyWithBorrowckFacts, RichLocation},
     data_structures::fx::FxHashMap,
     middle::{mir, ty::TyCtxt},
 };
@@ -33,9 +33,9 @@ impl<'mir, 'tcx: 'mir> MaybeBorrowedAnalysis<'mir, 'tcx> {
         &self,
     ) -> AnalysisResult<PointwiseState<'mir, 'tcx, MaybeBorrowedState<'tcx>>> {
         let body = &self.body_with_facts.body;
-        let location_table = &self.body_with_facts.location_table;
-        let borrowck_in_facts = &self.body_with_facts.input_facts;
-        let borrowck_out_facts = self.body_with_facts.output_facts.as_ref();
+        let location_table = self.body_with_facts.location_table.as_ref().unwrap();
+        let borrowck_in_facts = self.body_with_facts.input_facts.as_ref().unwrap();
+        let borrowck_out_facts = self.body_with_facts.output_facts.as_ref().unwrap().as_ref();
         let loan_issued_at = &borrowck_in_facts.loan_issued_at;
         let loan_live_at = &borrowck_out_facts.loan_live_at;
         let loan_issued_at_location: FxHashMap<_, mir::Location> = loan_issued_at

--- a/analysis/src/domains/reaching_definitions/state.rs
+++ b/analysis/src/domains/reaching_definitions/state.rs
@@ -128,7 +128,7 @@ impl<'mir, 'tcx: 'mir> ReachingDefsState<'mir, 'tcx> {
             mir::TerminatorKind::Call {
                 ref destination,
                 target,
-                cleanup,
+                unwind,
                 ..
             } => {
                 if let Some(bb) = target {
@@ -144,7 +144,7 @@ impl<'mir, 'tcx: 'mir> ReachingDefsState<'mir, 'tcx> {
                     res_vec.push((bb, dest_state));
                 }
 
-                if let Some(bb) = cleanup {
+                if let mir::UnwindAction::Cleanup(bb) = unwind {
                     let mut cleanup_state = self.clone();
                     // error state -> be conservative & add destination as possible reaching def
                     // while keeping all others

--- a/analysis/tests/test_cases/definitely_accessible/expired.stdout
+++ b/analysis/tests/test_cases/definitely_accessible/expired.stdout
@@ -438,7 +438,7 @@ Result for function main():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_1) -> bb6",
+    "terminator: drop(_1) -> [return: bb6, unwind terminate]",
     {
       "bb6": [
         "state:",

--- a/analysis/tests/test_cases/definitely_accessible/fields.rs
+++ b/analysis/tests/test_cases/definitely_accessible/fields.rs
@@ -1,3 +1,5 @@
+#![allow(dropping_references)]
+
 #[derive(Clone, Default)]
 struct T {
     // Wrap in Box to have non-Copy types

--- a/analysis/tests/test_cases/definitely_accessible/fields.stdout
+++ b/analysis/tests/test_cases/definitely_accessible/fields.stdout
@@ -685,7 +685,7 @@ Result for function main():
         "(_1.0: std::boxed::Box<u32>)"
       ]
     },
-    "terminator: drop(_11) -> bb13",
+    "terminator: drop(_11) -> [return: bb13, unwind terminate]",
     {
       "bb13": [
         "state:",
@@ -918,7 +918,7 @@ Result for function main():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_13) -> bb13",
+    "terminator: drop(_13) -> [return: bb13, unwind terminate]",
     {
       "bb13": [
         "state:",
@@ -936,7 +936,7 @@ Result for function main():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_3) -> bb13",
+    "terminator: drop(_3) -> [return: bb13, unwind terminate]",
     {
       "bb13": [
         "state:",
@@ -954,7 +954,7 @@ Result for function main():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_1) -> bb14",
+    "terminator: drop(_1) -> [return: bb14, unwind terminate]",
     {
       "bb14": [
         "state:",

--- a/analysis/tests/test_cases/definitely_accessible/infinite_list.stdout
+++ b/analysis/tests/test_cases/definitely_accessible/infinite_list.stdout
@@ -164,7 +164,7 @@ Result for function test1():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_1) -> bb4",
+    "terminator: drop(_1) -> [return: bb4, unwind terminate]",
     {
       "bb4": [
         "state:",
@@ -316,7 +316,7 @@ Result for function test2():
         "_1"
       ]
     },
-    "terminator: drop(_2) -> bb5",
+    "terminator: drop(_2) -> [return: bb5, unwind terminate]",
     {
       "bb5": [
         "state:",
@@ -412,7 +412,7 @@ Result for function test2():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_1) -> bb6",
+    "terminator: drop(_1) -> [return: bb6, unwind terminate]",
     {
       "bb6": [
         "state:",

--- a/analysis/tests/test_cases/definitely_accessible/ref_field.stdout
+++ b/analysis/tests/test_cases/definitely_accessible/ref_field.stdout
@@ -939,7 +939,7 @@ Result for function main():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_16) -> bb10",
+    "terminator: drop(_16) -> [return: bb10, unwind terminate]",
     {
       "bb10": [
         "state:",
@@ -957,7 +957,7 @@ Result for function main():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_1) -> bb12",
+    "terminator: drop(_1) -> [return: bb12, unwind terminate]",
     {
       "bb12": [
         "state:",
@@ -975,7 +975,7 @@ Result for function main():
       "accessible": [],
       "owned": []
     },
-    "terminator: drop(_2) -> bb12",
+    "terminator: drop(_2) -> [return: bb12, unwind terminate]",
     {
       "bb12": [
         "state:",

--- a/analysis/tests/test_cases/definitely_initialized/array.rs
+++ b/analysis/tests/test_cases/definitely_initialized/array.rs
@@ -1,3 +1,5 @@
+#![allow(dropping_copy_types)]
+
 #[analyzer::run]
 fn main() {
     let x = [1, 2, 3];

--- a/analysis/tests/test_cases/definitely_initialized/array.stdout
+++ b/analysis/tests/test_cases/definitely_initialized/array.stdout
@@ -284,7 +284,7 @@ Result for function main():
     [],
     "state before terminator:",
     [],
-    "terminator: drop(_7) -> bb7",
+    "terminator: drop(_7) -> [return: bb7, unwind terminate]",
     {
       "bb7": [
         "state:",
@@ -296,7 +296,7 @@ Result for function main():
     [],
     "state before terminator:",
     [],
-    "terminator: drop(_4) -> bb8",
+    "terminator: drop(_4) -> [return: bb8, unwind terminate]",
     {
       "bb8": [
         "state:",

--- a/analysis/tests/test_cases/definitely_initialized/fields.rs
+++ b/analysis/tests/test_cases/definitely_initialized/fields.rs
@@ -1,3 +1,5 @@
+#![allow(dropping_references)]
+
 #[derive(Clone, Default)]
 struct T {
     // Wrap in box to have non-Copy types

--- a/analysis/tests/test_cases/definitely_initialized/fields.stdout
+++ b/analysis/tests/test_cases/definitely_initialized/fields.stdout
@@ -478,7 +478,7 @@ Result for function main():
     [
       "(_1.0: std::boxed::Box<u32>)"
     ],
-    "terminator: drop(_11) -> bb13",
+    "terminator: drop(_11) -> [return: bb13, unwind terminate]",
     {
       "bb13": [
         "state:",
@@ -653,7 +653,7 @@ Result for function main():
     [],
     "state before terminator:",
     [],
-    "terminator: drop(_13) -> bb13",
+    "terminator: drop(_13) -> [return: bb13, unwind terminate]",
     {
       "bb13": [
         "state:",
@@ -665,7 +665,7 @@ Result for function main():
     [],
     "state before terminator:",
     [],
-    "terminator: drop(_3) -> bb13",
+    "terminator: drop(_3) -> [return: bb13, unwind terminate]",
     {
       "bb13": [
         "state:",
@@ -677,7 +677,7 @@ Result for function main():
     [],
     "state before terminator:",
     [],
-    "terminator: drop(_1) -> bb14",
+    "terminator: drop(_1) -> [return: bb14, unwind terminate]",
     {
       "bb14": [
         "state:",

--- a/analysis/tests/test_cases/framing/ref_field.stdout
+++ b/analysis/tests/test_cases/framing/ref_field.stdout
@@ -529,7 +529,7 @@ Result for function main():
       "frame_accessible": [],
       "frame_owned": []
     },
-    "terminator: drop(_9) -> bb10",
+    "terminator: drop(_9) -> [return: bb10, unwind terminate]",
     {
       "bb10": [
         "state:",
@@ -547,7 +547,7 @@ Result for function main():
       "frame_accessible": [],
       "frame_owned": []
     },
-    "terminator: drop(_1) -> bb12",
+    "terminator: drop(_1) -> [return: bb12, unwind terminate]",
     {
       "bb12": [
         "state:",
@@ -565,7 +565,7 @@ Result for function main():
       "frame_accessible": [],
       "frame_owned": []
     },
-    "terminator: drop(_2) -> bb12",
+    "terminator: drop(_2) -> [return: bb12, unwind terminate]",
     {
       "bb12": [
         "state:",

--- a/analysis/tests/test_cases/framing/rust_issue_63787.stdout
+++ b/analysis/tests/test_cases/framing/rust_issue_63787.stdout
@@ -350,7 +350,7 @@ Result for function break_it():
       "frame_accessible": [],
       "frame_owned": []
     },
-    "terminator: drop(_7) -> bb8",
+    "terminator: drop(_7) -> [return: bb8, unwind terminate]",
     {
       "bb8": [
         "state:",
@@ -368,7 +368,7 @@ Result for function break_it():
       "frame_accessible": [],
       "frame_owned": []
     },
-    "terminator: drop(_4) -> bb8",
+    "terminator: drop(_4) -> [return: bb8, unwind terminate]",
     {
       "bb8": [
         "state:",
@@ -386,7 +386,7 @@ Result for function break_it():
       "frame_accessible": [],
       "frame_owned": []
     },
-    "terminator: drop(_2) -> bb9",
+    "terminator: drop(_2) -> [return: bb9, unwind terminate]",
     {
       "bb9": [
         "state:",
@@ -688,7 +688,7 @@ Result for function main():
       "frame_accessible": [],
       "frame_owned": []
     },
-    "terminator: drop(_4) -> bb5",
+    "terminator: drop(_4) -> [return: bb5, unwind terminate]",
     {
       "bb5": [
         "state:",

--- a/analysis/tests/test_cases/maybe_borrowed/linked_list.stdout
+++ b/analysis/tests/test_cases/maybe_borrowed/linked_list.stdout
@@ -162,7 +162,7 @@ Result for function borrow_fields():
       "frozen": [],
       "blocked": []
     },
-    "terminator: drop(_1) -> bb4",
+    "terminator: drop(_1) -> [return: bb4, unwind terminate]",
     {
       "bb4": [
         "state:",
@@ -252,7 +252,7 @@ Result for function last_val_mut():
       "frozen": [],
       "blocked": []
     },
-    "terminator: falseUnwind -> [real: bb2, cleanup: bb6]",
+    "terminator: falseUnwind -> [real: bb2, unwind: bb6]",
     {
       "bb2": [
         "state:",

--- a/jni-gen/systest/tests/jvm_builtin_classes.rs
+++ b/jni-gen/systest/tests/jvm_builtin_classes.rs
@@ -10,7 +10,7 @@ fn string_to_jobject<'a>(env: &JNIEnv<'a>, string: &str) -> JNIResult<JObject<'a
     Ok(JObject::from(env.new_string(string.to_owned())?))
 }
 
-fn jobject_to_string<'a>(env: &JNIEnv<'a>, obj: JObject) -> JNIResult<String> {
+fn jobject_to_string(env: &JNIEnv<'_>, obj: JObject) -> JNIResult<String> {
     Ok(String::from(env.get_string(JString::from(obj))?))
 }
 

--- a/prusti-common/Cargo.toml
+++ b/prusti-common/Cargo.toml
@@ -13,7 +13,7 @@ viper = { path = "../viper" }
 vir = { path = "../vir" }
 log = { version = "0.4", features = ["release_max_level_info"] }
 config = "0.13"
-itertools = "0.10.3"
+itertools = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4.0"
 uuid = { version = "1.0", features = ["v4"] }

--- a/prusti-contracts/Cargo.toml
+++ b/prusti-contracts/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "prusti-specs",
     "prusti-std",
 ]
+resolver = "2"
 
 # This should not be built as part of Prusti (instead being build by `prusti-contracts-build`)
 # It would require setting the `build.rustc-wrapper` in a `../.cargo/config.toml` correctly

--- a/prusti-contracts/prusti-contracts-proc-macros/Cargo.toml
+++ b/prusti-contracts/prusti-contracts-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-contracts-proc-macros"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -15,7 +15,7 @@ categories = ["development-tools", "development-tools::testing"]
 proc-macro = true
 
 [dependencies]
-prusti-specs = { path = "../prusti-specs", version = "0.1.8", optional = true }
+prusti-specs = { path = "../prusti-specs", version = "0.1.9", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 
 [features]

--- a/prusti-contracts/prusti-contracts/Cargo.toml
+++ b/prusti-contracts/prusti-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-contracts"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -12,7 +12,7 @@ keywords = ["prusti", "contracts", "verification", "formal", "specifications"]
 categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
-prusti-contracts-proc-macros = { path = "../prusti-contracts-proc-macros", version = "0.1.8" }
+prusti-contracts-proc-macros = { path = "../prusti-contracts-proc-macros", version = "0.1.9" }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/prusti-contracts/prusti-contracts/tests/pass/true.rs
+++ b/prusti-contracts/prusti-contracts/tests/pass/true.rs
@@ -3,7 +3,6 @@
 
 // These feature flags are not needed when executing under Prusti
 // because it generates them for us.
-#![cfg_attr(feature = "prusti", feature(type_ascription))]
 #![cfg_attr(feature = "prusti", feature(register_tool))]
 #![cfg_attr(feature = "prusti", register_tool(prusti))]
 

--- a/prusti-contracts/prusti-specs/Cargo.toml
+++ b/prusti-contracts/prusti-specs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-specs"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/prusti-contracts/prusti-specs/Cargo.toml
+++ b/prusti-contracts/prusti-specs/Cargo.toml
@@ -19,5 +19,5 @@ syn = { version = "1.0", features = ["full", "extra-traits", "visit", "visit-mut
 quote = "1.0"
 proc-macro2 = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
-itertools = "0.10.3"
+itertools = "0.11"
 rustc-hash = "1.1.0"

--- a/prusti-contracts/prusti-specs/src/extern_spec_rewriter/impls.rs
+++ b/prusti-contracts/prusti-specs/src/extern_spec_rewriter/impls.rs
@@ -192,11 +192,11 @@ mod tests {
 
         #[test]
         fn generated_struct() {
-            let mut inp_impl: syn::ItemImpl = parse_quote!(
+            let inp_impl: syn::ItemImpl = parse_quote!(
                 impl<'a, const CONST: i32, T> MyStruct<'a, CONST, T> {}
             );
 
-            let rewritten = rewrite_extern_spec_internal(&mut inp_impl).unwrap();
+            let rewritten = rewrite_extern_spec_internal(&inp_impl).unwrap();
 
             let struct_ident = &rewritten.generated_struct.ident;
             let expected: syn::ItemStruct = parse_quote! {
@@ -212,7 +212,7 @@ mod tests {
 
         #[test]
         fn impl_no_generics() {
-            let mut inp_impl: syn::ItemImpl = parse_quote!(
+            let inp_impl: syn::ItemImpl = parse_quote!(
                 impl MyStruct {
                     fn foo(&self);
                     fn bar(&mut self);
@@ -220,7 +220,7 @@ mod tests {
                 }
             );
 
-            let rewritten = rewrite_extern_spec_internal(&mut inp_impl).unwrap();
+            let rewritten = rewrite_extern_spec_internal(&inp_impl).unwrap();
 
             let newtype_ident = &rewritten.generated_struct.ident;
             let expected: syn::ItemImpl = parse_quote! {
@@ -251,13 +251,13 @@ mod tests {
 
         #[test]
         fn impl_generics() {
-            let mut inp_impl: syn::ItemImpl = parse_quote!(
+            let inp_impl: syn::ItemImpl = parse_quote!(
                 impl<I, O> MyStruct<I, O, i32> {
                     fn foo(&self, arg1: I, arg2: i32) -> O;
                 }
             );
 
-            let rewritten = rewrite_extern_spec_internal(&mut inp_impl).unwrap();
+            let rewritten = rewrite_extern_spec_internal(&inp_impl).unwrap();
 
             let newtype_ident = &rewritten.generated_struct.ident;
             let expected: syn::ItemImpl = parse_quote! {
@@ -276,13 +276,13 @@ mod tests {
 
         #[test]
         fn impl_forwarded_generics() {
-            let mut inp_impl: syn::ItemImpl = parse_quote!(
+            let inp_impl: syn::ItemImpl = parse_quote!(
                 impl MyStruct {
                     fn foo<T: Copy>(&self) -> bool;
                 }
             );
 
-            let rewritten = rewrite_extern_spec_internal(&mut inp_impl).unwrap();
+            let rewritten = rewrite_extern_spec_internal(&inp_impl).unwrap();
 
             let newtype_ident = &rewritten.generated_struct.ident;
             let expected: syn::ItemImpl = parse_quote! {
@@ -305,13 +305,13 @@ mod tests {
 
         #[test]
         fn associated_types() {
-            let mut inp_impl: syn::ItemImpl = parse_quote!(
+            let inp_impl: syn::ItemImpl = parse_quote!(
                 impl MyTrait for MyStruct {
                     fn foo(&mut self) -> Self::Result;
                 }
             );
 
-            let rewritten = rewrite_extern_spec_internal(&mut inp_impl).unwrap();
+            let rewritten = rewrite_extern_spec_internal(&inp_impl).unwrap();
 
             let newtype_ident = &rewritten.generated_struct.ident;
             let expected_impl: syn::ItemImpl = parse_quote! {
@@ -330,13 +330,13 @@ mod tests {
 
         #[test]
         fn generic_trait() {
-            let mut inp_impl: syn::ItemImpl = parse_quote!(
+            let inp_impl: syn::ItemImpl = parse_quote!(
                 impl MyTrait<Foo> for MyStruct {
                     fn foo(&mut self, arg1: Foo);
                 }
             );
 
-            let rewritten = rewrite_extern_spec_internal(&mut inp_impl).unwrap();
+            let rewritten = rewrite_extern_spec_internal(&inp_impl).unwrap();
 
             let newtype_ident = &rewritten.generated_struct.ident;
             let expected_impl: syn::ItemImpl = parse_quote! {
@@ -355,13 +355,13 @@ mod tests {
 
         #[test]
         fn generic_blanket_impl() {
-            let mut inp_impl: syn::ItemImpl = parse_quote!(
+            let inp_impl: syn::ItemImpl = parse_quote!(
                 impl<I> MyTrait<I> for MyStruct {
                     fn foo(&mut self, arg1: I);
                 }
             );
 
-            let rewritten = rewrite_extern_spec_internal(&mut inp_impl).unwrap();
+            let rewritten = rewrite_extern_spec_internal(&inp_impl).unwrap();
 
             let newtype_ident = &rewritten.generated_struct.ident;
             let expected_impl: syn::ItemImpl = parse_quote! {

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -737,7 +737,7 @@ pub fn invariant(attr: TokenStream, tokens: TokenStream) -> TokenStream {
         #[prusti::type_invariant_spec]
         #[prusti::spec_id = #spec_id_str]
         fn #item_name(self) -> bool {
-            !!((#attr) : bool)
+            !!(#attr)
         }
     };
 

--- a/prusti-contracts/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/preparser.rs
@@ -722,8 +722,8 @@ fn translate_spec_ent(
         specification_entailment(
             #once,
             __cl_ref,
-            ( #( #[prusti::spec_only] || -> bool { ((#preconds): bool) }, )* ),
-            ( #( #[prusti::spec_only] || -> bool { ((#postconds): bool) }, )* ),
+            ( #( #[prusti::spec_only] || -> bool { #preconds }, )* ),
+            ( #( #[prusti::spec_only] || -> bool { #postconds }, )* ),
         )
     } }
 }
@@ -753,7 +753,7 @@ impl Quantifier {
                 quote_spanned! { full_span => ( #triggers ) }
             })
             .collect::<Vec<_>>();
-        let body = quote_spanned! { body.span() => ((#body): bool) };
+        let body = quote_spanned! { body.span() => #body };
         match self {
             Self::Forall => quote_spanned! { full_span => ::prusti_contracts::forall(
                 ( #( #trigger_sets, )* ),
@@ -1089,15 +1089,15 @@ mod tests {
             parse_prusti("forall(|x: i32| a ==> b)".parse().unwrap())
                 .unwrap()
                 .to_string(),
-            ":: prusti_contracts :: forall (() , # [prusti :: spec_only] | x : i32 | -> bool { ((! (a) || (b)) : bool) })",
+            ":: prusti_contracts :: forall (() , # [prusti :: spec_only] | x : i32 | -> bool { ! (a) || (b) })",
         );
         assert_eq!(
             parse_prusti("exists(|x: i32| a === b)".parse().unwrap()).unwrap().to_string(),
-            ":: prusti_contracts :: exists (() , # [prusti :: spec_only] | x : i32 | -> bool { ((snapshot_equality (& (a) , & (b))) : bool) })",
+            ":: prusti_contracts :: exists (() , # [prusti :: spec_only] | x : i32 | -> bool { snapshot_equality (& (a) , & (b)) })",
         );
         assert_eq!(
             parse_prusti("forall(|x: i32| a ==> b, triggers = [(c,), (d, e)])".parse().unwrap()).unwrap().to_string(),
-            ":: prusti_contracts :: forall (((# [prusti :: spec_only] | x : i32 | (c) ,) , (# [prusti :: spec_only] | x : i32 | (d) , # [prusti :: spec_only] | x : i32 | (e) ,) ,) , # [prusti :: spec_only] | x : i32 | -> bool { ((! (a) || (b)) : bool) })",
+            ":: prusti_contracts :: forall (((# [prusti :: spec_only] | x : i32 | (c) ,) , (# [prusti :: spec_only] | x : i32 | (d) , # [prusti :: spec_only] | x : i32 | (e) ,) ,) , # [prusti :: spec_only] | x : i32 | -> bool { ! (a) || (b) })",
         );
         assert_eq!(
             parse_prusti("assert!(a === b ==> b)".parse().unwrap())

--- a/prusti-contracts/prusti-std/Cargo.toml
+++ b/prusti-contracts/prusti-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusti-std"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -12,7 +12,7 @@ keywords = ["prusti", "contracts", "verification", "formal", "specifications"]
 categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
-prusti-contracts = { path = "../prusti-contracts", version = "0.1.8" }
+prusti-contracts = { path = "../prusti-contracts", version = "0.1.9" }
 
 # Forward "prusti" flag
 [features]

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -139,10 +139,7 @@ impl<'tcx> EnvBody<'tcx> {
     /// Get local MIR body of spec or pure functions. Retrieves the body from
     /// the compiler (relatively cheap).
     fn load_local_mir(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> MirBody<'tcx> {
-        let body = tcx
-            .mir_promoted(ty::WithOptConstParam::unknown(def_id))
-            .0
-            .borrow();
+        let body = tcx.mir_promoted(def_id).0.borrow();
         MirBody(Rc::new(body.clone()))
     }
 

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -169,9 +169,13 @@ impl<'tcx> EnvBody<'tcx> {
             let monomorphised = if let Some(caller_def_id) = caller_def_id {
                 let param_env = self.tcx.param_env(caller_def_id);
                 self.tcx
-                    .subst_and_normalize_erasing_regions(substs, param_env, body.0)
+                    .subst_and_normalize_erasing_regions(
+                        substs,
+                        param_env,
+                        ty::EarlyBinder::bind(body.0),
+                    )
             } else {
-                ty::EarlyBinder(body.0).subst(self.tcx, substs)
+                ty::EarlyBinder::bind(body.0).subst(self.tcx, substs)
             };
             v.insert(MirBody(monomorphised)).clone()
         } else {

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -125,9 +125,9 @@ impl<'tcx> EnvBody<'tcx> {
         let body_with_facts = unsafe { mir_storage::retrieve_mir_body(tcx, def_id) };
 
         let facts = BorrowckFacts {
-            input_facts: RefCell::new(Some(body_with_facts.input_facts)),
-            output_facts: body_with_facts.output_facts,
-            location_table: RefCell::new(Some(body_with_facts.location_table)),
+            input_facts: RefCell::new(body_with_facts.input_facts.map(|f| *f)),
+            output_facts: body_with_facts.output_facts.unwrap(),
+            location_table: RefCell::new(body_with_facts.location_table),
         };
 
         BodyWithBorrowckFacts {

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -130,7 +130,7 @@ impl<'tcx> EnvBody<'tcx> {
 
         let facts = BorrowckFacts {
             input_facts: RefCell::new(body_with_facts.input_facts.map(|f| *f)),
-            output_facts: body_with_facts.output_facts.unwrap(),
+            output_facts: body_with_facts.output_facts,
             location_table: RefCell::new(body_with_facts.location_table),
         };
 

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -143,8 +143,10 @@ impl<'tcx> EnvBody<'tcx> {
     /// Get local MIR body of spec or pure functions. Retrieves the body from
     /// the compiler (relatively cheap).
     fn load_local_mir(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> MirBody<'tcx> {
-        // Throw away the borrowck facts
-        Self::load_local_mir_with_facts(tcx, def_id).body
+        // SAFETY: This is safe because we are feeding in the same `tcx`
+        // that was used to store the data.
+        let body = unsafe { mir_storage::retrieve_promoted_mir_body(tcx, def_id) };
+        MirBody(Rc::new(body))
     }
 
     fn get_monomorphised(

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -1,4 +1,3 @@
-use prusti_common::config;
 use prusti_rustc_interface::{
     macros::{TyDecodable, TyEncodable},
     middle::{
@@ -321,15 +320,11 @@ impl<'tcx> EnvBody<'tcx> {
 
     pub(crate) fn load_pure_fn_body(&mut self, def_id: LocalDefId) {
         assert!(!self.pure_fns.local.contains_key(&def_id));
-        if config::no_verify() {
-            let body = Self::load_local_mir(self.tcx, def_id);
-            self.pure_fns.local.insert(def_id, body);
-        } else {
-            let bwbf = Self::load_local_mir_with_facts(self.tcx, def_id);
-            self.pure_fns.local.insert(def_id, bwbf.body.clone());
-            // Also add to `impure_fns` since we'll also be encoding this as impure
-            self.local_impure_fns.borrow_mut().insert(def_id, bwbf);
-        }
+        let body = Self::load_local_mir(self.tcx, def_id);
+        self.pure_fns.local.insert(def_id, body);
+        let bwbf = Self::load_local_mir_with_facts(self.tcx, def_id);
+        // Also add to `impure_fns` since we'll also be encoding this as impure
+        self.local_impure_fns.borrow_mut().insert(def_id, bwbf);
     }
 
     pub(crate) fn load_closure_body(&mut self, def_id: LocalDefId) {

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -199,11 +199,18 @@ impl<'tcx> EnvBody<'tcx> {
 
     /// Get the MIR body of a local impure function, monomorphised
     /// with the given type substitutions.
+    ///
+    /// FIXME: This function is called only in pure contexts???
     pub fn get_impure_fn_body(&self, def_id: LocalDefId, substs: SubstsRef<'tcx>) -> MirBody<'tcx> {
         if let Some(body) = self.get_monomorphised(def_id.to_def_id(), substs, None) {
             return body;
         }
-        let body = self.get_impure_fn_body_identity(def_id);
+        // let body = self.get_impure_fn_body_identity(def_id);
+        let body = if let Some(body) = self.pure_fns.local.get(&def_id) {
+            body.clone()
+        } else {
+            Self::load_local_mir(self.tcx, def_id)
+        };
         self.set_monomorphised(def_id.to_def_id(), substs, None, body)
     }
 

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -168,12 +168,11 @@ impl<'tcx> EnvBody<'tcx> {
         {
             let monomorphised = if let Some(caller_def_id) = caller_def_id {
                 let param_env = self.tcx.param_env(caller_def_id);
-                self.tcx
-                    .subst_and_normalize_erasing_regions(
-                        substs,
-                        param_env,
-                        ty::EarlyBinder::bind(body.0),
-                    )
+                self.tcx.subst_and_normalize_erasing_regions(
+                    substs,
+                    param_env,
+                    ty::EarlyBinder::bind(body.0),
+                )
             } else {
                 ty::EarlyBinder::bind(body.0).subst(self.tcx, substs)
             };

--- a/prusti-interface/src/environment/borrowck/facts.rs
+++ b/prusti-interface/src/environment/borrowck/facts.rs
@@ -36,7 +36,7 @@ pub struct BorrowckFacts {
     /// Polonius input facts.
     pub input_facts: RefCell<Option<AllInputFacts>>,
     /// Polonius output facts.
-    pub output_facts: Rc<AllOutputFacts>,
+    pub output_facts: Option<Rc<AllOutputFacts>>,
     /// The table that maps Polonius points to locations in the table.
     pub location_table: RefCell<Option<LocationTable>>,
 }

--- a/prusti-interface/src/environment/debug_utils/to_text.rs
+++ b/prusti-interface/src/environment/debug_utils/to_text.rs
@@ -68,7 +68,7 @@ impl ToText for prusti_rustc_interface::middle::ty::BoundRegionKind {
     fn to_text(&self) -> String {
         match self {
             prusti_rustc_interface::middle::ty::BoundRegionKind::BrAnon(_) => {
-                format!("lft_br_anon")
+                "lft_br_anon".to_string()
             }
             prusti_rustc_interface::middle::ty::BoundRegionKind::BrNamed(_, name) => {
                 format!("lft_br_named_{name}")

--- a/prusti-interface/src/environment/debug_utils/to_text.rs
+++ b/prusti-interface/src/environment/debug_utils/to_text.rs
@@ -67,8 +67,8 @@ impl ToText
 impl ToText for prusti_rustc_interface::middle::ty::BoundRegionKind {
     fn to_text(&self) -> String {
         match self {
-            prusti_rustc_interface::middle::ty::BoundRegionKind::BrAnon(id, _) => {
-                format!("lft_br_anon_{id}")
+            prusti_rustc_interface::middle::ty::BoundRegionKind::BrAnon(_) => {
+                format!("lft_br_anon")
             }
             prusti_rustc_interface::middle::ty::BoundRegionKind::BrNamed(_, name) => {
                 format!("lft_br_named_{name}")

--- a/prusti-interface/src/environment/diagnostic.rs
+++ b/prusti-interface/src/environment/diagnostic.rs
@@ -44,7 +44,7 @@ impl<'tcx> EnvDiagnostic<'tcx> {
         help: &Option<String>,
         notes: &[(String, Option<S>)],
     ) {
-        let mut diagnostic = self.tcx.sess.struct_err(msg);
+        let mut diagnostic = self.tcx.sess.struct_err(msg.to_string());
         Self::configure_diagnostic(&mut diagnostic, sp, help, notes);
         for warn in self.warn_buffer.borrow_mut().iter_mut() {
             self.tcx.sess.diagnostic().emit_diagnostic(warn);
@@ -60,7 +60,7 @@ impl<'tcx> EnvDiagnostic<'tcx> {
         help: &Option<String>,
         notes: &[(String, Option<S>)],
     ) {
-        let mut diagnostic = self.tcx.sess.struct_warn(msg);
+        let mut diagnostic = self.tcx.sess.struct_warn(msg.to_string());
         Self::configure_diagnostic(&mut diagnostic, sp, help, notes);
         diagnostic.emit();
     }
@@ -73,7 +73,7 @@ impl<'tcx> EnvDiagnostic<'tcx> {
         help: &Option<String>,
         notes: &[(String, Option<S>)],
     ) {
-        let mut diagnostic = self.tcx.sess.struct_warn(msg);
+        let mut diagnostic = self.tcx.sess.struct_warn(msg.to_string());
         Self::configure_diagnostic(&mut diagnostic, sp, help, notes);
         diagnostic.buffer(&mut self.warn_buffer.borrow_mut());
     }

--- a/prusti-interface/src/environment/diagnostic.rs
+++ b/prusti-interface/src/environment/diagnostic.rs
@@ -25,13 +25,13 @@ impl<'tcx> EnvDiagnostic<'tcx> {
     ) {
         diagnostic.set_span(sp);
         if let Some(help_msg) = help {
-            diagnostic.help(help_msg);
+            diagnostic.help(help_msg.clone());
         }
         for (note_msg, opt_note_sp) in notes {
             if let Some(note_sp) = opt_note_sp {
-                diagnostic.span_note(note_sp.clone(), note_msg);
+                diagnostic.span_note(note_sp.clone(), note_msg.clone());
             } else {
-                diagnostic.note(note_msg);
+                diagnostic.note(note_msg.clone());
             }
         }
     }

--- a/prusti-interface/src/environment/loops.rs
+++ b/prusti-interface/src/environment/loops.rs
@@ -32,8 +32,7 @@ fn collect_loop_body(
 ) {
     let mut work_queue = vec![back_edge_source];
     body.insert(back_edge_source);
-    while !work_queue.is_empty() {
-        let current = work_queue.pop().unwrap();
+    while let Some(current) = work_queue.pop() {
         for &predecessor in real_edges.predecessors(current).iter() {
             if body.contains(&predecessor) {
                 continue;

--- a/prusti-interface/src/environment/loops.rs
+++ b/prusti-interface/src/environment/loops.rs
@@ -123,6 +123,7 @@ impl<'b, 'tcx> Visitor<'tcx> for AccessCollector<'b, 'tcx> {
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Copy) => PlaceAccessKind::Read,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Move) => PlaceAccessKind::Move,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Inspect) => PlaceAccessKind::Read,
+                NonMutatingUse(mir::visit::NonMutatingUseContext::PlaceMention) => PlaceAccessKind::Read,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::SharedBorrow) => {
                     PlaceAccessKind::SharedBorrow
                 }

--- a/prusti-interface/src/environment/loops.rs
+++ b/prusti-interface/src/environment/loops.rs
@@ -11,7 +11,7 @@ use crate::{
 use log::{debug, trace};
 use prusti_rustc_interface::{
     data_structures::graph::dominators::Dominators,
-    index::vec::{Idx, IndexVec},
+    index::{Idx, IndexVec},
     middle::{mir, mir::visit::Visitor},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -257,7 +257,7 @@ pub type ReadAndWriteLeaves<'tcx> = (
 impl ProcedureLoops {
     #[tracing::instrument(name = "ProcedureLoops::new", level = "trace", skip(mir, real_edges))]
     pub fn new<'a, 'tcx: 'a>(mir: &'a mir::Body<'tcx>, real_edges: &RealEdges) -> ProcedureLoops {
-        let dominators = mir.basic_blocks.dominators();
+        let dominators = mir.basic_blocks.dominators().clone();
 
         let mut back_edges: FxHashSet<(_, _)> = FxHashSet::default();
         for bb in mir.basic_blocks.indices() {

--- a/prusti-interface/src/environment/loops.rs
+++ b/prusti-interface/src/environment/loops.rs
@@ -123,7 +123,9 @@ impl<'b, 'tcx> Visitor<'tcx> for AccessCollector<'b, 'tcx> {
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Copy) => PlaceAccessKind::Read,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Move) => PlaceAccessKind::Move,
                 NonMutatingUse(mir::visit::NonMutatingUseContext::Inspect) => PlaceAccessKind::Read,
-                NonMutatingUse(mir::visit::NonMutatingUseContext::PlaceMention) => PlaceAccessKind::Read,
+                NonMutatingUse(mir::visit::NonMutatingUseContext::PlaceMention) => {
+                    PlaceAccessKind::Read
+                }
                 NonMutatingUse(mir::visit::NonMutatingUseContext::SharedBorrow) => {
                     PlaceAccessKind::SharedBorrow
                 }

--- a/prusti-interface/src/environment/mir_body/borrowck/facts/patch.rs
+++ b/prusti-interface/src/environment/mir_body/borrowck/facts/patch.rs
@@ -178,7 +178,7 @@ pub fn apply_patch_to_borrowck<'tcx>(
                 }
                 mir::TerminatorKind::Drop { target, unwind, .. } => {
                     let mut target_points = vec![lt_patcher.start_point(target.index(), 0)];
-                    if let Some(unwind) = unwind {
+                    if let mir::UnwindAction::Cleanup(unwind) = unwind {
                         target_points.push(lt_patcher.start_point(unwind.index(), 0));
                     }
                     assert!(cfg_edges

--- a/prusti-interface/src/environment/mir_body/dead_blocks.rs
+++ b/prusti-interface/src/environment/mir_body/dead_blocks.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::{
-    index::{bit_set::BitSet, vec::Idx},
+    index::{bit_set::BitSet, Idx},
     middle::mir,
 };
 use std::collections::BTreeMap;

--- a/prusti-interface/src/environment/mir_body/graphviz.rs
+++ b/prusti-interface/src/environment/mir_body/graphviz.rs
@@ -176,8 +176,8 @@ fn visit_terminator(graph: &mut Graph, bb: mir::BasicBlock, terminator: &mir::Te
         TerminatorKind::Resume => {
             graph.add_exit_edge(bb.to_text(), "resume".to_text());
         }
-        TerminatorKind::Abort => {
-            graph.add_exit_edge(bb.to_text(), "abort".to_text());
+        TerminatorKind::Terminate => {
+            graph.add_exit_edge(bb.to_text(), "terminate".to_text());
         }
         TerminatorKind::Return => {
             graph.add_exit_edge(bb.to_text(), "return".to_text());
@@ -187,25 +187,25 @@ fn visit_terminator(graph: &mut Graph, bb: mir::BasicBlock, terminator: &mir::Te
         }
         TerminatorKind::Drop { target, unwind, .. } => {
             graph.add_regular_edge(bb.to_text(), target.to_text());
-            if let Some(target) = unwind {
+            if let mir::UnwindAction::Cleanup(target) = unwind {
                 graph.add_unwind_edge(bb.to_text(), target.to_text());
             }
         }
         TerminatorKind::Call {
-            target, cleanup, ..
+            target, unwind, ..
         } => {
             if let Some(target) = target {
                 graph.add_regular_edge(bb.to_text(), target.to_text());
             }
-            if let Some(target) = cleanup {
+            if let mir::UnwindAction::Cleanup(target) = unwind {
                 graph.add_unwind_edge(bb.to_text(), target.to_text());
             }
         }
         TerminatorKind::Assert {
-            target, cleanup, ..
+            target, unwind, ..
         } => {
             graph.add_regular_edge(bb.to_text(), target.to_text());
-            if let Some(target) = cleanup {
+            if let mir::UnwindAction::Cleanup(target) = unwind {
                 graph.add_unwind_edge(bb.to_text(), target.to_text());
             }
         }
@@ -227,7 +227,7 @@ fn visit_terminator(graph: &mut Graph, bb: mir::BasicBlock, terminator: &mir::Te
             unwind,
         } => {
             graph.add_regular_edge(bb.to_text(), real_target.to_text());
-            if let Some(imaginary_target) = unwind {
+            if let mir::UnwindAction::Cleanup(imaginary_target) = unwind {
                 graph.add_imaginary_edge(bb.to_text(), imaginary_target.to_text());
             }
         }

--- a/prusti-interface/src/environment/mir_body/graphviz.rs
+++ b/prusti-interface/src/environment/mir_body/graphviz.rs
@@ -191,9 +191,7 @@ fn visit_terminator(graph: &mut Graph, bb: mir::BasicBlock, terminator: &mir::Te
                 graph.add_unwind_edge(bb.to_text(), target.to_text());
             }
         }
-        TerminatorKind::Call {
-            target, unwind, ..
-        } => {
+        TerminatorKind::Call { target, unwind, .. } => {
             if let Some(target) = target {
                 graph.add_regular_edge(bb.to_text(), target.to_text());
             }
@@ -201,9 +199,7 @@ fn visit_terminator(graph: &mut Graph, bb: mir::BasicBlock, terminator: &mir::Te
                 graph.add_unwind_edge(bb.to_text(), target.to_text());
             }
         }
-        TerminatorKind::Assert {
-            target, unwind, ..
-        } => {
+        TerminatorKind::Assert { target, unwind, .. } => {
             graph.add_regular_edge(bb.to_text(), target.to_text());
             if let mir::UnwindAction::Cleanup(target) = unwind {
                 graph.add_unwind_edge(bb.to_text(), target.to_text());

--- a/prusti-interface/src/environment/mir_body/patch/compiler.rs
+++ b/prusti-interface/src/environment/mir_body/patch/compiler.rs
@@ -12,7 +12,7 @@
 
 use log::debug;
 use prusti_rustc_interface::{
-    index::vec::{Idx, IndexVec},
+    index::{Idx, IndexVec},
     middle::{mir::*, ty::Ty},
     span::Span,
 };

--- a/prusti-interface/src/environment/mir_body/patch/compiler.rs
+++ b/prusti-interface/src/environment/mir_body/patch/compiler.rs
@@ -134,7 +134,10 @@ impl<'tcx> MirPatch<'tcx> {
             Some(index) => self.new_blocks[index].statements.len(),
             None => body[bb].statements.len(),
         };
-        Location { block: bb, statement_index: offset }
+        Location {
+            block: bb,
+            statement_index: offset,
+        }
     }
 
     pub fn new_internal_with_info(
@@ -224,12 +227,19 @@ impl<'tcx> MirPatch<'tcx> {
                 delta = 0;
                 last_bb = loc.block;
             }
-            debug!("MirPatch: adding statement {:?} at loc {:?}+{}", stmt, loc, delta);
+            debug!(
+                "MirPatch: adding statement {:?} at loc {:?}+{}",
+                stmt, loc, delta
+            );
             loc.statement_index += delta;
             let source_info = Self::source_info_for_index(&body[loc.block], loc);
-            body[loc.block]
-                .statements
-                .insert(loc.statement_index, Statement { source_info, kind: stmt });
+            body[loc.block].statements.insert(
+                loc.statement_index,
+                Statement {
+                    source_info,
+                    kind: stmt,
+                },
+            );
             delta += 1;
         }
     }

--- a/prusti-interface/src/environment/mir_body/patch/compiler.rs
+++ b/prusti-interface/src/environment/mir_body/patch/compiler.rs
@@ -26,7 +26,11 @@ pub struct MirPatch<'tcx> {
     pub new_blocks: Vec<BasicBlockData<'tcx>>,
     pub new_statements: Vec<(Location, StatementKind<'tcx>)>,
     pub new_locals: Vec<LocalDecl<'tcx>>,
-    pub resume_block: BasicBlock,
+    pub resume_block: Option<BasicBlock>,
+    // Only for unreachable in cleanup path.
+    pub unreachable_cleanup_block: Option<BasicBlock>,
+    pub terminate_block: Option<BasicBlock>,
+    pub body_span: Span,
     pub next_local: usize,
 }
 
@@ -38,51 +42,87 @@ impl<'tcx> MirPatch<'tcx> {
             new_statements: vec![],
             new_locals: vec![],
             next_local: body.local_decls.len(),
-            resume_block: START_BLOCK,
+            resume_block: None,
+            unreachable_cleanup_block: None,
+            terminate_block: None,
+            body_span: body.span,
         };
 
-        // make sure the MIR we create has a resume block. It is
-        // completely legal to convert jumps to the resume block
-        // to jumps to None, but we occasionally have to add
-        // instructions just before that.
-
-        let mut resume_block = None;
-        let mut resume_stmt_block = None;
         for (bb, block) in body.basic_blocks.iter_enumerated() {
-            if let TerminatorKind::Resume = block.terminator().kind {
-                if !block.statements.is_empty() {
-                    assert!(resume_stmt_block.is_none());
-                    resume_stmt_block = Some(bb);
-                } else {
-                    resume_block = Some(bb);
-                }
-                break;
+            // Check if we already have a resume block
+            if let TerminatorKind::Resume = block.terminator().kind && block.statements.is_empty() {
+                result.resume_block = Some(bb);
+                continue;
+            }
+
+            // Check if we already have an unreachable block
+            if let TerminatorKind::Unreachable = block.terminator().kind
+                && block.statements.is_empty()
+                && block.is_cleanup
+            {
+                result.unreachable_cleanup_block = Some(bb);
+                continue;
+            }
+
+            // Check if we already have a terminate block
+            if let TerminatorKind::Terminate = block.terminator().kind && block.statements.is_empty() {
+                result.terminate_block = Some(bb);
+                continue;
             }
         }
-        let resume_block = resume_block.unwrap_or_else(|| {
-            result.new_block(BasicBlockData {
-                statements: vec![],
-                terminator: Some(Terminator {
-                    source_info: SourceInfo::outermost(body.span),
-                    kind: TerminatorKind::Resume,
-                }),
-                is_cleanup: true,
-            })
-        });
-        result.resume_block = resume_block;
-        if let Some(resume_stmt_block) = resume_stmt_block {
-            result.patch_terminator(
-                resume_stmt_block,
-                TerminatorKind::Goto {
-                    target: resume_block,
-                },
-            );
-        }
+
         result
     }
 
-    pub fn resume_block(&self) -> BasicBlock {
-        self.resume_block
+    pub fn resume_block(&mut self) -> BasicBlock {
+        if let Some(bb) = self.resume_block {
+            return bb;
+        }
+
+        let bb = self.new_block(BasicBlockData {
+            statements: vec![],
+            terminator: Some(Terminator {
+                source_info: SourceInfo::outermost(self.body_span),
+                kind: TerminatorKind::Resume,
+            }),
+            is_cleanup: true,
+        });
+        self.resume_block = Some(bb);
+        bb
+    }
+
+    pub fn unreachable_cleanup_block(&mut self) -> BasicBlock {
+        if let Some(bb) = self.unreachable_cleanup_block {
+            return bb;
+        }
+
+        let bb = self.new_block(BasicBlockData {
+            statements: vec![],
+            terminator: Some(Terminator {
+                source_info: SourceInfo::outermost(self.body_span),
+                kind: TerminatorKind::Unreachable,
+            }),
+            is_cleanup: true,
+        });
+        self.unreachable_cleanup_block = Some(bb);
+        bb
+    }
+
+    pub fn terminate_block(&mut self) -> BasicBlock {
+        if let Some(bb) = self.terminate_block {
+            return bb;
+        }
+
+        let bb = self.new_block(BasicBlockData {
+            statements: vec![],
+            terminator: Some(Terminator {
+                source_info: SourceInfo::outermost(self.body_span),
+                kind: TerminatorKind::Terminate,
+            }),
+            is_cleanup: true,
+        });
+        self.terminate_block = Some(bb);
+        bb
     }
 
     pub fn is_patched(&self, bb: BasicBlock) -> bool {
@@ -94,10 +134,21 @@ impl<'tcx> MirPatch<'tcx> {
             Some(index) => self.new_blocks[index].statements.len(),
             None => body[bb].statements.len(),
         };
-        Location {
-            block: bb,
-            statement_index: offset,
-        }
+        Location { block: bb, statement_index: offset }
+    }
+
+    pub fn new_internal_with_info(
+        &mut self,
+        ty: Ty<'tcx>,
+        span: Span,
+        local_info: LocalInfo<'tcx>,
+    ) -> Local {
+        let index = self.next_local;
+        self.next_local += 1;
+        let mut new_decl = LocalDecl::new(ty, span).internal();
+        **new_decl.local_info.as_mut().assert_crate_local() = local_info;
+        self.new_locals.push(new_decl);
+        Local::new(index)
     }
 
     pub fn new_temp(&mut self, ty: Ty<'tcx>, span: Span) -> Local {
@@ -114,7 +165,6 @@ impl<'tcx> MirPatch<'tcx> {
         Local::new(index)
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
     pub fn new_block(&mut self, data: BasicBlockData<'tcx>) -> BasicBlock {
         let block = BasicBlock::new(self.patch_map.len());
         debug!("MirPatch: new_block: {:?}: {:?}", block, data);
@@ -123,14 +173,14 @@ impl<'tcx> MirPatch<'tcx> {
         block
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
     pub fn patch_terminator(&mut self, block: BasicBlock, new: TerminatorKind<'tcx>) {
         assert!(self.patch_map[block].is_none());
+        debug!("MirPatch: patch_terminator({:?}, {:?})", block, new);
         self.patch_map[block] = Some(new);
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
     pub fn add_statement(&mut self, loc: Location, stmt: StatementKind<'tcx>) {
+        debug!("MirPatch: add_statement({:?}, {:?})", loc, stmt);
         self.new_statements.push((loc, stmt));
     }
 
@@ -138,7 +188,6 @@ impl<'tcx> MirPatch<'tcx> {
         self.add_statement(loc, StatementKind::Assign(Box::new((place, rv))));
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
     pub fn apply(self, body: &mut Body<'tcx>) {
         debug!(
             "MirPatch: {:?} new temps, starting from index {}: {:?}",
@@ -151,12 +200,17 @@ impl<'tcx> MirPatch<'tcx> {
             self.new_blocks.len(),
             body.basic_blocks.len()
         );
-        body.basic_blocks_mut().extend(self.new_blocks);
+        let bbs = if self.patch_map.is_empty() && self.new_blocks.is_empty() {
+            body.basic_blocks.as_mut_preserves_cfg()
+        } else {
+            body.basic_blocks.as_mut()
+        };
+        bbs.extend(self.new_blocks);
         body.local_decls.extend(self.new_locals);
         for (src, patch) in self.patch_map.into_iter_enumerated() {
             if let Some(patch) = patch {
                 debug!("MirPatch: patching block {:?}", src);
-                body[src].terminator_mut().kind = patch;
+                bbs[src].terminator_mut().kind = patch;
             }
         }
 
@@ -170,19 +224,12 @@ impl<'tcx> MirPatch<'tcx> {
                 delta = 0;
                 last_bb = loc.block;
             }
-            debug!(
-                "MirPatch: adding statement {:?} at loc {:?}+{}",
-                stmt, loc, delta
-            );
+            debug!("MirPatch: adding statement {:?} at loc {:?}+{}", stmt, loc, delta);
             loc.statement_index += delta;
             let source_info = Self::source_info_for_index(&body[loc.block], loc);
-            body[loc.block].statements.insert(
-                loc.statement_index,
-                Statement {
-                    source_info,
-                    kind: stmt,
-                },
-            );
+            body[loc.block]
+                .statements
+                .insert(loc.statement_index, Statement { source_info, kind: stmt });
             delta += 1;
         }
     }

--- a/prusti-interface/src/environment/mir_storage.rs
+++ b/prusti-interface/src/environment/mir_storage.rs
@@ -7,8 +7,8 @@
 //! `'tcx`.
 
 use prusti_rustc_interface::{
-    borrowck::consumers::BodyWithBorrowckFacts, data_structures::fx::FxHashMap, hir::def_id::LocalDefId,
-    middle::ty::TyCtxt,
+    borrowck::consumers::BodyWithBorrowckFacts, data_structures::fx::FxHashMap,
+    hir::def_id::LocalDefId, middle::ty::TyCtxt,
 };
 use std::{cell::RefCell, thread_local};
 

--- a/prusti-interface/src/environment/mir_storage.rs
+++ b/prusti-interface/src/environment/mir_storage.rs
@@ -35,6 +35,9 @@ pub unsafe fn store_mir_body<'tcx>(
     });
 }
 
+/// This function should only be called once per `def_id` after the borrow checker has run.
+/// Otherwise, it will panic.
+///
 /// # Safety
 ///
 /// See the module level comment.

--- a/prusti-interface/src/environment/mir_storage.rs
+++ b/prusti-interface/src/environment/mir_storage.rs
@@ -7,7 +7,7 @@
 //! `'tcx`.
 
 use prusti_rustc_interface::{
-    borrowck::BodyWithBorrowckFacts, data_structures::fx::FxHashMap, hir::def_id::LocalDefId,
+    borrowck::consumers::BodyWithBorrowckFacts, data_structures::fx::FxHashMap, hir::def_id::LocalDefId,
     middle::ty::TyCtxt,
 };
 use std::{cell::RefCell, thread_local};

--- a/prusti-interface/src/environment/mir_storage.rs
+++ b/prusti-interface/src/environment/mir_storage.rs
@@ -7,14 +7,19 @@
 //! `'tcx`.
 
 use prusti_rustc_interface::{
-    borrowck::consumers::BodyWithBorrowckFacts, data_structures::fx::FxHashMap,
-    hir::def_id::LocalDefId, middle::ty::TyCtxt,
+    borrowck::consumers::BodyWithBorrowckFacts,
+    data_structures::fx::FxHashMap,
+    hir::def_id::LocalDefId,
+    middle::{mir, ty::TyCtxt},
 };
 use std::{cell::RefCell, thread_local};
 
 thread_local! {
-    pub static SHARED_STATE:
+    pub static SHARED_STATE_WITH_FACTS:
         RefCell<FxHashMap<LocalDefId, BodyWithBorrowckFacts<'static>>> =
+        RefCell::new(FxHashMap::default());
+    pub static SHARED_STATE_WITHOUT_FACTS:
+        RefCell<FxHashMap<LocalDefId, mir::Body<'static>>> =
         RefCell::new(FxHashMap::default());
 }
 
@@ -29,7 +34,7 @@ pub unsafe fn store_mir_body<'tcx>(
     // SAFETY: See the module level comment.
     let body_with_facts: BodyWithBorrowckFacts<'static> =
         unsafe { std::mem::transmute(body_with_facts) };
-    SHARED_STATE.with(|state| {
+    SHARED_STATE_WITH_FACTS.with(|state| {
         let mut map = state.borrow_mut();
         assert!(map.insert(def_id, body_with_facts).is_none());
     });
@@ -46,10 +51,39 @@ pub(super) unsafe fn retrieve_mir_body<'tcx>(
     _tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
 ) -> BodyWithBorrowckFacts<'tcx> {
-    let body_with_facts: BodyWithBorrowckFacts<'static> = SHARED_STATE.with(|state| {
+    let body_with_facts: BodyWithBorrowckFacts<'static> = SHARED_STATE_WITH_FACTS.with(|state| {
         let mut map = state.borrow_mut();
         map.remove(&def_id).unwrap()
     });
     // SAFETY: See the module level comment.
     unsafe { std::mem::transmute(body_with_facts) }
+}
+
+/// # Safety
+///
+/// See the module level comment.
+pub unsafe fn store_promoted_mir_body<'tcx>(
+    _tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    body: mir::Body<'tcx>,
+) {
+    // SAFETY: See the module level comment.
+    let body: mir::Body<'static> = unsafe { std::mem::transmute(body) };
+    SHARED_STATE_WITHOUT_FACTS.with(|state| {
+        let mut map = state.borrow_mut();
+        assert!(map.insert(def_id, body).is_none());
+    });
+}
+
+#[allow(clippy::needless_lifetimes)] // We want to be very explicit about lifetimes here.
+pub(super) unsafe fn retrieve_promoted_mir_body<'tcx>(
+    _tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+) -> mir::Body<'tcx> {
+    let body_without_facts: mir::Body<'static> = SHARED_STATE_WITHOUT_FACTS.with(|state| {
+        let mut map = state.borrow_mut();
+        map.remove(&def_id).unwrap()
+    });
+    // SAFETY: See the module level comment.
+    unsafe { std::mem::transmute(body_without_facts) }
 }

--- a/prusti-interface/src/environment/mir_utils/args_for_mir.rs
+++ b/prusti-interface/src/environment/mir_utils/args_for_mir.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::{
-    index::vec::Idx,
+    index::Idx,
     middle::{mir, ty},
 };
 

--- a/prusti-interface/src/environment/mir_utils/real_edges.rs
+++ b/prusti-interface/src/environment/mir_utils/real_edges.rs
@@ -6,7 +6,7 @@
 
 use prusti_rustc_interface::middle::mir::{self, TerminatorKind};
 
-use prusti_rustc_interface::index::vec::IndexVec;
+use prusti_rustc_interface::index::IndexVec;
 
 /// A data structure to store the non-virtual CFG edges of a MIR body.
 pub struct RealEdges {
@@ -53,7 +53,7 @@ fn real_targets(terminator: &mir::Terminator) -> Vec<mir::BasicBlock> {
         TerminatorKind::SwitchInt { ref targets, .. } => targets.all_targets().to_vec(),
 
         TerminatorKind::Resume
-        | TerminatorKind::Abort
+        | TerminatorKind::Terminate
         | TerminatorKind::Return
         | TerminatorKind::GeneratorDrop
         | TerminatorKind::Unreachable => vec![],

--- a/prusti-interface/src/environment/mod.rs
+++ b/prusti-interface/src/environment/mod.rs
@@ -145,13 +145,16 @@ impl<'tcx> Environment<'tcx> {
             true
         } else {
             let param_env = self.tcx().param_env(caller_def_id);
-            if let Some(instance) = self
+            if let Some(_instance) = self
                 .tcx()
                 .resolve_instance(param_env.and((called_def_id, call_substs)))
                 .unwrap()
             {
-                self.tcx()
-                    .mir_callgraph_reachable((instance, caller_def_id.expect_local()))
+                // FIXME: This call panics due to stolen MIR. Therefore, we
+                // unsoundly assume that the callee is not reachable.
+                // self.tcx()
+                //     .mir_callgraph_reachable((instance, caller_def_id.expect_local()))
+                false
             } else {
                 true
             }

--- a/prusti-interface/src/environment/polonius_info.rs
+++ b/prusti-interface/src/environment/polonius_info.rs
@@ -29,7 +29,7 @@ use log::{debug, trace};
 use prusti_common::config;
 use prusti_rustc_interface::{
     borrowck::consumers::RustcFacts,
-    index::vec::Idx,
+    index::Idx,
     middle::{mir, ty},
     polonius_engine::{Algorithm, AllFacts, Output},
     span::{def_id::DefId, Span},

--- a/prusti-interface/src/environment/procedure.rs
+++ b/prusti-interface/src/environment/procedure.rs
@@ -205,9 +205,7 @@ fn build_reachable_basic_blocks(mir: &Body, real_edges: &RealEdges) -> FxHashSet
     let mut visited: FxHashSet<BasicBlock> = FxHashSet::default();
     let mut to_visit: Vec<BasicBlock> = vec![mir.basic_blocks.indices().next().unwrap()];
 
-    while !to_visit.is_empty() {
-        let source = to_visit.pop().unwrap();
-
+    while let Some(source) = to_visit.pop() {
         if visited.contains(&source) {
             continue;
         }
@@ -391,9 +389,7 @@ fn build_nonspec_basic_blocks(
 
     let mut bb_graph: FxHashMap<BasicBlock, BasicBlockNode> = FxHashMap::default();
 
-    while !to_visit.is_empty() {
-        let source = to_visit.pop().unwrap();
-
+    while let Some(source) = to_visit.pop() {
         if visited.contains(&source) {
             continue;
         }

--- a/prusti-interface/src/environment/query.rs
+++ b/prusti-interface/src/environment/query.rs
@@ -161,7 +161,7 @@ impl<'tcx> EnvQuery<'tcx> {
     ) -> ty::PolyFnSig<'tcx> {
         let def_id = def_id.into_param();
         let sig = if self.tcx.is_closure(def_id) {
-            ty::EarlyBinder(substs.as_closure().sig())
+            ty::EarlyBinder::bind(substs.as_closure().sig())
         } else {
             self.tcx.fn_sig(def_id)
         };
@@ -255,7 +255,7 @@ impl<'tcx> EnvQuery<'tcx> {
         // more precisely. We can do this directly with `impl_method_substs`
         // because they contain the substs for the `impl` block as a prefix.
         let call_trait_substs =
-            ty::EarlyBinder(trait_ref.substs).subst(self.tcx, impl_method_substs);
+            ty::EarlyBinder::bind(trait_ref.substs).subst(self.tcx, impl_method_substs);
         let impl_substs = self.identity_substs(impl_def_id);
         let trait_method_substs = self.tcx.mk_substs_from_iter(
             call_trait_substs
@@ -284,7 +284,7 @@ impl<'tcx> EnvQuery<'tcx> {
             debug!("Fetching implementations of method '{:?}' defined in trait '{}' with substs '{:?}'", proc_def_id, self.tcx.def_path_str(trait_id), substs);
             let infcx = self.tcx.infer_ctxt().build();
             let mut sc = SelectionContext::new(&infcx);
-            let trait_ref = self.tcx.mk_trait_ref(trait_id, substs);
+            let trait_ref = ty::TraitRef::new(self.tcx, trait_id, substs);
             let obligation = Obligation::new(
                 self.tcx,
                 ObligationCause::dummy(),

--- a/prusti-interface/src/lib.rs
+++ b/prusti-interface/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(min_specialization)]
+#![feature(let_chains)]
 // We may want to remove this in the future.
 #![allow(clippy::needless_lifetimes)]
 

--- a/prusti-interface/src/specs/cross_crate.rs
+++ b/prusti-interface/src/specs/cross_crate.rs
@@ -84,16 +84,13 @@ impl CrossCrateSpecs {
         def_spec: &DefSpecificationMap,
         path: &path::PathBuf,
     ) -> io::Result<usize> {
-        use std::io::Write;
-        let mut encoder = DefSpecsEncoder::new(env.tcx());
+        // Probably not needed; dir should already exist?
+        fs::create_dir_all(path.parent().unwrap())?;
+        let mut encoder = DefSpecsEncoder::new(env.tcx(), path)?;
         def_spec.proc_specs.encode(&mut encoder);
         def_spec.type_specs.encode(&mut encoder);
         CrossCrateBodies::from(&env.body).encode(&mut encoder);
-
-        // Probably not needed; dir should already exist?
-        fs::create_dir_all(path.parent().unwrap())?;
-        let mut file = fs::File::create(path)?;
-        file.write(&encoder.into_inner())
+        encoder.finish()
     }
 
     #[tracing::instrument(level = "debug", skip(env, def_spec))]

--- a/prusti-interface/src/specs/cross_crate.rs
+++ b/prusti-interface/src/specs/cross_crate.rs
@@ -82,7 +82,7 @@ impl CrossCrateSpecs {
     fn write_into_file(
         env: &Environment,
         def_spec: &DefSpecificationMap,
-        path: &path::PathBuf,
+        path: &path::Path,
     ) -> io::Result<usize> {
         // Probably not needed; dir should already exist?
         fs::create_dir_all(path.parent().unwrap())?;

--- a/prusti-interface/src/specs/decoder.rs
+++ b/prusti-interface/src/specs/decoder.rs
@@ -110,16 +110,6 @@ impl<'a, 'tcx> TyDecoder for DefSpecsDecoder<'a, 'tcx> {
         self.tcx
     }
 
-    #[inline]
-    fn peek_byte(&self) -> u8 {
-        self.opaque.data[self.opaque.position()]
-    }
-
-    #[inline]
-    fn position(&self) -> usize {
-        self.opaque.position()
-    }
-
     fn cached_ty_for_shorthand<F>(&mut self, shorthand: usize, or_insert_with: F) -> Ty<'tcx>
     where
         F: FnOnce(&mut Self) -> Ty<'tcx>,
@@ -137,7 +127,7 @@ impl<'a, 'tcx> TyDecoder for DefSpecsDecoder<'a, 'tcx> {
     where
         F: FnOnce(&mut Self) -> R,
     {
-        let new_opaque = opaque::MemDecoder::new(self.opaque.data, pos);
+        let new_opaque = opaque::MemDecoder::new(self.opaque.data(), pos);
         let old_opaque = std::mem::replace(&mut self.opaque, new_opaque);
         let r = f(self);
         self.opaque = old_opaque;

--- a/prusti-interface/src/specs/encoder.rs
+++ b/prusti-interface/src/specs/encoder.rs
@@ -11,24 +11,24 @@ use prusti_rustc_interface::{
 
 pub struct DefSpecsEncoder<'tcx> {
     tcx: TyCtxt<'tcx>,
-    opaque: opaque::MemEncoder,
+    opaque: opaque::FileEncoder,
     type_shorthands: FxHashMap<Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<PredicateKind<'tcx>, usize>,
     interpret_allocs: FxIndexSet<AllocId>,
 }
 
 impl<'tcx> DefSpecsEncoder<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
-        DefSpecsEncoder {
+    pub fn new(tcx: TyCtxt<'tcx>, file: &std::path::Path) -> std::io::Result<Self> {
+        Ok(DefSpecsEncoder {
             tcx,
-            opaque: opaque::MemEncoder::new(),
+            opaque: opaque::FileEncoder::new(file)?,
             type_shorthands: Default::default(),
             predicate_shorthands: Default::default(),
             interpret_allocs: Default::default(),
-        }
+        })
     }
 
-    pub fn into_inner(self) -> Vec<u8> {
+    pub fn finish(self) -> std::io::Result<usize> {
         self.opaque.finish()
     }
 }
@@ -59,8 +59,8 @@ impl<'tcx> Encoder for DefSpecsEncoder<'tcx> {
         emit_i8(i8);
 
         emit_bool(bool);
-        emit_f64(f64);
-        emit_f32(f32);
+        // emit_f64(f64);
+        // emit_f32(f32);
         emit_char(char);
         emit_str(&str);
         emit_raw_bytes(&[u8]);

--- a/prusti-tests/Cargo.toml
+++ b/prusti-tests/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Prusti Devs <prusti_developers@sympa.ethz.ch>"]
 edition = "2021"
 
 [dev-dependencies]
-compiletest_rs = "0.9"
+compiletest_rs = "0.10"
 prusti-server = { path = "../prusti-server" }
 prusti-launch = { path = "../prusti-launch", artifact = "bin" }
 prusti = { path = "../prusti", artifact = "bin" }
-cargo-test-support = { git = "https://github.com/rust-lang/cargo.git", rev = "17f8088" }
+cargo-test-support = { git = "https://github.com/rust-lang/cargo.git", rev = "ec8a8a0" }
 ureq = "2.1"
 log = { version = "0.4", features = ["release_max_level_info"] }
 env_logger = "0.10"

--- a/prusti-tests/tests/cargo_verify/prusti_toml/output.stdout
+++ b/prusti-tests/tests/cargo_verify/prusti_toml/output.stdout
@@ -1,7 +1,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -16,7 +15,8 @@ non_snake_case)]
 #[prusti::spec_id = "[..]"]
 fn prusti_post_item_test1_[..](result: ())
     -> bool {
-    !!((false): bool)
+    let prusti_result: bool = false;
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "[..]"]
 #[prusti::specs_version = "[..]"]

--- a/prusti-tests/tests/parse/ui/after_expiry.stdout
+++ b/prusti-tests/tests/parse/ui/after_expiry.stdout
@@ -8,7 +8,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -23,7 +22,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test1_$(NUM_UUID)(a: bool,
     result: ()) -> bool {
-    !!((a): bool)
+    let prusti_result: bool = a;
+    prusti_result
 }
 #[prusti::pledge_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -34,7 +34,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test2_$(NUM_UUID)(a: bool,
     result: ()) -> bool {
-    !!((a): bool)
+    let prusti_result: bool = a;
+    prusti_result
 }
 #[prusti::pledge_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -45,7 +46,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test3_$(NUM_UUID)(x: u32,
     result: u32) -> bool {
-    !!((result == match x { 1 => 1, 2 => 2, _ => 0, }): bool)
+    let prusti_result: bool = result == match x { 1 => 1, 2 => 2, _ => 0, };
+    prusti_result
 }
 #[prusti::pledge_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/parse/ui/and.stdout
+++ b/prusti-tests/tests/parse/ui/and.stdout
@@ -10,7 +10,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -24,7 +23,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!(((true) && (true)): bool)
+    let prusti_result: bool = (true) && (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -34,7 +34,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((((true) && (true)) && (true)): bool)
+    let prusti_result: bool = ((true) && (true)) && (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -44,7 +45,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!(((true) && (((true) && (true)))): bool)
+    let prusti_result: bool = (true) && (((true) && (true)));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -54,7 +56,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!(((((true) && (true))) && (true)): bool)
+    let prusti_result: bool = (((true) && (true))) && (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -64,7 +67,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!(((((true) && (true))) && (((true) && (true)))): bool)
+    let prusti_result: bool = (((true) && (true))) && (((true) && (true)));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/parse/ui/assert_on_expiry.stdout
+++ b/prusti-tests/tests/parse/ui/assert_on_expiry.stdout
@@ -9,7 +9,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -24,7 +23,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test1_$(NUM_UUID)(a: bool,
     result: ()) -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -32,7 +32,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test1_$(NUM_UUID)(a: bool,
     result: ()) -> bool {
-    !!((a): bool)
+    let prusti_result: bool = a;
+    prusti_result
 }
 #[prusti::assert_pledge_spec_id_ref_lhs = "$(NUM_UUID)"]
 #[prusti::assert_pledge_spec_id_ref_rhs = "$(NUM_UUID)"]
@@ -44,7 +45,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test2_$(NUM_UUID)(a: bool,
     result: ()) -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -52,7 +54,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test2_$(NUM_UUID)(a: bool,
     result: ()) -> bool {
-    !!((a): bool)
+    let prusti_result: bool = a;
+    prusti_result
 }
 #[prusti::assert_pledge_spec_id_ref_lhs = "$(NUM_UUID)"]
 #[prusti::assert_pledge_spec_id_ref_rhs = "$(NUM_UUID)"]
@@ -64,7 +67,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test3_$(NUM_UUID)(x: u32,
     result: u32) -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -72,7 +76,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_test3_$(NUM_UUID)(x: u32,
     result: u32) -> bool {
-    !!((result == match x { 1 => 1, 2 => 2, _ => 0, }): bool)
+    let prusti_result: bool = result == match x { 1 => 1, 2 => 2, _ => 0, };
+    prusti_result
 }
 #[prusti::assert_pledge_spec_id_ref_lhs = "$(NUM_UUID)"]
 #[prusti::assert_pledge_spec_id_ref_rhs = "$(NUM_UUID)"]

--- a/prusti-tests/tests/parse/ui/composite.stdout
+++ b/prusti-tests/tests/parse/ui/composite.stdout
@@ -29,7 +29,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -43,7 +42,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((!((true) && (true)) || ((true) && (true))): bool)
+    let prusti_result: bool = !((true) && (true)) || ((true) && (true));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -53,8 +53,9 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!(((((true) && ((!(true) || (true)))) && (((true) || (true)))) &&
-                            (true)): bool)
+    let prusti_result: bool =
+        (((true) && ((!(true) || (true)))) && (((true) || (true)))) && (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -64,7 +65,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((!(((true) && (true))) || (true)): bool)
+    let prusti_result: bool = !(((true) && (true))) || (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -74,7 +76,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((!(((!(true) || (true))) && (true)) || (true)): bool)
+    let prusti_result: bool = !(((!(true) || (true))) && (true)) || (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -84,8 +87,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((((!(true) || (true))) &&
-                            ((!(true) || ((true) && (((true) || (true))))))): bool)
+    let prusti_result: bool =
+        ((!(true) || (true))) &&
+            ((!(true) || ((true) && (((true) || (true))))));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -95,8 +100,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((!(((true) && (true))) ||
-                            (!(true) || (!(true) || (!(true) || (true))))): bool)
+    let prusti_result: bool =
+        !(((true) && (true))) ||
+            (!(true) || (!(true) || (!(true) || (true))));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -106,8 +113,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test7_$(NUM_UUID)() -> bool {
-    !!((!(((true) && (true))) ||
-                            (!(((true) && (true))) || (((true) && (true))))): bool)
+    let prusti_result: bool =
+        !(((true) && (true))) ||
+            (!(((true) && (true))) || (((true) && (true))));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -117,7 +126,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test8_$(NUM_UUID)() -> bool {
-    !!((!(((true) || (true))) || (((true) || (true)))): bool)
+    let prusti_result: bool = !(((true) || (true))) || (((true) || (true)));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -127,8 +137,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test9_$(NUM_UUID)() -> bool {
-    !!((!(((true) || (true))) ||
-                            (((true) || (((true) && (((true) || (true)))))))): bool)
+    let prusti_result: bool =
+        !(((true) || (true))) ||
+            (((true) || (((true) && (((true) || (true)))))));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -138,10 +150,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test10_$(NUM_UUID)() -> bool {
-    !!(((true) &&
-                            (::prusti_contracts::forall((),
-                                    #[prusti::spec_only] |a: i32| -> bool
-                                        { ((a == 5): bool) }))): bool)
+    let prusti_result: bool =
+        (true) &&
+            (::prusti_contracts::forall((),
+                    #[prusti::spec_only] |a: i32| -> bool { a == 5 }));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -151,9 +164,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test12_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                { ((a == 5): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |a: i32| -> bool { a == 5 });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -163,10 +177,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test13_$(NUM_UUID)() -> bool {
-    !!((!(true) ||
-                            (!(::prusti_contracts::forall((),
-                                                #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                                    { ((a == 5): bool) })) || (true))): bool)
+    let prusti_result: bool =
+        !(true) ||
+            (!(::prusti_contracts::forall((),
+                                #[prusti::spec_only] |a: i32, b: i32| -> bool { a == 5 }))
+                    || (true));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -176,10 +192,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test14_$(NUM_UUID)() -> bool {
-    !!((!(true) ||
-                            (::prusti_contracts::forall((),
-                                    #[prusti::spec_only] |a: i32| -> bool
-                                        { ((a == 5): bool) }))): bool)
+    let prusti_result: bool =
+        !(true) ||
+            (::prusti_contracts::forall((),
+                    #[prusti::spec_only] |a: i32| -> bool { a == 5 }));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -189,9 +206,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test15_$(NUM_UUID)() -> bool {
-    !!((!(::prusti_contracts::forall((),
-                                        #[prusti::spec_only] |a: i32| -> bool { ((a == 5): bool) }))
-                            || (true)): bool)
+    let prusti_result: bool =
+        !(::prusti_contracts::forall((),
+                        #[prusti::spec_only] |a: i32| -> bool { a == 5 })) ||
+            (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -201,13 +220,13 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test16_$(NUM_UUID)() -> bool {
-    !!((!(::prusti_contracts::forall((),
-                                        #[prusti::spec_only] |b: i32| -> bool
-                                            { ((b == 10): bool) })) ||
-                            (!(true) ||
-                                    (::prusti_contracts::forall((),
-                                            #[prusti::spec_only] |a: u32, b: u32| -> bool
-                                                { ((a == 5): bool) })))): bool)
+    let prusti_result: bool =
+        !(::prusti_contracts::forall((),
+                        #[prusti::spec_only] |b: i32| -> bool { b == 10 })) ||
+            (!(true) ||
+                    (::prusti_contracts::forall((),
+                            #[prusti::spec_only] |a: u32, b: u32| -> bool { a == 5 })));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -217,10 +236,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test17_$(NUM_UUID)() -> bool {
-    !!(((true) &&
-                            (::prusti_contracts::exists((),
-                                    #[prusti::spec_only] |a: i32| -> bool
-                                        { ((a == 5): bool) }))): bool)
+    let prusti_result: bool =
+        (true) &&
+            (::prusti_contracts::exists((),
+                    #[prusti::spec_only] |a: i32| -> bool { a == 5 }));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -230,9 +250,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test19_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                { ((a == 5): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |a: i32| -> bool { a == 5 });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -242,10 +263,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test20_$(NUM_UUID)() -> bool {
-    !!((!(true) ||
-                            (!(::prusti_contracts::exists((),
-                                                #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                                    { ((a == 5): bool) })) || (true))): bool)
+    let prusti_result: bool =
+        !(true) ||
+            (!(::prusti_contracts::exists((),
+                                #[prusti::spec_only] |a: i32, b: i32| -> bool { a == 5 }))
+                    || (true));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -255,10 +278,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test21_$(NUM_UUID)() -> bool {
-    !!((!(true) ||
-                            (::prusti_contracts::exists((),
-                                    #[prusti::spec_only] |a: i32| -> bool
-                                        { ((a == 5): bool) }))): bool)
+    let prusti_result: bool =
+        !(true) ||
+            (::prusti_contracts::exists((),
+                    #[prusti::spec_only] |a: i32| -> bool { a == 5 }));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -268,9 +292,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test22_$(NUM_UUID)() -> bool {
-    !!((!(::prusti_contracts::exists((),
-                                        #[prusti::spec_only] |a: i32| -> bool { ((a == 5): bool) }))
-                            || (true)): bool)
+    let prusti_result: bool =
+        !(::prusti_contracts::exists((),
+                        #[prusti::spec_only] |a: i32| -> bool { a == 5 })) ||
+            (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -280,13 +306,13 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test23_$(NUM_UUID)() -> bool {
-    !!((!(::prusti_contracts::exists((),
-                                        #[prusti::spec_only] |b: i32| -> bool
-                                            { ((b == 10): bool) })) ||
-                            (!(true) ||
-                                    (::prusti_contracts::exists((),
-                                            #[prusti::spec_only] |a: u32, b: u32| -> bool
-                                                { ((a == 5): bool) })))): bool)
+    let prusti_result: bool =
+        !(::prusti_contracts::exists((),
+                        #[prusti::spec_only] |b: i32| -> bool { b == 10 })) ||
+            (!(true) ||
+                    (::prusti_contracts::exists((),
+                            #[prusti::spec_only] |a: u32, b: u32| -> bool { a == 5 })));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -296,7 +322,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test24_$(NUM_UUID)() -> bool {
-    !!((((true) && (true)) || (true)): bool)
+    let prusti_result: bool = ((true) && (true)) || (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -306,12 +333,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test25_$(NUM_UUID)() -> bool {
-    !!(((::prusti_contracts::forall((),
-                                    #[prusti::spec_only] |a: i32| -> bool { ((a == 5): bool) }))
-                            ||
-                            (::prusti_contracts::forall((),
-                                    #[prusti::spec_only] |a: i32| -> bool
-                                        { ((a == 5): bool) }))): bool)
+    let prusti_result: bool =
+        (::prusti_contracts::forall((),
+                    #[prusti::spec_only] |a: i32| -> bool { a == 5 })) ||
+            (::prusti_contracts::forall((),
+                    #[prusti::spec_only] |a: i32| -> bool { a == 5 }));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -321,12 +348,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test26_$(NUM_UUID)() -> bool {
-    !!(((::prusti_contracts::exists((),
-                                    #[prusti::spec_only] |a: i32| -> bool { ((a == 5): bool) }))
-                            ||
-                            (::prusti_contracts::exists((),
-                                    #[prusti::spec_only] |a: i32| -> bool
-                                        { ((a == 5): bool) }))): bool)
+    let prusti_result: bool =
+        (::prusti_contracts::exists((),
+                    #[prusti::spec_only] |a: i32| -> bool { a == 5 })) ||
+            (::prusti_contracts::exists((),
+                    #[prusti::spec_only] |a: i32| -> bool { a == 5 }));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/parse/ui/empty.stdout
+++ b/prusti-tests/tests/parse/ui/empty.stdout
@@ -1,6 +1,5 @@
 // compile-flags: -Pprint_desugared_specs=true -Pno_verify=true -Phide_uuids=true
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]

--- a/prusti-tests/tests/parse/ui/exists.stdout
+++ b/prusti-tests/tests/parse/ui/exists.stdout
@@ -11,7 +11,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -25,9 +24,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                { (((a + a == a + a)): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |a: i32| -> bool { (a + a == a + a) });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -37,11 +37,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                {
-                                    ((((a + b == a + b) && (true)) == (a + b == a + b)): bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |a: i32, b: i32| -> bool
+                { ((a + b == a + b) && (true)) == (a + b == a + b) });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -51,9 +51,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                { ((!(a + b == a + b) || (a + b == a + b)): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |a: i32, b: i32| -> bool
+                { !(a + b == a + b) || (a + b == a + b) });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -63,10 +65,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32| (1),
-                                    #[prusti::spec_only] |a: i32| ((2 == 2) && (true))),),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                { ((a + a == a + a): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists(((#[prusti::spec_only] |a: i32| (1),
+                    #[prusti::spec_only] |a: i32| ((2 == 2) && (true))),),
+            #[prusti::spec_only] |a: i32| -> bool { a + a == a + a });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -76,11 +79,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: i32|
-                                        (1), #[prusti::spec_only] |a: i32, b: i32| (2)),
-                                (#[prusti::spec_only] |a: i32, b: i32| (1),)),
-                            #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                { ((a + b == a + b): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: i32|
+                        (1), #[prusti::spec_only] |a: i32, b: i32| (2)),
+                (#[prusti::spec_only] |a: i32, b: i32| (1),)),
+            #[prusti::spec_only] |a: i32, b: i32| -> bool { a + b == a + b });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -90,14 +94,16 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: i32|
-                                        (1), #[prusti::spec_only] |a: i32, b: i32| (2),
-                                    #[prusti::spec_only] |a: i32, b: i32| (3)),
-                                (#[prusti::spec_only] |a: i32, b: i32| (1),
-                                    #[prusti::spec_only] |a: i32, b: i32| (2)),
-                                (#[prusti::spec_only] |a: i32, b: i32| (1),)),
-                            #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                { ((!(a + b == a + b) || (a + b == a + b)): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: i32|
+                        (1), #[prusti::spec_only] |a: i32, b: i32| (2),
+                    #[prusti::spec_only] |a: i32, b: i32| (3)),
+                (#[prusti::spec_only] |a: i32, b: i32| (1),
+                    #[prusti::spec_only] |a: i32, b: i32| (2)),
+                (#[prusti::spec_only] |a: i32, b: i32| (1),)),
+            #[prusti::spec_only] |a: i32, b: i32| -> bool
+                { !(a + b == a + b) || (a + b == a + b) });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/parse/ui/expression.stdout
+++ b/prusti-tests/tests/parse/ui/expression.stdout
@@ -7,7 +7,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -21,7 +20,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!(((1 == 1) && (1 != 2)): bool)
+    let prusti_result: bool = (1 == 1) && (1 != 2);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -32,7 +32,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test2_$(NUM_UUID)(result: ())
     -> bool {
-    !!(((1 == 1) || (1 == 2)): bool)
+    let prusti_result: bool = (1 == 1) || (1 == 2);
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/parse/ui/forall.stdout
+++ b/prusti-tests/tests/parse/ui/forall.stdout
@@ -11,7 +11,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -25,9 +24,10 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                { (((a + a == a + a)): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |a: i32| -> bool { (a + a == a + a) });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -37,11 +37,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                {
-                                    ((((a + b == a + b) && (true)) == (a + b == a + b)): bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |a: i32, b: i32| -> bool
+                { ((a + b == a + b) && (true)) == (a + b == a + b) });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -51,9 +51,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                { ((!(a + b == a + b) || (a + b == a + b)): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |a: i32, b: i32| -> bool
+                { !(a + b == a + b) || (a + b == a + b) });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -63,10 +65,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32| (1),
-                                    #[prusti::spec_only] |a: i32| ((2 == 2) && (true))),),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                { ((a + a == a + a): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall(((#[prusti::spec_only] |a: i32| (1),
+                    #[prusti::spec_only] |a: i32| ((2 == 2) && (true))),),
+            #[prusti::spec_only] |a: i32| -> bool { a + a == a + a });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -76,11 +79,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: i32|
-                                        (1), #[prusti::spec_only] |a: i32, b: i32| (2)),
-                                (#[prusti::spec_only] |a: i32, b: i32| (1),)),
-                            #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                { ((a + b == a + b): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: i32|
+                        (1), #[prusti::spec_only] |a: i32, b: i32| (2)),
+                (#[prusti::spec_only] |a: i32, b: i32| (1),)),
+            #[prusti::spec_only] |a: i32, b: i32| -> bool { a + b == a + b });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -90,14 +94,16 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: i32|
-                                        (1), #[prusti::spec_only] |a: i32, b: i32| (2),
-                                    #[prusti::spec_only] |a: i32, b: i32| (3)),
-                                (#[prusti::spec_only] |a: i32, b: i32| (1),
-                                    #[prusti::spec_only] |a: i32, b: i32| (2)),
-                                (#[prusti::spec_only] |a: i32, b: i32| (1),)),
-                            #[prusti::spec_only] |a: i32, b: i32| -> bool
-                                { ((!(a + b == a + b) || (a + b == a + b)): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: i32|
+                        (1), #[prusti::spec_only] |a: i32, b: i32| (2),
+                    #[prusti::spec_only] |a: i32, b: i32| (3)),
+                (#[prusti::spec_only] |a: i32, b: i32| (1),
+                    #[prusti::spec_only] |a: i32, b: i32| (2)),
+                (#[prusti::spec_only] |a: i32, b: i32| (1),)),
+            #[prusti::spec_only] |a: i32, b: i32| -> bool
+                { !(a + b == a + b) || (a + b == a + b) });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/parse/ui/implies.stdout
+++ b/prusti-tests/tests/parse/ui/implies.stdout
@@ -15,7 +15,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -29,7 +28,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((!(true) || (true)): bool)
+    let prusti_result: bool = !(true) || (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -39,7 +39,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((!(true) || (!(true) || (true))): bool)
+    let prusti_result: bool = !(true) || (!(true) || (true));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -49,7 +50,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((!(true) || ((!(true) || (true)))): bool)
+    let prusti_result: bool = !(true) || ((!(true) || (true)));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -59,7 +61,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((!((!(true) || (true))) || (true)): bool)
+    let prusti_result: bool = !((!(true) || (true))) || (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -69,7 +72,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((!((!(true) || (true))) || ((!(true) || (true)))): bool)
+    let prusti_result: bool = !((!(true) || (true))) || ((!(true) || (true)));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -79,7 +83,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test21_$(NUM_UUID)() -> bool {
-    !!((!(true) || (true)): bool)
+    let prusti_result: bool = !(true) || (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -89,7 +94,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test22_$(NUM_UUID)() -> bool {
-    !!((!(true) || (!(true) || (true))): bool)
+    let prusti_result: bool = !(true) || (!(true) || (true));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -99,7 +105,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test23_$(NUM_UUID)() -> bool {
-    !!((!(true) || ((!(true) || (true)))): bool)
+    let prusti_result: bool = !(true) || ((!(true) || (true)));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -109,7 +116,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test24_$(NUM_UUID)() -> bool {
-    !!((!((!(true) || (true))) || (true)): bool)
+    let prusti_result: bool = !((!(true) || (true))) || (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -119,7 +127,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test25_$(NUM_UUID)() -> bool {
-    !!((!((!(true) || (true))) || ((!(true) || (true)))): bool)
+    let prusti_result: bool = !((!(true) || (true))) || ((!(true) || (true)));
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/parse/ui/parenthesis.stderr
+++ b/prusti-tests/tests/parse/ui/parenthesis.stderr
@@ -2,7 +2,10 @@ error[E0308]: mismatched types
  --> $DIR/parenthesis.rs:8:15
   |
 8 | #[requires(   (    12345))]
-  |               ^^^^^^^^^^^ expected `bool`, found integer
+  |               ^^^^^^^^^^^
+  |               |
+  |               expected `bool`, found integer
+  |               expected due to this
 
 error[E0308]: mismatched types
   --> $DIR/parenthesis.rs:11:20

--- a/prusti-tests/tests/parse/ui/predicates-visibility.stdout
+++ b/prusti-tests/tests/parse/ui/predicates-visibility.stdout
@@ -8,7 +8,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -26,17 +25,21 @@ mod foo {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pred_item_pred1_$(NUM_UUID)(a: bool)
         -> bool {
-        (({
-                        ::prusti_contracts::forall((),
-                            #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
-                    }): bool)
+        let prusti_result: bool =
+            {
+                ::prusti_contracts::forall((),
+                    #[prusti::spec_only] |b: bool| -> bool { a == b })
+            };
+        prusti_result
     }
     #[allow(unused_must_use, unused_variables, dead_code)]
     #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
     pub fn pred1(a: bool) -> bool {
-        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-                format_args!("predicate")))
+        {
+            ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                    format_args!("predicate")));
+        }
     }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
@@ -44,7 +47,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test_pub_pred_$(NUM_UUID)() -> bool {
-    !!((foo::pred1(true)): bool)
+    let prusti_result: bool = foo::pred1(true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/parse/ui/predicates.stdout
+++ b/prusti-tests/tests/parse/ui/predicates.stdout
@@ -12,7 +12,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -27,24 +26,29 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_pred1_$(NUM_UUID)(a: bool) -> bool {
-    (({
-                    ::prusti_contracts::forall((),
-                        #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
-                }): bool)
+    let prusti_result: bool =
+        {
+            ::prusti_contracts::forall((),
+                #[prusti::spec_only] |b: bool| -> bool { a == b })
+        };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn pred1(a: bool) -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_use_pred1_$(NUM_UUID)() -> bool {
-    !!((pred1(true)): bool)
+    let prusti_result: bool = pred1(true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -54,24 +58,29 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_pred2_$(NUM_UUID)(a: bool) -> bool {
-    (({
-                    ::prusti_contracts::exists((),
-                        #[prusti::spec_only] |b: bool| -> bool { ((a == b): bool) })
-                }): bool)
+    let prusti_result: bool =
+        {
+            ::prusti_contracts::exists((),
+                #[prusti::spec_only] |b: bool| -> bool { a == b })
+        };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn pred2(a: bool) -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_use_pred2_$(NUM_UUID)() -> bool {
-    !!((pred2(true)): bool)
+    let prusti_result: bool = pred2(true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -82,18 +91,22 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_forall_implication_$(NUM_UUID)()
     -> bool {
-    (({
-                    ::prusti_contracts::forall((),
-                        #[prusti::spec_only] |x: usize| -> bool
-                            { ((!((x != 0)) || (x * 2 != 0)): bool) })
-                }): bool)
+    let prusti_result: bool =
+        {
+            ::prusti_contracts::forall((),
+                #[prusti::spec_only] |x: usize| -> bool
+                    { !((x != 0)) || (x * 2 != 0) })
+        };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn forall_implication() -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -101,18 +114,22 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_exists_implication_$(NUM_UUID)()
     -> bool {
-    (({
-                    ::prusti_contracts::exists((),
-                        #[prusti::spec_only] |x: usize| -> bool
-                            { ((!((x != 0)) || (x * 2 != 0)): bool) })
-                }): bool)
+    let prusti_result: bool =
+        {
+            ::prusti_contracts::exists((),
+                #[prusti::spec_only] |x: usize| -> bool
+                    { !((x != 0)) || (x * 2 != 0) })
+        };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn exists_implication() -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 fn main() {}
 ProcedureSpecification { source: DefId(0:7 ~ predicates[$(CRATE_ID)]::pred1), kind: Inherent(Predicate(Some(DefId(0:5 ~ predicates[$(CRATE_ID)]::prusti_pred_item_pred1_$(NUM_UUID))))), pres: Empty, posts: Empty, pledges: Empty, trusted: Inherent(false), terminates: Inherent(None), purity: Inherent(None) }

--- a/prusti-tests/tests/parse/ui/simple_and.stderr
+++ b/prusti-tests/tests/parse/ui/simple_and.stderr
@@ -2,25 +2,37 @@ error[E0308]: mismatched types
  --> $DIR/simple_and.rs:5:12
   |
 5 | #[requires(12345)]
-  |            ^^^^^ expected `bool`, found integer
+  |            ^^^^^
+  |            |
+  |            expected `bool`, found integer
+  |            expected due to this
 
 error[E0308]: mismatched types
  --> $DIR/simple_and.rs:8:17
   |
 8 | #[requires     (12345)]
-  |                 ^^^^^ expected `bool`, found integer
+  |                 ^^^^^
+  |                 |
+  |                 expected `bool`, found integer
+  |                 expected due to this
 
 error[E0308]: mismatched types
   --> $DIR/simple_and.rs:17:5
    |
 17 |     12345) ]
-   |     ^^^^^ expected `bool`, found integer
+   |     ^^^^^
+   |     |
+   |     expected `bool`, found integer
+   |     expected due to this
 
 error[E0308]: mismatched types
   --> $DIR/simple_and.rs:22:5
    |
 22 |     12345)
-   |     ^^^^^ expected `bool`, found integer
+   |     ^^^^^
+   |     |
+   |     expected `bool`, found integer
+   |     expected due to this
 
 error[E0308]: mismatched types
   --> $DIR/simple_and.rs:26:20

--- a/prusti-tests/tests/parse/ui/trait-bounds.stdout
+++ b/prusti-tests/tests/parse/ui/trait-bounds.stdout
@@ -8,7 +8,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -35,7 +34,8 @@ impl<'a, T: PartialEq, const L : usize>
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_bar_$(NUM_UUID)(_self:
             Foo<'a, T, L>, result: &'a [T; L]) -> bool {
-        !!((result == _self.0): bool)
+        let prusti_result: bool = result == _self.0;
+        prusti_result
     }
     #[prusti::extern_spec = "inherent_impl"]
     #[allow(unused, dead_code)]

--- a/prusti-tests/tests/parse/ui/traits.stdout
+++ b/prusti-tests/tests/parse/ui/traits.stdout
@@ -25,7 +25,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -40,7 +39,8 @@ trait Test1 {
     #[prusti::spec_only]
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
@@ -51,7 +51,8 @@ trait Test1 {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_test2_$(NUM_UUID)(result: ())
         -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
@@ -61,7 +62,8 @@ trait Test1 {
     #[prusti::spec_only]
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
@@ -72,7 +74,8 @@ trait Test1 {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_test4_$(NUM_UUID)(result: ())
         -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
@@ -84,7 +87,8 @@ trait Test2 {
     #[prusti::spec_only]
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
     non_snake_case)]
@@ -92,7 +96,8 @@ trait Test2 {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_test1_$(NUM_UUID)(result: ())
         -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
@@ -103,7 +108,8 @@ trait Test2 {
     #[prusti::spec_only]
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
     non_snake_case)]
@@ -111,7 +117,8 @@ trait Test2 {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_test2_$(NUM_UUID)(result: ())
         -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
@@ -124,7 +131,8 @@ trait Test3 {
     #[prusti::spec_only]
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pre_item_test1_$(NUM_UUID)(&self) -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
@@ -135,7 +143,8 @@ trait Test3 {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_test2_$(NUM_UUID)(&self,
         result: ()) -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
@@ -145,7 +154,8 @@ trait Test3 {
     #[prusti::spec_only]
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pre_item_test3_$(NUM_UUID)(&self) -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
@@ -156,7 +166,8 @@ trait Test3 {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_test4_$(NUM_UUID)(&self,
         result: ()) -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::specs_version = $(SPECS_VERSION)]
@@ -168,7 +179,8 @@ trait Test4 {
     #[prusti::spec_only]
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pre_item_test1_$(NUM_UUID)(&self) -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
     non_snake_case)]
@@ -176,7 +188,8 @@ trait Test4 {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_test1_$(NUM_UUID)(&self,
         result: ()) -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
@@ -187,7 +200,8 @@ trait Test4 {
     #[prusti::spec_only]
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_pre_item_test2_$(NUM_UUID)(&self) -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
     non_snake_case)]
@@ -195,7 +209,8 @@ trait Test4 {
     #[prusti::spec_id = "$(NUM_UUID)"]
     fn prusti_post_item_test2_$(NUM_UUID)(&self,
         result: ()) -> bool {
-        !!((true): bool)
+        let prusti_result: bool = true;
+        prusti_result
     }
     #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
     #[prusti::post_spec_id_ref = "$(NUM_UUID)"]

--- a/prusti-tests/tests/parse/ui/true.stdout
+++ b/prusti-tests/tests/parse/ui/true.stdout
@@ -9,7 +9,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -23,7 +22,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -34,7 +34,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test2_$(NUM_UUID)(result: ())
     -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -61,7 +62,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -69,7 +71,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test4_$(NUM_UUID)(result: ())
     -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]

--- a/prusti-tests/tests/parse/ui/trusted.stdout
+++ b/prusti-tests/tests/parse/ui/trusted.stdout
@@ -7,7 +7,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]

--- a/prusti-tests/tests/typecheck/ui/forall_encode_typeck.stdout
+++ b/prusti-tests/tests/typecheck/ui/forall_encode_typeck.stdout
@@ -7,7 +7,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -21,11 +20,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: u32|
-                                        (a == a), #[prusti::spec_only] |a: i32, b: u32| (a == a)),
-                                (#[prusti::spec_only] |a: i32, b: u32| (true),)),
-                            #[prusti::spec_only] |a: i32, b: u32| -> bool
-                                { ((a == a): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall(((#[prusti::spec_only] |a: i32, b: u32|
+                        (a == a), #[prusti::spec_only] |a: i32, b: u32| (a == a)),
+                (#[prusti::spec_only] |a: i32, b: u32| (true),)),
+            #[prusti::spec_only] |a: i32, b: u32| -> bool { a == a });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -35,11 +35,12 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: u32|
-                                        (a == a), #[prusti::spec_only] |a: i32, b: u32| (a == a)),
-                                (#[prusti::spec_only] |a: i32, b: u32| (true),)),
-                            #[prusti::spec_only] |a: i32, b: u32| -> bool
-                                { ((a == a): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists(((#[prusti::spec_only] |a: i32, b: u32|
+                        (a == a), #[prusti::spec_only] |a: i32, b: u32| (a == a)),
+                (#[prusti::spec_only] |a: i32, b: u32| (true),)),
+            #[prusti::spec_only] |a: i32, b: u32| -> bool { a == a });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/typecheck/ui/forall_triggers.stdout
+++ b/prusti-tests/tests/typecheck/ui/forall_triggers.stdout
@@ -13,7 +13,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -27,10 +26,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
-                                        (a == a),),),
-                            #[prusti::spec_only] |a: i32| -> bool { ((true): bool) })):
-                    bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
+                        (a == a),),),
+            #[prusti::spec_only] |a: i32| -> bool { true });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -40,14 +40,15 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
-                                        ((a == a) && (true)),),),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::forall((),
-                                                    #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
-                                            bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
+                        ((a == a) && (true)),),),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::forall((),
+                        #[prusti::spec_only] |b: i32| -> bool { true })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -57,15 +58,16 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
-                                        (a == a),),),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::forall(((#[prusti::spec_only] |b: i32|
-                                                                (a == a),),),
-                                                    #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
-                                            bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
+                        (a == a),),),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::forall(((#[prusti::spec_only] |b: i32|
+                                    (a == a),),),
+                        #[prusti::spec_only] |b: i32| -> bool { true })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -75,15 +77,16 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
-                                        ((a == a) && (true)),),),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::forall(((#[prusti::spec_only] |b: i32|
-                                                                (a == b),),),
-                                                    #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
-                                            bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall(((#[prusti::spec_only] |a: i32|
+                        ((a == a) && (true)),),),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::forall(((#[prusti::spec_only] |b: i32|
+                                    (a == b),),),
+                        #[prusti::spec_only] |b: i32| -> bool { true })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -93,10 +96,11 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
-                                        (a == a),),),
-                            #[prusti::spec_only] |a: i32| -> bool { ((true): bool) })):
-                    bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
+                        (a == a),),),
+            #[prusti::spec_only] |a: i32| -> bool { true });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -106,14 +110,15 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
-                                        ((a == a) && (true)),),),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::exists((),
-                                                    #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
-                                            bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
+                        ((a == a) && (true)),),),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::exists((),
+                        #[prusti::spec_only] |b: i32| -> bool { true })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -123,15 +128,16 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test7_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
-                                        (a == a),),),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::exists(((#[prusti::spec_only] |b: i32|
-                                                                (a == a),),),
-                                                    #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
-                                            bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
+                        (a == a),),),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::exists(((#[prusti::spec_only] |b: i32|
+                                    (a == a),),),
+                        #[prusti::spec_only] |b: i32| -> bool { true })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -141,15 +147,16 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test8_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
-                                        ((a == a) && (true)),),),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::exists(((#[prusti::spec_only] |b: i32|
-                                                                (a == b),),),
-                                                    #[prusti::spec_only] |b: i32| -> bool { ((true): bool) })):
-                                            bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists(((#[prusti::spec_only] |a: i32|
+                        ((a == a) && (true)),),),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::exists(((#[prusti::spec_only] |b: i32|
+                                    (a == b),),),
+                        #[prusti::spec_only] |b: i32| -> bool { true })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/typecheck/ui/nested_forall.stdout
+++ b/prusti-tests/tests/typecheck/ui/nested_forall.stdout
@@ -12,7 +12,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -26,13 +25,14 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::forall((),
-                                                    #[prusti::spec_only] |a: i32| -> bool
-                                                        { ((a == a): bool) })): bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::forall((),
+                        #[prusti::spec_only] |a: i32| -> bool { a == a })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -42,13 +42,15 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test2_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::forall((),
-                                                    #[prusti::spec_only] |b: i32| -> bool
-                                                        { ((!(a == a) || (b == b)): bool) })): bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::forall((),
+                        #[prusti::spec_only] |b: i32| -> bool
+                            { !(a == a) || (b == b) })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -58,17 +60,19 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test3_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::forall((),
-                                                    #[prusti::spec_only] |b: i32| -> bool
-                                                        {
-                                                            ((::prusti_contracts::forall((),
-                                                                            #[prusti::spec_only] |c: i32| -> bool
-                                                                                { (((a == a) && (b == b)): bool) })): bool)
-                                                        })): bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::forall((),
+                        #[prusti::spec_only] |b: i32| -> bool
+                            {
+                                ::prusti_contracts::forall((),
+                                    #[prusti::spec_only] |c: i32| -> bool
+                                        { (a == a) && (b == b) })
+                            })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -78,13 +82,14 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::exists((),
-                                                    #[prusti::spec_only] |a: i32| -> bool
-                                                        { ((a == a): bool) })): bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::exists((),
+                        #[prusti::spec_only] |a: i32| -> bool { a == a })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -94,13 +99,15 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test5_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::exists((),
-                                                    #[prusti::spec_only] |b: i32| -> bool
-                                                        { ((!(a == a) || (b == b)): bool) })): bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::exists((),
+                        #[prusti::spec_only] |b: i32| -> bool
+                            { !(a == a) || (b == b) })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -110,17 +117,19 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test6_$(NUM_UUID)() -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |a: i32| -> bool
-                                {
-                                    ((::prusti_contracts::exists((),
-                                                    #[prusti::spec_only] |b: i32| -> bool
-                                                        {
-                                                            ((::prusti_contracts::exists((),
-                                                                            #[prusti::spec_only] |c: i32| -> bool
-                                                                                { (((a == a) && (b == b)): bool) })): bool)
-                                                        })): bool)
-                                })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |a: i32| -> bool
+                {
+                    ::prusti_contracts::exists((),
+                        #[prusti::spec_only] |b: i32| -> bool
+                            {
+                                ::prusti_contracts::exists((),
+                                    #[prusti::spec_only] |c: i32| -> bool
+                                        { (a == a) && (b == b) })
+                            })
+                });
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/verify/fail/no-annotations/divide-by-zero.rs
+++ b/prusti-tests/tests/verify/fail/no-annotations/divide-by-zero.rs
@@ -1,4 +1,5 @@
 fn main() {
     let y = 0;
     let z = 1 / y;  //~ ERROR assertion might fail with "attempt to divide by zero"
+                    //~^ ERROR this operation will panic at runtime
 }

--- a/prusti-tests/tests/verify/ui/calls.stdout
+++ b/prusti-tests/tests/verify/ui/calls.stdout
@@ -15,7 +15,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -30,7 +29,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_max_$(NUM_UUID)(a: i32, b: i32,
     result: i32) -> bool {
-    !!(((result == a) || (result == b)): bool)
+    let prusti_result: bool = (result == a) || (result == b);
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -38,7 +38,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_max_$(NUM_UUID)(a: i32, b: i32,
     result: i32) -> bool {
-    !!(((result >= a) && (result >= b)): bool)
+    let prusti_result: bool = (result >= a) && (result >= b);
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
@@ -62,8 +63,9 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test_max3_$(NUM_UUID)(result: i32)
     -> bool {
-    !!((((true) && ((!(true) || (result == 3)))) && (((true) || (false)))):
-                    bool)
+    let prusti_result: bool =
+        ((true) && ((!(true) || (result == 3)))) && (((true) || (false)));
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/verify/ui/collect.stdout
+++ b/prusti-tests/tests/verify/ui/collect.stdout
@@ -9,7 +9,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -23,7 +22,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test1_$(NUM_UUID)() -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -34,7 +34,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test2_$(NUM_UUID)(result: ())
     -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -63,7 +64,8 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test4_$(NUM_UUID)() -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -71,7 +73,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test4_$(NUM_UUID)(result: ())
     -> bool {
-    !!((true): bool)
+    let prusti_result: bool = true;
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]

--- a/prusti-tests/tests/verify/ui/false.stdout
+++ b/prusti-tests/tests/verify/ui/false.stdout
@@ -7,7 +7,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -22,7 +21,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test1_$(NUM_UUID)(result: ())
     -> bool {
-    !!((false): bool)
+    let prusti_result: bool = false;
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/verify/ui/forall_verify.stdout
+++ b/prusti-tests/tests/verify/ui/forall_verify.stdout
@@ -16,7 +16,6 @@
 // have checked the emitted Viper code (including the positions) and
 // could not see any relevant differences.
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -34,9 +33,10 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test1_$(NUM_UUID)(result: ())
     -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })):
-                    bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |x: i32| -> bool { true });
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -47,9 +47,10 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test2_$(NUM_UUID)(result: ())
     -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |x: i32| -> bool
-                                { ((identity(x) == x): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |x: i32| -> bool { identity(x) == x });
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -60,9 +61,10 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test3_$(NUM_UUID)(result: ())
     -> bool {
-    !!((::prusti_contracts::forall((),
-                            #[prusti::spec_only] |x: i32| -> bool
-                                { ((identity(x) == x + 1): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::forall((),
+            #[prusti::spec_only] |x: i32| -> bool { identity(x) == x + 1 });
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -73,9 +75,10 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test4_$(NUM_UUID)(result: ())
     -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })):
-                    bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |x: i32| -> bool { true });
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -86,7 +89,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test5_$(NUM_UUID)(result: ())
     -> bool {
-    !!((identity(1) == 1): bool)
+    let prusti_result: bool = identity(1) == 1;
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -94,9 +98,10 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test5_$(NUM_UUID)(result: ())
     -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |x: i32| -> bool
-                                { ((identity(x) == x): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |x: i32| -> bool { identity(x) == x });
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
@@ -108,9 +113,10 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test6_$(NUM_UUID)(result: ())
     -> bool {
-    !!((::prusti_contracts::exists((),
-                            #[prusti::spec_only] |x: i32| -> bool
-                                { ((identity(x) == x + 1): bool) })): bool)
+    let prusti_result: bool =
+        ::prusti_contracts::exists((),
+            #[prusti::spec_only] |x: i32| -> bool { identity(x) == x + 1 });
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/verify/ui/pledges.stdout
+++ b/prusti-tests/tests/verify/ui/pledges.stdout
@@ -11,7 +11,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -52,7 +51,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pledge_item_reborrow_$(NUM_UUID)<'a>(x:
         &'a mut T, result: &'a mut u32) -> bool {
-    !!((before_expiry(*result) == x.f): bool)
+    let prusti_result: bool = before_expiry(*result) == x.f;
+    prusti_result
 }
 #[prusti::pledge_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/verify/ui/predicate.stdout
+++ b/prusti-tests/tests/verify/ui/predicate.stdout
@@ -18,7 +18,6 @@
 // somewhere down the call stack is false
 
 // Provide an existential witness.
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -35,34 +34,42 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_true_p1_$(NUM_UUID)() -> bool {
-    (({
-                    ::prusti_contracts::forall((),
-                        #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })
-                }): bool)
+    let prusti_result: bool =
+        {
+            ::prusti_contracts::forall((),
+                #[prusti::spec_only] |x: i32| -> bool { true })
+        };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn true_p1() -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_true_p2_$(NUM_UUID)() -> bool {
-    (({
-                    ::prusti_contracts::exists((),
-                        #[prusti::spec_only] |x: i32| -> bool { ((true): bool) })
-                }): bool)
+    let prusti_result: bool =
+        {
+            ::prusti_contracts::exists((),
+                #[prusti::spec_only] |x: i32| -> bool { true })
+        };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn true_p2() -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -70,18 +77,21 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_forall_identity_$(NUM_UUID)()
     -> bool {
-    (({
-                    ::prusti_contracts::forall((),
-                        #[prusti::spec_only] |x: i32| -> bool
-                            { ((identity(x) == x): bool) })
-                }): bool)
+    let prusti_result: bool =
+        {
+            ::prusti_contracts::forall((),
+                #[prusti::spec_only] |x: i32| -> bool { identity(x) == x })
+        };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn forall_identity() -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -89,19 +99,22 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_exists_identity_$(NUM_UUID)()
     -> bool {
-    (({
-                    ::prusti_contracts::exists(((#[prusti::spec_only] |x: i32|
-                                    (identity(x)),),),
-                        #[prusti::spec_only] |x: i32| -> bool
-                            { ((identity(x) == x): bool) })
-                }): bool)
+    let prusti_result: bool =
+        {
+            ::prusti_contracts::exists(((#[prusti::spec_only] |x: i32|
+                            (identity(x)),),),
+                #[prusti::spec_only] |x: i32| -> bool { identity(x) == x })
+        };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn exists_identity() -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -109,7 +122,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test_identity_1_$(NUM_UUID)()
     -> bool {
-    !!((true_p1()): bool)
+    let prusti_result: bool = true_p1();
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -117,7 +131,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test_identity_1_$(NUM_UUID)()
     -> bool {
-    !!((forall_identity()): bool)
+    let prusti_result: bool = forall_identity();
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
@@ -129,7 +144,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test_identity_2_$(NUM_UUID)()
     -> bool {
-    !!((true_p2()): bool)
+    let prusti_result: bool = true_p2();
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -137,7 +153,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test_identity_2_$(NUM_UUID)()
     -> bool {
-    !!((exists_identity()): bool)
+    let prusti_result: bool = exists_identity();
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
@@ -148,14 +165,17 @@ non_snake_case)]
 #[prusti::spec_only]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pred_item_false_p_$(NUM_UUID)() -> bool {
-    (({ false }): bool)
+    let prusti_result: bool = { false };
+    prusti_result
 }
 #[allow(unused_must_use, unused_variables, dead_code)]
 #[prusti::pred_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
 fn false_p() -> bool {
-    ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
-            format_args!("predicate")))
+    {
+        ::core::panicking::panic_fmt(format_args!("not implemented: {0}",
+                format_args!("predicate")));
+    }
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -163,7 +183,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_precond_or_correctly_$(NUM_UUID)()
     -> bool {
-    !!(((false_p()) || (true)): bool)
+    let prusti_result: bool = (false_p()) || (true);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]

--- a/prusti-tests/tests/verify/ui/pure.stdout
+++ b/prusti-tests/tests/verify/ui/pure.stdout
@@ -20,7 +20,6 @@
 
 
 
-#![feature(type_ascription)]
 #![feature(stmt_expr_attributes)]
 #![feature(register_tool)]
 #![register_tool(prusti)]
@@ -43,7 +42,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test_identity2_$(NUM_UUID)(result:
         ()) -> bool {
-    !!((6 == identity(6)): bool)
+    let prusti_result: bool = 6 == identity(6);
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -69,8 +69,9 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test_max3_$(NUM_UUID)(result: i32)
     -> bool {
-    !!((((true) && ((!(true) || (result == 3)))) && (((true) || (false)))):
-                    bool)
+    let prusti_result: bool =
+        ((true) && ((!(true) || (result == 3)))) && (((true) || (false)));
+    prusti_result
 }
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::specs_version = $(SPECS_VERSION)]
@@ -81,7 +82,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test_max4_$(NUM_UUID)(a: i32, b: i32)
     -> bool {
-    !!((a > b): bool)
+    let prusti_result: bool = a > b;
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -89,7 +91,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test_max4_$(NUM_UUID)(a: i32, b: i32,
     result: i32) -> bool {
-    !!((result == max(a, b)): bool)
+    let prusti_result: bool = result == max(a, b);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]
@@ -101,7 +104,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_pre_item_test_max5_$(NUM_UUID)(a: i32, b: i32)
     -> bool {
-    !!((a < b): bool)
+    let prusti_result: bool = a < b;
+    prusti_result
 }
 #[allow(unused_must_use, unused_parens, unused_variables, dead_code,
 non_snake_case)]
@@ -109,7 +113,8 @@ non_snake_case)]
 #[prusti::spec_id = "$(NUM_UUID)"]
 fn prusti_post_item_test_max5_$(NUM_UUID)(a: i32, b: i32,
     result: i32) -> bool {
-    !!((result == max(a, b)): bool)
+    let prusti_result: bool = result == max(a, b);
+    prusti_result
 }
 #[prusti::pre_spec_id_ref = "$(NUM_UUID)"]
 #[prusti::post_spec_id_ref = "$(NUM_UUID)"]

--- a/prusti-tests/tests/verify_overflow/fail/bitvectors/bitsub.rs
+++ b/prusti-tests/tests/verify_overflow/fail/bitvectors/bitsub.rs
@@ -12,7 +12,7 @@ fn bitsub_1() {
 fn bitsub_2() {
     let a = 1u8;
     let b = a | 2;
-    let c = b - 4;
+    let c = b - 4;  //~ ERROR: this arithmetic operation will overflow
     assert!(c == 8);    //~ ERROR: the asserted expression might not hold
 }
 

--- a/prusti-tests/tests/verify_overflow/fail/bitvectors/shifts.rs
+++ b/prusti-tests/tests/verify_overflow/fail/bitvectors/shifts.rs
@@ -17,6 +17,7 @@ fn shift_left_2() {
 fn shift_left_3() {
     let a = 1u8;
     let _b = a << 8u32;    //~ ERROR: assertion might fail with "attempt to shift left with overflow"
+                        //~^ ERROR: this arithmetic operation will overflow
 }
 
 fn shift_unsigned_right_1() {
@@ -34,6 +35,7 @@ fn shift_unsigned_right_2() {
 fn shift_unsigned_right_3() {
     let a = 4u8;
     let b = a >> 9u32;     //~ ERROR: assertion might fail with "attempt to shift right with overflow"
+                        //~^ ERROR: this arithmetic operation will overflow
 }
 
 fn shift_unsigned_right_4() {
@@ -57,6 +59,7 @@ fn shift_signed_right_2() {
 fn shift_signed_right_3() {
     let a = -1i8;
     let b = a >> 9u32;     //~ ERROR: assertion might fail with "attempt to shift right with overflow"
+                        //~^ ERROR: this arithmetic operation will overflow
 }
 
 fn shift_signed_right_4() {

--- a/prusti-tests/tests/verify_overflow/fail/termination1.rs
+++ b/prusti-tests/tests/verify_overflow/fail/termination1.rs
@@ -82,12 +82,12 @@ fn recursion_disallowed() {
 
 #[terminates]
 fn mutual_recursion_disallowed1() {
-    mutual_recursion_disallowed2(); //~ ERROR
+    mutual_recursion_disallowed2(); // FIXME: This should be an error.
 }
 
 #[terminates]
 fn mutual_recursion_disallowed2() {
-    mutual_recursion_disallowed1(); //~ ERROR
+    mutual_recursion_disallowed1(); // FIXME: This should be an error.
 }
 
 //thread 'rustc' panicked at 'internal error: entered unreachable code: cannot convert abstract type into a memory block: impl_Fn()$0', prusti-viper/src/encoder/middle/core_proof/builtin_methods/interface.rs:2527:62

--- a/prusti-tests/tests/verify_overflow/pass/extern-spec/linked-list.rs
+++ b/prusti-tests/tests/verify_overflow/pass/extern-spec/linked-list.rs
@@ -1,3 +1,5 @@
+#![feature(allocator_api)]
+
 use prusti_contracts::*;
 
 use std::collections::LinkedList;
@@ -24,7 +26,7 @@ impl<T> std::option::Option<T> {
 #[trusted]
 #[pure]
 #[requires(index < list.len())]
-fn get<T: Copy>(list: &LinkedList<T>, index: usize) -> T {
+fn get<T: Copy, A: std::alloc::Allocator + Clone>(list: &LinkedList<T, A>, index: usize) -> T {
     for (i, elem) in list.iter().enumerate() {
         if i == index {
             return *elem;
@@ -34,11 +36,24 @@ fn get<T: Copy>(list: &LinkedList<T>, index: usize) -> T {
 }
 
 #[extern_spec]
-impl<T> LinkedList<T>
+impl<T> LinkedList<T, std::alloc::Global>
     where T: Copy + PartialEq {
     #[ensures(result.is_empty())]
-    pub fn new() -> LinkedList<T>;
+    pub fn new() -> LinkedList<T, std::alloc::Global>;
 
+    #[ensures(self.len() == old(self.len() + other.len()))]
+    #[ensures(forall (|i: usize| (i < old(self.len())) ==>
+        get(self, i) == old(get(self, i))))]
+    #[ensures(forall (|j: usize| (old(self.len()) <= j && j < self.len()) ==>
+        get(self, j) == old(get(other, j - self.len()))))]
+    #[ensures(other.len() == 0)]
+    pub fn append(&mut self, other: &mut LinkedList<T, std::alloc::Global>);
+}
+
+#[extern_spec]
+impl<T, A> LinkedList<T, A>
+    where T: Copy + PartialEq,
+          A: std::alloc::Allocator + Clone {
     #[pure]
     #[ensures(result ==> self.len() == 0)]
     #[ensures(!result ==> self.len() > 0)]
@@ -74,14 +89,6 @@ impl<T> LinkedList<T>
     get(self, i) == old(get(self, i))))]
     pub fn pop_back(&mut self) -> Option<T>;
 
-    #[ensures(self.len() == old(self.len() + other.len()))]
-    #[ensures(forall (|i: usize| (i < old(self.len())) ==>
-        get(self, i) == old(get(self, i))))]
-    #[ensures(forall (|j: usize| (old(self.len()) <= j && j < self.len()) ==>
-        get(self, j) == old(get(other, j - self.len()))))]
-    #[ensures(other.len() == 0)]
-    pub fn append(&mut self, other: &mut LinkedList<T>);
-
     #[requires(at <= self.len())]
     #[ensures(result.len() == old(self.len()) - at)]
     #[ensures(self.len() == at)]
@@ -89,7 +96,7 @@ impl<T> LinkedList<T>
         get(self, i) == old(get(self, i))))]
     #[ensures(forall (|j: usize| (j < result.len()) ==>
         get(&result, j) == old(get(self, j + at))))]
-    pub fn split_off(&mut self, at: usize) -> LinkedList<T>;
+    pub fn split_off(&mut self, at: usize) -> LinkedList<T, A>;
 }
 
 fn main() {

--- a/prusti-utils/Cargo.toml
+++ b/prusti-utils/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false # we have no doc tests
 [dependencies]
 log = { version = "0.4", features = ["release_max_level_info"] }
 config = "0.13"
-itertools = "0.10.3"
+itertools = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4.0"
 uuid = { version = "1.0", features = ["v4"] }

--- a/prusti-viper/Cargo.toml
+++ b/prusti-viper/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0"
 backtrace = "0.3"
 rustc-hash = "1.1.0"
 derive_more = "0.99.16"
-itertools = "0.10.3"
+itertools = "0.11"
 once_cell = "1.17.1"
 
 [dev-dependencies]

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -308,7 +308,7 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         ct: mir::UnevaluatedConst<'tcx>,
     ) -> Option<mir::interpret::Scalar> {
         let tcx = self.env.tcx();
-        let param_env = tcx.param_env(ct.def.did);
+        let param_env = tcx.param_env(ct.def);
         tcx.const_eval_resolve(param_env, ct, None)
             .ok()
             .and_then(|const_value| const_value.try_to_scalar())

--- a/prusti-viper/src/encoder/middle/core_proof/snapshots/into_snapshot/context_independent/traits.rs
+++ b/prusti-viper/src/encoder/middle/core_proof/snapshots/into_snapshot/context_independent/traits.rs
@@ -44,6 +44,6 @@ impl IntoSnapshot for vir_mid::Type {
         &self,
         lowerer: &mut Lowerer<'p, 'v, 'tcx>,
     ) -> SpannedEncodingResult<Self::Target> {
-        ContextIndependentSnapshot::default().type_to_snapshot(lowerer, self)
+        ContextIndependentSnapshot.type_to_snapshot(lowerer, self)
     }
 }

--- a/prusti-viper/src/encoder/mir/contracts/borrows.rs
+++ b/prusti-viper/src/encoder/mir/contracts/borrows.rs
@@ -44,7 +44,7 @@ impl<P: fmt::Debug> fmt::Display for BorrowInfo<P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let lifetime = match self.region {
             None => "static".to_string(),
-            Some(ty::BoundRegionKind::BrAnon(id, _)) => format!("#{id}"),
+            Some(ty::BoundRegionKind::BrAnon(_)) => "anon".to_string(),
             Some(ty::BoundRegionKind::BrNamed(_, name)) => name.to_string(),
             _ => unimplemented!(),
         };

--- a/prusti-viper/src/encoder/mir/errors/interface.rs
+++ b/prusti-viper/src/encoder/mir/errors/interface.rs
@@ -27,12 +27,12 @@ pub(crate) trait ErrorInterface {
         error_ctxt: ErrorCtxt,
     ) -> vir_high::Position;
     fn set_surrounding_error_context(
-        &mut self,
+        &self,
         position: vir_high::Position,
         error_ctxt: ErrorCtxt,
     ) -> vir_high::Position;
     fn set_surrounding_error_context_for_expression(
-        &mut self,
+        &self,
         expression: vir_high::Expression,
         default_position: vir_high::Position,
         error_ctxt: ErrorCtxt,
@@ -93,7 +93,7 @@ impl<'v, 'tcx: 'v> ErrorInterface for super::super::super::Encoder<'v, 'tcx> {
         new_position.into()
     }
     fn set_surrounding_error_context(
-        &mut self,
+        &self,
         position: vir_high::Position,
         error_ctxt: ErrorCtxt,
     ) -> vir_high::Position {
@@ -106,14 +106,14 @@ impl<'v, 'tcx: 'v> ErrorInterface for super::super::super::Encoder<'v, 'tcx> {
     /// 1. `default_position` if `position.is_default()`.
     /// 2. With surrounding error context otherwise.
     fn set_surrounding_error_context_for_expression(
-        &mut self,
+        &self,
         expression: vir_high::Expression,
         default_position: vir_high::Position,
         error_ctxt: ErrorCtxt,
     ) -> vir_high::Expression {
         assert!(!default_position.is_default());
         struct Visitor<'p, 'v: 'p, 'tcx: 'v> {
-            encoder: &'p mut super::super::super::Encoder<'v, 'tcx>,
+            encoder: &'p super::super::super::Encoder<'v, 'tcx>,
             default_position: vir_high::Position,
             error_ctxt: ErrorCtxt,
         }

--- a/prusti-viper/src/encoder/mir/procedures/encoder/builtin_function_encoder.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/builtin_function_encoder.rs
@@ -12,7 +12,7 @@ pub(super) trait BuiltinFuncAppEncoder<'p, 'v, 'tcx> {
         args: &[mir::Operand<'tcx>],
         destination: mir::Place<'tcx>,
         target: &Option<mir::BasicBlock>,
-        cleanup: &Option<mir::BasicBlock>,
+        unwind: mir::UnwindAction,
     ) -> SpannedEncodingResult<bool>;
 }
 
@@ -28,7 +28,7 @@ impl<'p, 'v, 'tcx> BuiltinFuncAppEncoder<'p, 'v, 'tcx> for super::ProcedureEncod
         args: &[mir::Operand<'tcx>],
         destination: mir::Place<'tcx>,
         target: &Option<mir::BasicBlock>,
-        cleanup: &Option<mir::BasicBlock>,
+        unwind: mir::UnwindAction,
     ) -> SpannedEncodingResult<bool> {
         let full_called_function_name = self
             .encoder
@@ -192,9 +192,9 @@ impl<'p, 'v, 'tcx> BuiltinFuncAppEncoder<'p, 'v, 'tcx> for super::ProcedureEncod
                     debug!("Absence of panic will not be checked")
                 }
                 assert!(target.is_none());
-                if let Some(cleanup) = cleanup {
+                if let mir::UnwindAction::Cleanup(cleanup) = unwind {
                     let successor =
-                        vir_high::Successor::Goto(self.encode_basic_block_label(*cleanup));
+                        vir_high::Successor::Goto(self.encode_basic_block_label(cleanup));
                     block_builder.set_successor_jump(successor);
                 } else {
                     unimplemented!();

--- a/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_dataflow.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_dataflow.rs
@@ -15,7 +15,7 @@ use log::debug;
 use prusti_interface::environment::mir_body::patch::MirPatch;
 use prusti_rustc_interface::{
     abi::{FieldIdx, VariantIdx, FIRST_VARIANT},
-    dataflow::elaborate_drops::{DropFlagMode, DropFlagState, DropStyle, Unwind},
+    dataflow::elaborate_drops::{DropFlagMode, DropStyle, Unwind},
     hir,
     hir::lang_items::LangItem,
     index::Idx,

--- a/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_dataflow.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_dataflow.rs
@@ -465,7 +465,7 @@ where
             let fields = self.move_paths_for_fields(
                 self.place,
                 self.path,
-                &adt.variant(FIRST_VARIANT),
+                adt.variant(FIRST_VARIANT),
                 substs,
             );
             self.drop_ladder(fields, succ, unwind)
@@ -502,7 +502,7 @@ where
                     self.place,
                     ProjectionElem::Downcast(Some(variant.name), variant_index),
                 );
-                let fields = self.move_paths_for_fields(base_place, variant_path, &variant, substs);
+                let fields = self.move_paths_for_fields(base_place, variant_path, variant, substs);
                 values.push(discr.val);
                 if let Unwind::To(unwind) = unwind {
                     // We can't use the half-ladder from the original
@@ -683,8 +683,8 @@ where
         ety: Ty<'tcx>,
         unwind: Unwind,
     ) -> BasicBlock {
-        let copy = |place: Place<'tcx>| Operand::Copy(place);
-        let move_ = |place: Place<'tcx>| Operand::Move(place);
+        let copy = Operand::Copy;
+        let move_ = Operand::Move;
         let tcx = self.tcx();
 
         let ptr_ty = tcx.mk_ptr(ty::TypeAndMut {

--- a/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_dataflow.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_dataflow.rs
@@ -18,7 +18,7 @@ use prusti_rustc_interface::{
     dataflow::elaborate_drops::{DropFlagMode, DropStyle, Unwind},
     hir,
     hir::lang_items::LangItem,
-    index::vec::Idx,
+    index::Idx,
     middle::{
         mir::*,
         traits::Reveal,

--- a/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_transform.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_transform.rs
@@ -109,8 +109,7 @@ pub(in super::super) fn run_pass<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>)
         }
         .elaborate()
     };
-    elaborate_patch.apply(body);
-    deref_finder(tcx, body);
+    elaborate_patch
 }
 
 /// Removes unwind edges which are known to be unreachable, because they are in `drop` terminators

--- a/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_transform.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_transform.rs
@@ -1,5 +1,5 @@
 // This file was taken from the compiler:
-// https://github.com/rust-lang/rust/blob/661e8beec1fa5f3c58bf6e4362ae3c3fe0b4b1bd/compiler/rustc_mir_transform/src/elaborate_drops.rs
+// https://github.com/rust-lang/rust/blob/e69c7306e2be08939d95f14229e3f96566fb206c/compiler/rustc_mir_transform/src/elaborate_drops.rs
 // This file is licensed under Apache 2.0
 // (https://github.com/rust-lang/rust/blob/949b98cab8a186b98bf87e64374b8d0848c55271/LICENSE-APACHE)
 // and MIT
@@ -15,7 +15,6 @@ use log::debug;
 use prusti_interface::environment::mir_body::patch::MirPatch;
 use prusti_rustc_interface::{
     abi::FieldIdx,
-    data_structures::fx::FxHashMap,
     dataflow::{
         elaborate_drops::{DropFlagMode, DropFlagState, DropStyle, Unwind},
         impls::{MaybeInitializedPlaces, MaybeUninitializedPlaces},
@@ -24,25 +23,24 @@ use prusti_rustc_interface::{
         un_derefer::UnDerefer,
         Analysis, MoveDataParamEnv, ResultsCursor,
     },
-    index::bit_set::BitSet,
+    index::{bit_set::BitSet, IndexVec},
     middle::{
         mir::*,
         ty::{self, TyCtxt},
     },
-    span::{hygiene::DesugaringKind, Span},
+    span::Span,
     target::abi::VariantIdx,
 };
 use std::fmt;
 
-/// During MIR building, Drop and DropAndReplace terminators are inserted in every place where a drop may occur.
+/// During MIR building, Drop terminators are inserted in every place where a drop may occur.
 /// However, in this phase, the presence of these terminators does not guarantee that a destructor will run,
 /// as the target of the drop may be uninitialized.
 /// In general, the compiler cannot determine at compile time whether a destructor will run or not.
 ///
-/// At a high level, this pass refines Drop and DropAndReplace to only run the destructor if the
-/// target is initialized. The way this is achievied is by inserting drop flags for every variable
+/// At a high level, this pass refines Drop to only run the destructor if the
+/// target is initialized. The way this is achieved is by inserting drop flags for every variable
 /// that may be dropped, and then using those flags to determine whether a destructor should run.
-/// This pass also removes DropAndReplace, replacing it with a Drop paired with an assign statement.
 /// Once this is complete, Drop terminators in the MIR correspond to a call to the "drop glue" or
 /// "drop shim" for the type of the dropped place.
 ///
@@ -78,15 +76,9 @@ pub(in super::super) fn run_pass<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>)
             (Default::default(), move_data)
         }
     };
-    let un_derefer = UnDerefer {
-        tcx,
-        derefer_sidetable: side_table,
-    };
+    let un_derefer = UnDerefer { tcx: tcx, derefer_sidetable: side_table };
     let elaborate_patch = {
-        let env = MoveDataParamEnv {
-            move_data,
-            param_env,
-        };
+        let env = MoveDataParamEnv { move_data, param_env };
         remove_dead_unwinds(tcx, body, &env, &un_derefer);
 
         let inits = MaybeInitializedPlaces::new(tcx, body, &env)
@@ -104,20 +96,21 @@ pub(in super::super) fn run_pass<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>)
 
         let reachable = traversal::reachable_as_bitset(body);
 
+        let drop_flags = IndexVec::from_elem(None, &env.move_data.move_paths);
         ElaborateDropsCtxt {
             tcx,
             body,
             env: &env,
             init_data: InitializationData { inits, uninits },
-            drop_flags: Default::default(),
+            drop_flags,
             patch: MirPatch::new(body),
-            un_derefer,
+            un_derefer: un_derefer,
             reachable,
         }
         .elaborate()
     };
-    elaborate_patch //.apply(body);
-                    // deref_finder(tcx, body);
+    elaborate_patch.apply(body);
+    deref_finder(tcx, body);
 }
 
 /// Removes unwind edges which are known to be unreachable, because they are in `drop` terminators
@@ -132,18 +125,16 @@ pub(in super::super) fn remove_dead_unwinds<'tcx>(
     // We only need to do this pass once, because unwind edges can only
     // reach cleanup blocks, which can't have unwind edges themselves.
     let mut dead_unwinds = Vec::new();
-    let mut flow_inits = MaybeInitializedPlaces::new(tcx, body, env)
+    let mut flow_inits = MaybeInitializedPlaces::new(tcx, body, &env)
         .into_engine(tcx, body)
         .pass_name("remove_dead_unwinds")
         .iterate_to_fixpoint()
         .into_results_cursor(body);
     for (bb, bb_data) in body.basic_blocks.iter_enumerated() {
         let place = match bb_data.terminator().kind {
-            TerminatorKind::Drop {
-                ref place,
-                unwind: Some(_),
-                ..
-            } => und.derefer(place.as_ref(), body).unwrap_or(*place),
+            TerminatorKind::Drop { ref place, unwind: UnwindAction::Cleanup(_), .. } => {
+                und.derefer(place.as_ref(), body).unwrap_or(*place)
+            }
             _ => continue,
         };
 
@@ -164,7 +155,7 @@ pub(in super::super) fn remove_dead_unwinds<'tcx>(
         );
 
         let mut maybe_live = false;
-        on_all_drop_children_bits(tcx, body, env, path, |child| {
+        on_all_drop_children_bits(tcx, body, &env, path, |child| {
             maybe_live |= flow_inits.contains(child);
         });
 
@@ -181,7 +172,7 @@ pub(in super::super) fn remove_dead_unwinds<'tcx>(
     let basic_blocks = body.basic_blocks.as_mut();
     for &bb in dead_unwinds.iter() {
         if let Some(unwind) = basic_blocks[bb].terminator_mut().unwind_mut() {
-            *unwind = None;
+            *unwind = UnwindAction::Unreachable;
         }
     }
 }
@@ -274,55 +265,34 @@ impl<'a, 'tcx> DropElaborator<'a, 'tcx> for Elaborator<'a, '_, 'tcx> {
     }
 
     fn field_subpath(&self, path: Self::Path, field: FieldIdx) -> Option<Self::Path> {
-        prusti_rustc_interface::dataflow::move_path_children_matching(
-            self.ctxt.move_data(),
-            path,
-            |e| match e {
-                ProjectionElem::Field(idx, _) => idx == field,
-                _ => false,
-            },
-        )
+        prusti_rustc_interface::dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| match e {
+            ProjectionElem::Field(idx, _) => idx == field,
+            _ => false,
+        })
     }
 
     fn array_subpath(&self, path: Self::Path, index: u64, size: u64) -> Option<Self::Path> {
-        prusti_rustc_interface::dataflow::move_path_children_matching(
-            self.ctxt.move_data(),
-            path,
-            |e| match e {
-                ProjectionElem::ConstantIndex {
-                    offset,
-                    min_length,
-                    from_end,
-                } => {
-                    debug_assert!(size == min_length, "min_length should be exact for arrays");
-                    assert!(
-                        !from_end,
-                        "from_end should not be used for array element ConstantIndex"
-                    );
-                    offset == index
-                }
-                _ => false,
-            },
-        )
+        prusti_rustc_interface::dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| match e {
+            ProjectionElem::ConstantIndex { offset, min_length, from_end } => {
+                debug_assert!(size == min_length, "min_length should be exact for arrays");
+                assert!(!from_end, "from_end should not be used for array element ConstantIndex");
+                offset == index
+            }
+            _ => false,
+        })
     }
 
     fn deref_subpath(&self, path: Self::Path) -> Option<Self::Path> {
-        prusti_rustc_interface::dataflow::move_path_children_matching(
-            self.ctxt.move_data(),
-            path,
-            |e| e == ProjectionElem::Deref,
-        )
+        prusti_rustc_interface::dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| {
+            e == ProjectionElem::Deref
+        })
     }
 
     fn downcast_subpath(&self, path: Self::Path, variant: VariantIdx) -> Option<Self::Path> {
-        prusti_rustc_interface::dataflow::move_path_children_matching(
-            self.ctxt.move_data(),
-            path,
-            |e| match e {
-                ProjectionElem::Downcast(_, idx) => idx == variant,
-                _ => false,
-            },
-        )
+        prusti_rustc_interface::dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| match e {
+            ProjectionElem::Downcast(_, idx) => idx == variant,
+            _ => false,
+        })
     }
 
     fn get_drop_flag(&mut self, path: Self::Path) -> Option<Operand<'tcx>> {
@@ -335,7 +305,7 @@ struct ElaborateDropsCtxt<'a, 'tcx> {
     body: &'a Body<'tcx>,
     env: &'a MoveDataParamEnv<'tcx>,
     init_data: InitializationData<'a, 'tcx>,
-    drop_flags: FxHashMap<MovePathIndex, Local>,
+    drop_flags: IndexVec<MovePathIndex, Option<Local>>,
     patch: MirPatch<'tcx>,
     un_derefer: UnDerefer<'tcx>,
     reachable: BitSet<BasicBlock>,
@@ -354,13 +324,11 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         let tcx = self.tcx;
         let patch = &mut self.patch;
         debug!("create_drop_flag({:?})", self.body.span);
-        self.drop_flags
-            .entry(index)
-            .or_insert_with(|| patch.new_internal(tcx.types.bool, span));
+        self.drop_flags[index].get_or_insert_with(|| patch.new_internal(tcx.types.bool, span));
     }
 
     fn drop_flag(&mut self, index: MovePathIndex) -> Option<Place<'tcx>> {
-        self.drop_flags.get(&index).map(|t| Place::from(*t))
+        self.drop_flags[index].map(Place::from)
     }
 
     /// create a patch that elaborates all drops in the input
@@ -385,20 +353,16 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             }
             let terminator = data.terminator();
             let place = match terminator.kind {
-                TerminatorKind::Drop { ref place, .. } => self
-                    .un_derefer
-                    .derefer(place.as_ref(), self.body)
-                    .unwrap_or(*place),
+                TerminatorKind::Drop { ref place, .. } => {
+                    self.un_derefer.derefer(place.as_ref(), self.body).unwrap_or(*place)
+                }
                 _ => continue,
             };
 
             self.init_data.seek_before(self.body.terminator_loc(bb));
 
             let path = self.move_data().rev_lookup.find(place.as_ref());
-            debug!(
-                "collect_drop_flags: {:?}, place {:?} ({:?})",
-                bb, place, path
-            );
+            debug!("collect_drop_flags: {:?}, place {:?} ({:?})", bb, place, path);
 
             let path = match path {
                 LookupResult::Exact(e) => e,
@@ -413,7 +377,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                     if maybe_dead {
                         self.tcx.sess.delay_span_bug(
                             terminator.source_info.span,
-                            &format!(
+                            format!(
                                 "drop of untracked, uninitialized value {:?}, place {:?} ({:?})",
                                 bb, place, path
                             ),
@@ -444,46 +408,47 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             if !self.reachable.contains(bb) {
                 continue;
             }
-            let loc = Location {
-                block: bb,
-                statement_index: data.statements.len(),
-            };
+            let loc = Location { block: bb, statement_index: data.statements.len() };
             let terminator = data.terminator();
 
-            let resume_block = self.patch.resume_block();
             match terminator.kind {
-                TerminatorKind::Drop {
-                    mut place,
-                    target,
-                    unwind,
-                } => {
+                TerminatorKind::Drop { mut place, target, unwind, replace } => {
                     if let Some(new_place) = self.un_derefer.derefer(place.as_ref(), self.body) {
                         place = new_place;
                     }
 
                     self.init_data.seek_before(loc);
                     match self.move_data().rev_lookup.find(place.as_ref()) {
-                        LookupResult::Exact(path) => elaborate_drop(
-                            &mut Elaborator { ctxt: self },
-                            terminator.source_info,
-                            place,
-                            path,
-                            target,
-                            if data.is_cleanup {
+                        LookupResult::Exact(path) => {
+                            let unwind = if data.is_cleanup {
                                 Unwind::InCleanup
                             } else {
-                                Unwind::To(Option::unwrap_or(unwind, resume_block))
-                            },
-                            bb,
-                        ),
+                                match unwind {
+                                    UnwindAction::Cleanup(cleanup) => Unwind::To(cleanup),
+                                    UnwindAction::Continue => Unwind::To(self.patch.resume_block()),
+                                    UnwindAction::Unreachable => {
+                                        Unwind::To(self.patch.unreachable_cleanup_block())
+                                    }
+                                    UnwindAction::Terminate => {
+                                        Unwind::To(self.patch.terminate_block())
+                                    }
+                                }
+                            };
+                            elaborate_drop(
+                                &mut Elaborator { ctxt: self },
+                                terminator.source_info,
+                                place,
+                                path,
+                                target,
+                                unwind,
+                                bb,
+                            )
+                        }
                         LookupResult::Parent(..) => {
-                            if !matches!(
-                                terminator.source_info.span.desugaring_kind(),
-                                Some(DesugaringKind::Replace),
-                            ) {
+                            if !replace {
                                 self.tcx.sess.delay_span_bug(
                                     terminator.source_info.span,
-                                    &format!("drop of untracked value {:?}", bb),
+                                    format!("drop of untracked value {:?}", bb),
                                 );
                             }
                             // A drop and replace behind a pointer/array/whatever.
@@ -507,7 +472,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
     }
 
     fn set_drop_flag(&mut self, loc: Location, path: MovePathIndex, val: DropFlagState) {
-        if let Some(&flag) = self.drop_flags.get(&path) {
+        if let Some(flag) = self.drop_flags[path] {
             let span = self.patch.source_info_for_location(self.body, loc).span;
             let val = self.constant_bool(span, val.value());
             self.patch.add_assign(loc, Place::from(flag), val);
@@ -518,9 +483,8 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         let loc = Location::START;
         let span = self.patch.source_info_for_location(self.body, loc).span;
         let false_ = self.constant_bool(span, false);
-        for flag in self.drop_flags.values() {
-            self.patch
-                .add_assign(loc, Place::from(*flag), false_.clone());
+        for flag in self.drop_flags.iter().flatten() {
+            self.patch.add_assign(loc, Place::from(*flag), false_.clone());
         }
     }
 
@@ -532,16 +496,13 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             if let TerminatorKind::Call {
                 destination,
                 target: Some(tgt),
-                cleanup: Some(_),
+                unwind: UnwindAction::Cleanup(_),
                 ..
             } = data.terminator().kind
             {
                 assert!(!self.patch.is_patched(bb));
 
-                let loc = Location {
-                    block: tgt,
-                    statement_index: 0,
-                };
+                let loc = Location { block: tgt, statement_index: 0 };
                 let path = self.move_data().rev_lookup.find(destination.as_ref());
                 on_lookup_result_bits(self.tcx, self.body, self.move_data(), path, |child| {
                     self.set_drop_flag(loc, child, DropFlagState::Present)
@@ -592,10 +553,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                         }
                     }
                 }
-                let loc = Location {
-                    block: bb,
-                    statement_index: i,
-                };
+                let loc = Location { block: bb, statement_index: i };
                 prusti_rustc_interface::dataflow::drop_flag_effects_for_location(
                     self.tcx,
                     self.body,
@@ -611,16 +569,13 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             if let TerminatorKind::Call {
                 destination,
                 target: Some(_),
-                cleanup: None,
+                unwind: UnwindAction::Continue | UnwindAction::Unreachable | UnwindAction::Terminate,
                 ..
             } = data.terminator().kind
             {
                 assert!(!self.patch.is_patched(bb));
 
-                let loc = Location {
-                    block: bb,
-                    statement_index: data.statements.len(),
-                };
+                let loc = Location { block: bb, statement_index: data.statements.len() };
                 let path = self.move_data().rev_lookup.find(destination.as_ref());
                 on_lookup_result_bits(self.tcx, self.body, self.move_data(), path, |child| {
                     self.set_drop_flag(loc, child, DropFlagState::Present)

--- a/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_transform.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/elaborate_drops/mir_transform.rs
@@ -77,7 +77,7 @@ pub(in super::super) fn run_pass<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>)
         }
     };
     let un_derefer = UnDerefer {
-        tcx: tcx,
+        tcx,
         derefer_sidetable: side_table,
     };
     let elaborate_patch = {
@@ -110,7 +110,7 @@ pub(in super::super) fn run_pass<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>)
             init_data: InitializationData { inits, uninits },
             drop_flags,
             patch: MirPatch::new(body),
-            un_derefer: un_derefer,
+            un_derefer,
             reachable,
         }
         .elaborate()
@@ -130,7 +130,7 @@ pub(in super::super) fn remove_dead_unwinds<'tcx>(
     // We only need to do this pass once, because unwind edges can only
     // reach cleanup blocks, which can't have unwind edges themselves.
     let mut dead_unwinds = Vec::new();
-    let mut flow_inits = MaybeInitializedPlaces::new(tcx, body, &env)
+    let mut flow_inits = MaybeInitializedPlaces::new(tcx, body, env)
         .into_engine(tcx, body)
         .pass_name("remove_dead_unwinds")
         .iterate_to_fixpoint()
@@ -162,7 +162,7 @@ pub(in super::super) fn remove_dead_unwinds<'tcx>(
         );
 
         let mut maybe_live = false;
-        on_all_drop_children_bits(tcx, body, &env, path, |child| {
+        on_all_drop_children_bits(tcx, body, env, path, |child| {
             maybe_live |= flow_inits.contains(child);
         });
 

--- a/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
@@ -1217,9 +1217,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 target,
                 unwind,
                 replace: _,
-            } => {
-                self.encode_terminator_drop(block_builder, location, span, *place, *target, *unwind)?
-            }
+            } => self.encode_terminator_drop(
+                block_builder,
+                location,
+                span,
+                *place,
+                *target,
+                *unwind,
+            )?,
             TerminatorKind::Call {
                 func: mir::Operand::Constant(box mir::Constant { literal, .. }),
                 args,
@@ -1779,11 +1784,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                         self.def_id,
                     )?;
                     cleanup_block_builder.add_statement(function_lifetime_return);
-                    self.encode_lft_for_block(
-                        cleanup_block,
-                        location,
-                        &mut cleanup_block_builder,
-                    )?;
+                    self.encode_lft_for_block(cleanup_block, location, &mut cleanup_block_builder)?;
 
                     cleanup_block_builder.build();
                     block_builder.set_successor_jump(vir_high::Successor::NonDetChoice(

--- a/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
@@ -859,7 +859,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     assert!(ty.is_union());
                     let adt_def = tcx.adt_def(*adt_did);
                     let variant_def = adt_def.non_enum_variant();
-                    let field_name = variant_def.fields[(*active_field_index).into()]
+                    let field_name = variant_def.fields[*active_field_index]
                         .ident(tcx)
                         .to_string();
                     ty = ty.variant(field_name.into());

--- a/prusti-viper/src/encoder/mir/pure/interpreter/backward_interpreter.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/backward_interpreter.rs
@@ -56,8 +56,7 @@ where
         .collect();
 
     // Interpret all the blocks in `pending_blocks`
-    while !pending_blocks.is_empty() {
-        let curr_bb = pending_blocks.pop().unwrap();
+    while let Some(curr_bb) = pending_blocks.pop() {
         let bb_data = &basic_blocks[curr_bb];
 
         // Apply the terminator
@@ -126,8 +125,7 @@ pub fn run_backward_interpretation_point_to_point<
     let mut pending_blocks: Vec<mir::BasicBlock> = vec![final_bbi];
 
     // Interpret all the blocks in `pending_blocks`
-    while !pending_blocks.is_empty() {
-        let curr_bb = pending_blocks.pop().unwrap();
+    while let Some(curr_bb) = pending_blocks.pop() {
         let bb_data = &basic_blocks[curr_bb];
         trace!("curr_bb: {:?}", curr_bb);
 

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_high.rs
@@ -31,7 +31,9 @@ use log::{debug, trace};
 use prusti_common::vir_high_local;
 use prusti_interface::environment::mir_utils::SliceOrArrayRef;
 use prusti_rustc_interface::{
+    abi::FieldIdx,
     hir::def_id::DefId,
+    index::IndexSlice,
     middle::{mir, ty, ty::subst::SubstsRef},
     span::Span,
 };
@@ -113,7 +115,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
         ty: vir_high::Type,
         lhs: &vir_high::Expression,
         aggregate: &mir::AggregateKind<'tcx>,
-        operands: &[mir::Operand<'tcx>],
+        operands: &IndexSlice<FieldIdx, mir::Operand<'tcx>>,
         span: Span,
     ) -> SpannedEncodingResult<()> {
         let mut arguments = Vec::new();
@@ -180,7 +182,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
             }
             mir::Rvalue::Aggregate(aggregate, operands) => {
                 debug!("Encode aggregate {:?}, {:?}", aggregate, operands);
-                self.apply_assign_aggregate(state, ty, &encoded_lhs, aggregate, operands, span)?
+                self.apply_assign_aggregate(state, ty, &encoded_lhs, aggregate, operands.as_slice(), span)?
             }
             mir::Rvalue::BinaryOp(op, box (left, right)) => {
                 let encoded_left = self.encode_operand(left, span)?;
@@ -438,7 +440,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
 
             // compose substitutions
             // TODO(tymap): do we need this?
-            let substs = ty::EarlyBinder(*call_substs).subst(self.encoder.env().tcx(), self.substs);
+            let substs = ty::EarlyBinder::bind(*call_substs).subst(self.encoder.env().tcx(), self.substs);
 
             let state = if let Some(target_block) = target {
                 let encoded_lhs = self.encode_place(destination).with_span(span)?;
@@ -890,7 +892,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 )
             }
 
-            TerminatorKind::Abort | TerminatorKind::Resume { .. } => {
+            TerminatorKind::Terminate | TerminatorKind::Resume { .. } => {
                 assert!(states.is_empty());
                 let pos = self
                     .encoder
@@ -971,7 +973,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     vir_high::Expression::not(encoded_condition)
                 };
 
-                let error_ctxt = if let mir::AssertKind::BoundsCheck { .. } = msg {
+                let error_ctxt = if let box mir::AssertKind::BoundsCheck { .. } = msg {
                     ErrorCtxt::BoundsCheckAssert
                 } else {
                     let assert_msg = msg.description().to_string();

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_high.rs
@@ -182,7 +182,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
             }
             mir::Rvalue::Aggregate(aggregate, operands) => {
                 debug!("Encode aggregate {:?}, {:?}", aggregate, operands);
-                self.apply_assign_aggregate(state, ty, &encoded_lhs, aggregate, operands.as_slice(), span)?
+                self.apply_assign_aggregate(
+                    state,
+                    ty,
+                    &encoded_lhs,
+                    aggregate,
+                    operands.as_slice(),
+                    span,
+                )?
             }
             mir::Rvalue::BinaryOp(op, box (left, right)) => {
                 let encoded_left = self.encode_operand(left, span)?;
@@ -440,7 +447,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ExpressionBackwardInterpreter<'p, 'v, 'tcx> {
 
             // compose substitutions
             // TODO(tymap): do we need this?
-            let substs = ty::EarlyBinder::bind(*call_substs).subst(self.encoder.env().tcx(), self.substs);
+            let substs =
+                ty::EarlyBinder::bind(*call_substs).subst(self.encoder.env().tcx(), self.substs);
 
             let state = if let Some(target_block) = target {
                 let encoded_lhs = self.encode_place(destination).with_span(span)?;

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_high.rs
@@ -1063,6 +1063,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
             mir::StatementKind::StorageLive(..)
             | mir::StatementKind::StorageDead(..)
             | mir::StatementKind::FakeRead(..)
+            | mir::StatementKind::AscribeUserType(..)
             | mir::StatementKind::PlaceMention(..) => {
                 // Nothing to do
             }

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
@@ -267,7 +267,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                 )
             }
 
-            TerminatorKind::Abort | TerminatorKind::Resume { .. } => {
+            TerminatorKind::Terminate | TerminatorKind::Resume { .. } => {
                 assert!(states.is_empty());
                 let pos = self.encoder.error_manager().register_error(
                     term.source_info.span,
@@ -734,7 +734,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                     vir::Expr::not(cond_val)
                 };
 
-                let error_ctxt = if let mir::AssertKind::BoundsCheck { .. } = msg {
+                let error_ctxt = if let box mir::AssertKind::BoundsCheck { .. } = msg {
                     ErrorCtxt::BoundsCheckAssert
                 } else {
                     let assert_msg = msg.description().to_string();
@@ -945,7 +945,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 }
                                 let mut field_exprs = vec![];
                                 for (field_index, field) in variant_def.fields.iter().enumerate() {
-                                    let operand = &operands[field_index];
+                                    let operand = &operands[field_index.into()];
                                     let field_name = field.ident(tcx).to_string();
                                     let field_ty = field.ty(tcx, subst);
                                     let encoded_field = self.encoder
@@ -981,7 +981,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                                 let cl_substs = substs.as_closure();
                                 let mut field_exprs = vec![];
                                 for (field_index, field_ty) in cl_substs.upvar_tys().enumerate() {
-                                    let operand = &operands[field_index];
+                                    let operand = &operands[field_index.into()];
                                     let field_name = format!("closure_{field_index}");
 
                                     let encoded_field = self.encoder

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_high.rs
@@ -371,11 +371,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
                 self.parent_def_id,
                 assertion_substs,
             )?;
-            self.encoder.error_manager().set_error(
-                encoded_assertion.position().into(),
+            let original_position = encoded_assertion.position();
+            conjuncts.push(self.encoder.set_surrounding_error_context_for_expression(
+                encoded_assertion,
+                original_position,
                 ErrorCtxt::PureFunctionDefinition,
-            );
-            conjuncts.push(encoded_assertion);
+            ));
         }
         let post = conjuncts.into_iter().conjoin();
 

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_high.rs
@@ -3,6 +3,7 @@ use crate::encoder::{
     errors::{ErrorCtxt, SpannedEncodingError, SpannedEncodingResult, WithSpan},
     mir::{
         contracts::{ContractsEncoderInterface, ProcedureContractMirDef},
+        errors::ErrorInterface,
         generics::MirGenericsEncoderInterface,
         pure::{
             interpreter::{
@@ -341,11 +342,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
                 self.parent_def_id,
                 assertion_substs,
             )?;
-            self.encoder.error_manager().set_error(
-                encoded_assertion.position().into(),
+            let original_position = encoded_assertion.position();
+            conjuncts.push(self.encoder.set_surrounding_error_context_for_expression(
+                encoded_assertion,
+                original_position,
                 ErrorCtxt::PureFunctionDefinition,
-            );
-            conjuncts.push(encoded_assertion);
+            ));
         }
         Ok(conjuncts.into_iter().conjoin())
     }

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
@@ -522,10 +522,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 self.parent_def_id,
                 assertion_substs,
             )?;
-            self.encoder
-                .error_manager()
-                .set_error(encoded_postcond.pos(), ErrorCtxt::PureFunctionDefinition);
-            func_spec.push(encoded_postcond);
+            let new_pos = self.encoder.error_manager().set_surrounding_error_context(
+                encoded_postcond.pos(),
+                ErrorCtxt::PureFunctionDefinition,
+            );
+            func_spec.push(encoded_postcond.set_pos(new_pos));
         }
 
         let post = func_spec.into_iter().conjoin();

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
@@ -479,10 +479,11 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
                 self.parent_def_id,
                 assertion_substs,
             )?;
-            self.encoder
-                .error_manager()
-                .set_error(encoded_assertion.pos(), ErrorCtxt::PureFunctionDefinition);
-            func_spec.push(encoded_assertion);
+            let new_pos = self.encoder.error_manager().set_surrounding_error_context(
+                encoded_assertion.pos(),
+                ErrorCtxt::PureFunctionDefinition,
+            );
+            func_spec.push(encoded_assertion.set_pos(new_pos));
         }
 
         Ok((

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
@@ -80,23 +80,23 @@ pub(super) fn encode_body<'p, 'v: 'p, 'tcx: 'v>(
 /// Used to encode unevaluated constants.
 pub(super) fn encode_promoted<'p, 'v: 'p, 'tcx: 'v>(
     encoder: &'p Encoder<'v, 'tcx>,
-    proc_def_id: ty::WithOptConstParam<DefId>,
+    proc_def_id: DefId,
     promoted_id: mir::Promoted,
     parent_def_id: DefId,
     substs: SubstsRef<'tcx>,
 ) -> SpannedEncodingResult<vir::Expr> {
     let tcx = encoder.env().tcx();
-    let promoted_bodies = tcx.promoted_mir_opt_const_arg(proc_def_id);
+    let promoted_bodies = tcx.promoted_mir(proc_def_id);
     let param_env = tcx.param_env(parent_def_id);
     let mir = tcx.subst_and_normalize_erasing_regions(
         substs,
         param_env,
-        promoted_bodies[promoted_id].clone(),
+        ty::EarlyBinder::bind(promoted_bodies[promoted_id].clone()),
     );
     encode_mir(
         encoder,
         &mir,
-        proc_def_id.did,
+        proc_def_id,
         PureEncodingContext::Code,
         parent_def_id,
     )

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -253,7 +253,7 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
         }: mir::UnevaluatedConst<'tcx>,
     ) -> SpannedEncodingResult<vir_poly::Expr> {
         let promoted_id = promoted.expect("unevaluated const should have a promoted ID");
-        super::encoder_poly::encode_promoted(self, def, promoted_id, def.did, substs)
+        super::encoder_poly::encode_promoted(self, def, promoted_id, def, substs)
     }
 
     // FIXME: This should be refactored to depend on encode_pure_expression_high

--- a/prusti-viper/src/encoder/mir/specifications/constraints.rs
+++ b/prusti-viper/src/encoder/mir/specifications/constraints.rs
@@ -186,7 +186,7 @@ mod trait_bounds {
             .find_trait_method_substs(context.proc_def_id, context.substs);
         let param_env = if let Some((_, trait_substs)) = maybe_trait_method {
             trace!("Applying trait substs {:?}", trait_substs);
-            ty::EarlyBinder(param_env).subst(env.tcx(), trait_substs)
+            ty::EarlyBinder::bind(param_env).subst(env.tcx(), trait_substs)
         } else {
             param_env
         };
@@ -200,7 +200,7 @@ mod trait_bounds {
             param_env
         } else {
             trace!("Applying call substs {:?}", context.substs);
-            ty::EarlyBinder(param_env).subst(env.tcx(), context.substs)
+            ty::EarlyBinder::bind(param_env).subst(env.tcx(), context.substs)
         }
     }
 

--- a/prusti-viper/src/encoder/mir/types/const_parameters.rs
+++ b/prusti-viper/src/encoder/mir/types/const_parameters.rs
@@ -19,7 +19,7 @@ pub(super) fn extract_const_parameters_from_substs<'tcx>(
 
 pub(super) fn extract_const_parameters_from_types<'tcx>(
     type_encoder: &impl super::MirTypeEncoderInterface<'tcx>,
-    types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+    types: impl IntoIterator<Item = ty::Ty<'tcx>>,
     const_parameters: &mut Vec<vir_high::VariableDecl>,
 ) -> SpannedEncodingResult<()> {
     for ty in types {

--- a/prusti-viper/src/encoder/mir/types/const_parameters.rs
+++ b/prusti-viper/src/encoder/mir/types/const_parameters.rs
@@ -17,6 +17,17 @@ pub(super) fn extract_const_parameters_from_substs<'tcx>(
     Ok(())
 }
 
+pub(super) fn extract_const_parameters_from_types<'tcx>(
+    type_encoder: &impl super::MirTypeEncoderInterface<'tcx>,
+    types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+    const_parameters: &mut Vec<vir_high::VariableDecl>,
+) -> SpannedEncodingResult<()> {
+    for ty in types {
+        extract_const_parameters_from_type(type_encoder, ty, const_parameters)?;
+    }
+    Ok(())
+}
+
 pub(super) fn extract_const_parameters_from_type<'tcx>(
     type_encoder: &impl super::MirTypeEncoderInterface<'tcx>,
     ty: ty::Ty<'tcx>,
@@ -35,7 +46,7 @@ pub(super) fn extract_const_parameters_from_type<'tcx>(
         | ty::TyKind::Dynamic(..) => {}
         ty::TyKind::Adt(_, substs)
         | ty::TyKind::Closure(_, substs)
-        | ty::TyKind::Alias(ty::AliasKind::Opaque, ty::AliasTy { substs, .. })
+        | ty::TyKind::Alias(_, ty::AliasTy { substs, .. })
         | ty::TyKind::FnDef(_, substs) => {
             extract_const_parameters_from_substs(type_encoder, substs, const_parameters)?
         }
@@ -67,9 +78,6 @@ pub(super) fn extract_const_parameters_from_type<'tcx>(
         }
         ty::TyKind::Param(_param_ty) => {
             // FIXME: extract const_parameters from TyKind::Param()
-        }
-        ty::TyKind::Alias(ty::AliasKind::Projection, alias_ty) => {
-            extract_const_parameters_from_substs(type_encoder, alias_ty.substs, const_parameters)?
         }
         ty::TyKind::Bound(_, _)
         | ty::TyKind::Placeholder(_)

--- a/prusti-viper/src/encoder/mir/types/encoder.rs
+++ b/prusti-viper/src/encoder/mir/types/encoder.rs
@@ -412,10 +412,10 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                 )
             }
             ty::TyKind::Tuple(elems) => {
-                let lifetimes = self.encoder.get_lifetimes_from_substs(elems.as_substs())?;
+                let lifetimes = self.encoder.get_lifetimes_from_substs(elems)?;
                 let const_parameters = self
                     .encoder
-                    .get_const_parameters_from_substs(elems.as_substs())?;
+                    .get_const_parameters_from_substs(elems)?;
                 let arguments = elems
                     .into_iter()
                     .map(|ty| self.encoder.encode_type_high(ty))

--- a/prusti-viper/src/encoder/mir/types/encoder.rs
+++ b/prusti-viper/src/encoder/mir/types/encoder.rs
@@ -272,7 +272,6 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
             | ty::TyKind::GeneratorWitnessMIR(..)
             | ty::TyKind::Never
             | ty::TyKind::Tuple(_)
-            | ty::TyKind::Alias(ty::AliasKind::Projection, _)
             | ty::TyKind::Param(_)
             | ty::TyKind::Bound(..)
             | ty::TyKind::Placeholder(_)
@@ -283,7 +282,7 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
             | ty::TyKind::FnDef(did, _)
             | ty::TyKind::Closure(did, _)
             | ty::TyKind::Generator(did, _, _)
-            | ty::TyKind::Alias(ty::AliasKind::Opaque, ty::AliasTy { def_id: did, .. }) => {
+            | ty::TyKind::Alias(_, ty::AliasTy { def_id: did, .. }) => {
                 self.encoder.env().query.get_def_span(did).into()
             }
         }
@@ -412,10 +411,8 @@ impl<'p, 'v, 'r: 'v, 'tcx: 'v> TypeEncoder<'p, 'v, 'tcx> {
                 )
             }
             ty::TyKind::Tuple(elems) => {
-                let lifetimes = self.encoder.get_lifetimes_from_substs(elems)?;
-                let const_parameters = self
-                    .encoder
-                    .get_const_parameters_from_substs(elems)?;
+                let lifetimes = self.encoder.get_lifetimes_from_types(*elems)?;
+                let const_parameters = self.encoder.get_const_parameters_from_types(*elems)?;
                 let arguments = elems
                     .into_iter()
                     .map(|ty| self.encoder.encode_type_high(ty))

--- a/prusti-viper/src/encoder/mir/types/interface.rs
+++ b/prusti-viper/src/encoder/mir/types/interface.rs
@@ -41,7 +41,7 @@ pub(crate) trait MirTypeEncoderInterface<'tcx> {
     fn encode_value_field_high(&self, ty: ty::Ty<'tcx>) -> EncodingResult<vir_high::FieldDecl>;
     fn get_lifetimes_from_types(
         &self,
-        types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+        types: impl IntoIterator<Item = ty::Ty<'tcx>>,
     ) -> SpannedEncodingResult<Vec<vir_high::ty::LifetimeConst>>;
     fn get_lifetimes_from_substs(
         &self,
@@ -53,7 +53,7 @@ pub(crate) trait MirTypeEncoderInterface<'tcx> {
     ) -> SpannedEncodingResult<Vec<vir_high::VariableDecl>>;
     fn get_const_parameters_from_types(
         &self,
-        types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+        types: impl IntoIterator<Item = ty::Ty<'tcx>>,
     ) -> SpannedEncodingResult<Vec<vir_high::VariableDecl>>;
     fn get_lifetimes_from_type_high(
         &self,
@@ -193,7 +193,7 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
     }
     fn get_lifetimes_from_types(
         &self,
-        types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+        types: impl IntoIterator<Item = ty::Ty<'tcx>>,
     ) -> SpannedEncodingResult<Vec<vir_high::ty::LifetimeConst>> {
         let mut lifetimes = Vec::new();
         super::lifetimes::extract_lifetimes_from_types(self, types, &mut lifetimes)?;
@@ -213,7 +213,7 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
     }
     fn get_const_parameters_from_types(
         &self,
-        types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+        types: impl IntoIterator<Item = ty::Ty<'tcx>>,
     ) -> SpannedEncodingResult<Vec<vir_high::VariableDecl>> {
         let mut const_parameters = Vec::new();
         super::const_parameters::extract_const_parameters_from_types(

--- a/prusti-viper/src/encoder/mir/types/interface.rs
+++ b/prusti-viper/src/encoder/mir/types/interface.rs
@@ -39,6 +39,10 @@ pub(crate) trait MirTypeEncoderInterface<'tcx> {
         declaration_span: Span,
     ) -> SpannedEncodingResult<vir_high::FieldDecl>;
     fn encode_value_field_high(&self, ty: ty::Ty<'tcx>) -> EncodingResult<vir_high::FieldDecl>;
+    fn get_lifetimes_from_types(
+        &self,
+        types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+    ) -> SpannedEncodingResult<Vec<vir_high::ty::LifetimeConst>>;
     fn get_lifetimes_from_substs(
         &self,
         substs: SubstsRef<'tcx>,
@@ -46,6 +50,10 @@ pub(crate) trait MirTypeEncoderInterface<'tcx> {
     fn get_const_parameters_from_substs(
         &self,
         substs: SubstsRef<'tcx>,
+    ) -> SpannedEncodingResult<Vec<vir_high::VariableDecl>>;
+    fn get_const_parameters_from_types(
+        &self,
+        types: impl IntoIterator<Item=ty::Ty<'tcx>>,
     ) -> SpannedEncodingResult<Vec<vir_high::VariableDecl>>;
     fn get_lifetimes_from_type_high(
         &self,
@@ -183,6 +191,14 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
         super::lifetimes::extract_lifetimes_from_substs(self, substs, &mut lifetimes)?;
         Ok(lifetimes)
     }
+    fn get_lifetimes_from_types(
+        &self,
+        types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+    ) -> SpannedEncodingResult<Vec<vir_high::ty::LifetimeConst>> {
+        let mut lifetimes = Vec::new();
+        super::lifetimes::extract_lifetimes_from_types(self, types, &mut lifetimes)?;
+        Ok(lifetimes)
+    }
     fn get_const_parameters_from_substs(
         &self,
         substs: SubstsRef<'tcx>,
@@ -191,6 +207,18 @@ impl<'v, 'tcx: 'v> MirTypeEncoderInterface<'tcx> for super::super::super::Encode
         super::const_parameters::extract_const_parameters_from_substs(
             self,
             substs,
+            &mut const_parameters,
+        )?;
+        Ok(const_parameters)
+    }
+    fn get_const_parameters_from_types(
+        &self,
+        types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+    ) -> SpannedEncodingResult<Vec<vir_high::VariableDecl>> {
+        let mut const_parameters = Vec::new();
+        super::const_parameters::extract_const_parameters_from_types(
+            self,
+            types,
             &mut const_parameters,
         )?;
         Ok(const_parameters)

--- a/prusti-viper/src/encoder/mir/types/lifetimes.rs
+++ b/prusti-viper/src/encoder/mir/types/lifetimes.rs
@@ -25,6 +25,17 @@ pub(super) fn extract_lifetimes_from_substs<'tcx>(
     Ok(())
 }
 
+pub(super) fn extract_lifetimes_from_types<'tcx>(
+    type_encoder: &impl super::MirTypeEncoderInterface<'tcx>,
+    types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+    lifetimes: &mut Vec<vir_high::ty::LifetimeConst>,
+) -> SpannedEncodingResult<()> {
+    for ty in types {
+        extract_lifetimes_from_type(type_encoder, ty, lifetimes)?;
+    }
+    Ok(())
+}
+
 pub(super) fn extract_lifetimes_from_type<'tcx>(
     type_encoder: &impl super::MirTypeEncoderInterface<'tcx>,
     ty: ty::Ty<'tcx>,
@@ -42,7 +53,7 @@ pub(super) fn extract_lifetimes_from_type<'tcx>(
         | ty::TyKind::Never => {}
         ty::TyKind::Adt(_, substs)
         | ty::TyKind::Closure(_, substs)
-        | ty::TyKind::Alias(ty::AliasKind::Opaque, ty::AliasTy { substs, .. })
+        | ty::TyKind::Alias(_, ty::AliasTy { substs, .. })
         | ty::TyKind::FnDef(_, substs) => {
             extract_lifetimes_from_substs(type_encoder, substs, lifetimes)?
         }
@@ -78,9 +89,6 @@ pub(super) fn extract_lifetimes_from_type<'tcx>(
         }
         ty::TyKind::Param(_param_ty) => {
             // FIXME: extract lifetimes from TyKind::Param()
-        }
-        ty::TyKind::Alias(ty::AliasKind::Projection, alias_ty) => {
-            extract_lifetimes_from_substs(type_encoder, alias_ty.substs, lifetimes)?
         }
         ty::TyKind::Bound(_, _)
         | ty::TyKind::Placeholder(_)

--- a/prusti-viper/src/encoder/mir/types/lifetimes.rs
+++ b/prusti-viper/src/encoder/mir/types/lifetimes.rs
@@ -27,7 +27,7 @@ pub(super) fn extract_lifetimes_from_substs<'tcx>(
 
 pub(super) fn extract_lifetimes_from_types<'tcx>(
     type_encoder: &impl super::MirTypeEncoderInterface<'tcx>,
-    types: impl IntoIterator<Item=ty::Ty<'tcx>>,
+    types: impl IntoIterator<Item = ty::Ty<'tcx>>,
     lifetimes: &mut Vec<vir_high::ty::LifetimeConst>,
 ) -> SpannedEncodingResult<()> {
     for ty in types {

--- a/prusti-viper/src/encoder/mir_encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir_encoder/mod.rs
@@ -19,7 +19,7 @@ use prusti_common::config;
 use prusti_rustc_interface::target::abi;
 use prusti_rustc_interface::hir::def_id::DefId;
 use prusti_rustc_interface::middle::{mir, ty};
-use prusti_rustc_interface::index::vec::IndexVec;
+use prusti_rustc_interface::index::IndexVec;
 use prusti_rustc_interface::span::{Span, DUMMY_SP};
 use log::{trace, debug};
 use prusti_interface::environment::mir_utils::MirPlace;

--- a/prusti-viper/src/encoder/places.rs
+++ b/prusti-viper/src/encoder/places.rs
@@ -6,7 +6,7 @@
 
 use prusti_rustc_interface::middle::mir;
 use prusti_rustc_interface::middle::ty::Ty;
-use prusti_rustc_interface::index::vec::{Idx, IndexVec};
+use prusti_rustc_interface::index::{Idx, IndexVec};
 use std::{iter};
 
 /// A local variable used as an abstraction over both real Rust MIR local

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1555,7 +1555,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     location
                 )?
             }
-            mir::Rvalue::NullaryOp(op, op_ty) => {
+            mir::Rvalue::NullaryOp(ref op, op_ty) => {
                 self.encode_assign_nullary_op(
                     op,
                     op_ty,
@@ -5988,7 +5988,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
     #[tracing::instrument(level = "trace", skip(self))]
     fn encode_assign_nullary_op(
         &mut self,
-        op: mir::NullOp,
+        op: &mir::NullOp,
         op_ty: ty::Ty<'tcx>,
         encoded_lhs: vir::Expr,
         ty: ty::Ty<'tcx>,
@@ -6007,6 +6007,12 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             mir::NullOp::SizeOf => layout.size().bytes(),
             // FIXME: abi or pref?
             mir::NullOp::AlignOf => layout.align().abi.bytes(),
+            mir::NullOp::OffsetOf(_) => {
+                return Err(SpannedEncodingError::internal(
+                    format!("`OffsetOf` is not supported yet"),
+                    self.mir.source_info(location).span,
+                ))
+            }
         };
         let bytes_vir = vir::Expr::from(bytes);
         self.encode_copy_value_assign(

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -6009,7 +6009,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             mir::NullOp::AlignOf => layout.align().abi.bytes(),
             mir::NullOp::OffsetOf(_) => {
                 return Err(SpannedEncodingError::internal(
-                    format!("`OffsetOf` is not supported yet"),
+                    "`OffsetOf` is not supported yet".to_string(),
                     self.mir.source_info(location).span,
                 ))
             }

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -5511,10 +5511,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
             }
         } else {
             // FIXME: why are we getting the MIR body for this?
-            let mir = self.encoder.env().body.get_impure_fn_body(
+            let mir = self.encoder.env().body.get_impure_fn_body_identity(
                 containing_def_id.expect_local(),
-                // TODO(tymap): identity substs here are probably wrong?
-                self.encoder.env().query.identity_substs(containing_def_id),
             );
             let return_ty = mir.return_ty();
             let arg_tys = mir.args_iter().map(|arg| mir.local_decls[arg].ty).collect();

--- a/prusti-viper/src/utils/mod.rs
+++ b/prusti-viper/src/utils/mod.rs
@@ -35,6 +35,7 @@ pub fn ty_to_string(typ: &ty::TyKind) -> String {
         &ty::TyKind::Tuple(_) => "tuple",
         &ty::TyKind::Alias(ty::AliasKind::Projection, _) => "projection",
         &ty::TyKind::Alias(ty::AliasKind::Opaque, _) => "opaque type",
+        &ty::TyKind::Alias(ty::AliasKind::Inherent, _) => "inherent alias type",
         &ty::TyKind::Param(_) => "type parameter",
         &ty::TyKind::Bound(_, _) => "bound type variable",
         &ty::TyKind::Placeholder(_) => "placeholder type",

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -35,10 +35,10 @@ fn mir_borrowck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> mir_borrowck<'tc
         // (anon) const bodies at all, and if so, how to get them?
         if !is_anon_const {
             let body_with_facts = consumers::get_body_with_borrowck_facts(
-                    tcx,
-                    def_id,
-                    consumers::ConsumerOptions::PoloniusOutputFacts,
-                );
+                tcx,
+                def_id,
+                consumers::ConsumerOptions::PoloniusOutputFacts,
+            );
             // SAFETY: This is safe because we are feeding in the same `tcx` that is
             // going to be used as a witness when pulling out the data.
             unsafe {

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -9,12 +9,11 @@ use prusti_rustc_interface::{
     driver::Compilation,
     hir::{def::DefKind, def_id::LocalDefId},
     interface::{interface::Compiler, Config, Queries},
-    middle::ty::{
-        self,
-        TyCtxt,
+    middle::{
+        mir::BorrowCheckResult,
+        query::{ExternProviders, Providers},
+        ty::{self, TyCtxt},
     },
-    middle::mir::BorrowCheckResult,
-    middle::query::{ExternProviders, Providers},
     session::Session,
 };
 

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -5,6 +5,7 @@ use prusti_interface::{
     specs::{self, cross_crate::CrossCrateSpecs, is_spec_fn},
 };
 use prusti_rustc_interface::{
+    borrowck::consumers,
     driver::Compilation,
     hir::{def::DefKind, def_id::LocalDefId},
     interface::{interface::Compiler, Config, Queries},
@@ -33,10 +34,10 @@ fn mir_borrowck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> mir_borrowck<'tc
         // when calling `get_body_with_borrowck_facts`. TODO: figure out if we need
         // (anon) const bodies at all, and if so, how to get them?
         if !is_anon_const {
-            let body_with_facts =
-                prusti_rustc_interface::borrowck::consumers::get_body_with_borrowck_facts(
+            let body_with_facts = consumers::get_body_with_borrowck_facts(
                     tcx,
-                    ty::WithOptConstParam::unknown(def_id),
+                    def_id,
+                    consumers::ConsumerOptions::PoloniusOutputFacts,
                 );
             // SAFETY: This is safe because we are feeding in the same `tcx` that is
             // going to be used as a witness when pulling out the data.

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -11,9 +11,10 @@ use prusti_rustc_interface::{
     interface::{interface::Compiler, Config, Queries},
     middle::ty::{
         self,
-        query::{query_values::mir_borrowck, ExternProviders, Providers},
         TyCtxt,
     },
+    middle::mir::BorrowCheckResult,
+    middle::query::{ExternProviders, Providers},
     session::Session,
 };
 
@@ -25,7 +26,7 @@ pub struct PrustiCompilerCalls;
 
 #[allow(clippy::needless_lifetimes)]
 #[tracing::instrument(level = "debug", skip(tcx))]
-fn mir_borrowck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> mir_borrowck<'tcx> {
+fn mir_borrowck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &BorrowCheckResult<'tcx> {
     // *Don't take MIR bodies with borrowck info if we won't need them*
     if !is_spec_fn(tcx, def_id.to_def_id()) {
         let def_kind = tcx.def_kind(def_id.to_def_id());

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -86,14 +86,14 @@ fn report_prusti_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
 
     let version_info = get_prusti_version_info();
 
-    let xs: Vec<Cow<'static, str>> = vec![
+    let xs: Vec<String> = vec![
         "Prusti or the compiler unexpectedly panicked. This is a bug.".into(),
         format!("We would appreciate a bug report: {bug_report_url}").into(),
         format!("Prusti version: {version_info}").into(),
     ];
 
-    for note in &xs {
-        handler.note_without_error(note.as_ref());
+    for note in xs {
+        handler.note_without_error(note);
     }
 
     // If backtraces are enabled, also print the query stack

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -88,8 +88,8 @@ fn report_prusti_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
 
     let xs: Vec<String> = vec![
         "Prusti or the compiler unexpectedly panicked. This is a bug.".into(),
-        format!("We would appreciate a bug report: {bug_report_url}").into(),
-        format!("Prusti version: {version_info}").into(),
+        format!("We would appreciate a bug report: {bug_report_url}"),
+        format!("Prusti version: {version_info}"),
     ];
 
     for note in xs {
@@ -244,7 +244,7 @@ fn main() {
             ));
         }
 
-        let mut callbacks = PrustiCompilerCalls::default();
+        let mut callbacks = PrustiCompilerCalls;
 
         prusti_rustc_interface::driver::RunCompiler::new(&rustc_args, &mut callbacks).run()
     });

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -209,7 +209,6 @@ fn main() {
         }
 
         rustc_args.push("-Zalways-encode-mir".to_owned());
-        rustc_args.push("-Zcrate-attr=feature(type_ascription)".to_owned());
         rustc_args.push("-Zcrate-attr=feature(stmt_expr_attributes)".to_owned());
         rustc_args.push("-Zcrate-attr=feature(register_tool)".to_owned());
         rustc_args.push("-Zcrate-attr=register_tool(prusti)".to_owned());

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -19,7 +19,7 @@ use lazy_static::lazy_static;
 use log::info;
 use prusti_common::{config, report::user, Stopwatch};
 use prusti_rustc_interface::interface::interface::try_print_query_stack;
-use std::{borrow::Cow, env, panic};
+use std::{env, panic};
 use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
 use tracing_subscriber::{filter::EnvFilter, prelude::*};
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-04-01"
+channel = "nightly-2023-06-15"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-std", "rustfmt", "clippy" ]
 profile = "minimal"

--- a/test-crates/Cargo.toml
+++ b/test-crates/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 prusti = { path = "../prusti", artifact = "bin" }
 prusti-launch = { path = "../prusti-launch", artifact = "bin" }
 color-backtrace = "0.5"
-rustwide = "0.15.0"
+rustwide = "0.16"
 env_logger = "0.10"
 log = "0.4"
 csv = "1.1.5"
@@ -16,4 +16,4 @@ serde = "1.0"
 toml = "0.7"
 glob = "0.3.0"
 clap = { version = "4.0", features = ["derive"] }
-failure = "0.1.3"
+failure = "0.1"

--- a/vir/Cargo.toml
+++ b/vir/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro2 = { version = "1.0", features = ["span-locations"] }
 uuid = { version = "1.0", features = ["v4"] }
 log = { version = "0.4", features = ["release_max_level_info"] }
 lazy_static = "1.4.0"
-itertools = "0.10.3"
+itertools = "0.11"
 derive_more = "0.99.16"
 rustc-hash = "1.1.0"
 tracing = { path = "../tracing" }


### PR DESCRIPTION
* [x] Update Viper version to `v-2023-05-17-0733`.
* [x] Update rustc version to `nightly-2023-06-15`.
* [x] Run `cargo audit` and fix the issues.
* [x] Manualy update outdated dependencies (see the list below).
* [x] Manualy run `cargo update`.

<details><summary>List of direct outdated dependencies:</summary>

```
$ mv prusti-contracts/Cargo.toml prusti-contracts/Cargo_disabled.toml
$ cargo outdated --root-deps-only --workspace

info: syncing channel updates for 'nightly-2023-06-15-x86_64-unknown-linux-gnu'
info: latest update on 2023-06-15, rust version 1.72.0-nightly (8c74a5d27 2023-06-14)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'llvm-tools'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustc-dev'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'llvm-tools'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustc-dev'
info: installing component 'rustfmt'
    Updating git repository `https://github.com/rust-lang/cargo.git`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_git_ignore_exists/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/creates_library_when_instructed_and_has_bin_file/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_implicit/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_hg/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_lib/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/inferred_lib_with_git/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/lib_already_exists_src/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_implicit_namesrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/ignores_failure_to_format_source/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_explicit/out`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/git_autodetect/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/formats_source/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/inferred_bin_with_git/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/mercurial_autodetect/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/creates_binary_when_instructed_and_has_lib_file/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/fossil_autodetect/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_explicit_nosrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/creates_binary_when_both_binlib_present/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/explicit_bin_with_git/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/pijul_autodetect/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_implicit_nosrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_bin/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/bin_already_exists_implicit_namenosrc/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_git/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/simple_hg_ignore_exists/out`
warning: skipping duplicate package `case` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/init/auto_git/out`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_no_optional/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/registry/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/in`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_workspace_dep/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_workspace_dep/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_path_dev/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_optional/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_version_with_git/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/git_registry/in`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_path/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_path/in/primary`
warning: skipping duplicate package `your-face` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_path_noop/in/dependency`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/build_prefer_existing_version/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/in`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_inferred_name/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_inferred_name/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inline_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/deprecated_default_features/in`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_version_with_path/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_version_with_path/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/unknown_inherited_feature/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/unknown_inherited_feature/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_git_with_path/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_git_with_path/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_path_name/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_path_name/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_dev/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_dev/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/add-basic.in`
warning: skipping duplicate package `your-face` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_name_dev_noop/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_path_with_version/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_path_with_version/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_inherit_dependency/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_inherit_dependency/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_with_rename/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/deprecated_section/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/preserve_sorted/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/in`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/merge_activated_features/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/merge_activated_features/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_rename_with_rename/in`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/detect_workspace_inherit_optional/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/detect_workspace_inherit_optional/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_no_default_features/in`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_noop/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_noop/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/require_weak/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/in`
warning: skipping duplicate package `optional-dep` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/in/optional`
warning: skipping duplicate package `your-face` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/in`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/manifest_path_package/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/manifest_path_package/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_workspace_dep_features/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_workspace_dep_features/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_features_noop/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_inherit_features_noop/in/primary`
warning: skipping duplicate package `foo` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/detect_workspace_inherit/in/dependency`
warning: skipping duplicate package `bar` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/detect_workspace_inherit/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_name/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/workspace_name/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/dev_prefer_existing_version/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/overwrite_default_features/in`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/preserve_unsorted/in`
warning: skipping duplicate package `cargo-list-test-fixture-dependency` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_normalized_name/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/path_normalized_name/in/primary`
warning: skipping duplicate package `optional-dep` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path_no_default/in/optional`
warning: skipping duplicate package `your-face` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path_no_default/in/dependency`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/list_features_path_no_default/in/primary`
warning: skipping duplicate package `cargo-list-test-fixture` found at `/home/runner/.cargo/git/checkouts/cargo-e7ff1db891893a9e/17f8088/tests/testsuite/cargo_add/features_preserve/in`
error: failed to select a version for `git2`.
    ... required by package `rustwide v0.16.0`
    ... which satisfies dependency `rustwide = "^0.16.0"` of package `test-crates v0.1.0 (/tmp/cargo-outdated2Ag3Lj/test-crates)`
versions that meet the requirements `^0.17.0` are: 0.17.2, 0.17.1, 0.17.0

the package `git2` links to the native library `git2`, but it conflicts with a previous package which links to `git2` as well:
package `git2 v0.14.2`
    ... which satisfies dependency `git2 = "^0.14.2"` of package `cargo-test-support v0.1.0 (https://github.com/rust-lang/cargo.git?rev=17f8088#17f8088d)`
    ... which satisfies git dependency `cargo-test-support` (locked to 0.1.0) of package `prusti-tests v0.2.0 (/tmp/cargo-outdated2Ag3Lj/prusti-tests)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='git2' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `git2` which could resolve this conflict
cargo outdated failed to execute

$ mv prusti-contracts/Cargo_disabled.toml prusti-contracts/Cargo.toml
```
</details>

@fpoli could you take care of this?