### PR TITLE
Remove redundant build on Ubuntu 22.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -110,7 +110,7 @@ jobs:
       - name: Zip Prusti artifacts
         shell: bash
         run: |
-          for os in ubuntu-20.04 ubuntu-22.04 windows-latest macos-latest
+          for os in ubuntu-20.04 windows-latest macos-latest
           do
             echo "Package Prusti artifact for $os"
             cd prusti-release-$os
@@ -132,7 +132,7 @@ jobs:
           release_name: Nightly Release ${{ env.TAG_NAME }}
           keep_num: 4
 
-      - name: Upload release asset for Ubuntu 20.04 using a backward compatible asset name
+      - name: Upload release asset for Ubuntu
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -140,26 +140,6 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./prusti-release-ubuntu-20.04/prusti.zip
           asset_name: prusti-release-ubuntu.zip
-          asset_content_type: application/zip
-
-      - name: Upload release asset for Ubuntu 20.04
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./prusti-release-ubuntu-20.04/prusti.zip
-          asset_name: prusti-release-ubuntu-20.04.zip
-          asset_content_type: application/zip
-
-      - name: Upload release asset for Ubuntu 22.04
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./prusti-release-ubuntu-22.04/prusti.zip
-          asset_name: prusti-release-ubuntu-22.04.zip
           asset_content_type: application/zip
 
       - name: Upload release asset for Windows


### PR DESCRIPTION
Since we fixed the error with the libssl version, building releases on Ubuntu 22.04 is not needed: the version built on Ubuntu 20.04 runs perfectly fine in Ubuntu 22.04.

(Maybe Ubuntu 24.04 will require a separate build; who knows. Good luck future readers.)