### PR TITLE
Disable tracing by default

### DIFF
--- a/prusti-utils/src/config.rs
+++ b/prusti-utils/src/config.rs
@@ -86,7 +86,7 @@ lazy_static::lazy_static! {
         settings.set_default("log", "").unwrap();
         settings.set_default("log_style", "auto").unwrap();
         settings.set_default("log_dir", "log").unwrap();
-        settings.set_default("log_tracing", true).unwrap();
+        settings.set_default("log_tracing", false).unwrap();
         settings.set_default("cache_path", "").unwrap();
         settings.set_default("dump_debug_info", false).unwrap();
         settings.set_default("dump_debug_info_during_fold", false).unwrap();


### PR DESCRIPTION
I'm not sure why it was `true` by default - with that value `PRUSTI_LOG=debug` doesn't work.