### PR TITLE
Fix encoding of mutually recursive pure functions

### DIFF
--- a/prusti-tests/tests/verify/fail/issues/issue-1214-1.rs
+++ b/prusti-tests/tests/verify/fail/issues/issue-1214-1.rs
@@ -1,0 +1,35 @@
+use prusti_contracts::*;
+
+#[pure]
+#[ensures(result == 0)]
+fn f(n: u64) -> u64 {
+    if n == 0 {
+        0
+    } else {
+        g(n - 1)
+    }
+}
+
+#[pure]
+#[ensures(result == 0)]
+fn g(n: u64) -> u64 {
+    if n == 0 {
+        0
+    } else {
+        f(n - 1)
+    }
+}
+
+fn test() {
+    assert!(f(0) == 0);
+    assert!(g(0) == 0);
+    assert!(f(1) == 0);
+    assert!(g(1) == 0);
+    assert!(f(2) == 0);
+    assert!(g(2) == 0);
+    assert!(f(3) == 0);
+    assert!(g(3) == 0);
+    assert!(false); //~ ERROR the asserted expression might not hold
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify/fail/issues/issue-1267.rs
+++ b/prusti-tests/tests/verify/fail/issues/issue-1267.rs
@@ -1,0 +1,9 @@
+use prusti_contracts::*;
+
+#[pure]
+#[ensures(double(x) % 2 == 0)] //~ ERROR precondition of pure function call might not hold
+fn double(x: i64) -> i64 { //~ ERROR only trusted functions can call themselves in their contracts
+    2 * x
+}
+
+fn main() {}

--- a/prusti-tests/tests/verify_overflow/fail/issues/issue-769.rs
+++ b/prusti-tests/tests/verify_overflow/fail/issues/issue-769.rs
@@ -21,13 +21,10 @@ fn fib(n: i32) -> i32 {
 #[ensures(result == match n {
     0 => 0,
     1 => 1,
-    _ => fib2(n - 1) + fib2(n - 2),
+    _ => fib2(n - 1) + fib2(n - 2), //~ ERROR: precondition of pure function call might not hold
 })]
 fn fib2(n: i32) -> i32 {
     //~^ ERROR: only trusted functions can call themselves in their contracts
-    //~^^ ERROR: Prusti encountered an unexpected internal error
-    //~| NOTE: We would appreciate a bug report
-    //~| NOTE: Rust function m_fib2 encoded both as a Viper method and function
     match n {
         0 => 0,
         1 => 1,

--- a/prusti-tests/tests/verify_overflow/pass/mutual-recursion.rs
+++ b/prusti-tests/tests/verify_overflow/pass/mutual-recursion.rs
@@ -1,0 +1,35 @@
+use prusti_contracts::*;
+
+#[pure]
+#[requires(curr >= 0)]
+fn a(curr: i32) -> bool{
+    b(curr)
+}
+
+#[pure]
+#[requires(curr >= 0)]
+fn b(curr: i32) -> bool {
+    if curr == 0 {
+        return true;
+    }
+    else{
+        a(curr - 1)
+    }
+}
+
+fn test() {
+    assert!(b(0));
+    assert!(a(0));
+    assert!(b(1));
+    assert!(a(1));
+    assert!(b(2));
+    assert!(a(2));
+    assert!(b(3));
+    assert!(a(3));
+    assert!(b(4));
+    assert!(a(4));
+    assert!(b(5));
+    assert!(a(5));
+}
+
+fn main() {}

--- a/prusti-viper/src/encoder/encoder.rs
+++ b/prusti-viper/src/encoder/encoder.rs
@@ -673,9 +673,19 @@ impl<'v, 'tcx> Encoder<'v, 'tcx> {
         expr
     }
 
+    /// To be used for encoding impure functions.
     pub fn encode_item_name(&self, def_id: DefId) -> String {
         let full_name = format!("m_{}", encode_identifier(self.env.name.get_unique_item_name(def_id)));
         let short_name = format!("m_{}", encode_identifier(
+            self.env.name.get_item_name(def_id)
+        ));
+        self.intern_viper_identifier(full_name, short_name)
+    }
+
+    /// To be used for encoding pure functions.
+    pub fn encode_pure_item_name(&self, def_id: DefId) -> String {
+        let full_name = format!("f_{}", encode_identifier(self.env.name.get_unique_item_name(def_id)));
+        let short_name = format!("f_{}", encode_identifier(
             self.env.name.get_item_name(def_id)
         ));
         self.intern_viper_identifier(full_name, short_name)

--- a/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mir/procedures/encoder/mod.rs
@@ -1717,9 +1717,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 {
                     // If we are verifying a pure function, we always need
                     // to encode it as a method
-                    //
-                    // FIXME: This is not enough, we also need to handle
-                    // mutual-recursion case.
                     let (function_name, return_type) = self
                         .encoder
                         .encode_pure_function_use_high(called_def_id, self.def_id, call_substs)

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_high.rs
@@ -235,7 +235,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
     }
 
     fn encode_function_name(&self) -> String {
-        self.encoder.encode_item_name(self.proc_def_id)
+        self.encoder.encode_pure_item_name(self.proc_def_id)
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(proc_def_id = ?self.proc_def_id))]

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_high.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_high.rs
@@ -235,7 +235,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureEncoder<'p, 'v, 'tcx> {
     }
 
     fn encode_function_name(&self) -> String {
-        self.encoder.encode_pure_item_name(self.proc_def_id)
+        // FIXME: This should use encode_pure_item_name to support mutual recursion, but that
+        // change makes some tests fail.
+        self.encoder.encode_item_name(self.proc_def_id)
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(proc_def_id = ?self.proc_def_id))]

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
@@ -590,7 +590,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
     }
 
     pub fn encode_function_name(&self) -> String {
-        self.encoder.encode_item_name(self.proc_def_id)
+        self.encoder.encode_pure_item_name(self.proc_def_id)
     }
 
     pub fn encode_function_return_type(&self) -> SpannedEncodingResult<vir::Type> {

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -1005,6 +1005,9 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
         } else {
             // Cannot add loop guard to loop invariant
             let fn_names: Vec<_> = preconds.iter().filter_map(|(name, _)| name.as_ref()).map(|name| {
+                if let Some(rust_name) = name.strip_prefix("f_") {
+                    return rust_name
+                };
                 name.strip_prefix("m_").unwrap_or(name)
             }).collect();
             let warning_msg = if fn_names.is_empty() {

--- a/prusti-viper/src/encoder/stub_function_encoder.rs
+++ b/prusti-viper/src/encoder/stub_function_encoder.rs
@@ -84,7 +84,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> StubFunctionEncoder<'p, 'v, 'tcx> {
     pub fn encode_function_name(&self) -> String {
         // TODO: It would be nice to somehow mark that this function is a stub
         // in the encoding.
-        self.encoder.encode_item_name(self.proc_def_id)
+        self.encoder.encode_pure_item_name(self.proc_def_id)
     }
 
     pub fn encode_function_return_type(&self) -> SpannedEncodingResult<vir::Type> {


### PR DESCRIPTION
Use the `f_` prefix for encoding pure function names instead of `m_`.

Partially addresses #1214.
Fixes #1267.
