### PR TITLE
Sync written files

### DIFF
--- a/jni-gen/systest/build.rs
+++ b/jni-gen/systest/build.rs
@@ -20,6 +20,7 @@ fn main() {
             let fname = deps_dir.path().join("asm.jar");
             let mut dest = File::create(fname.clone()).unwrap();
             copy(&mut response.into_reader(), &mut dest).unwrap();
+            dest.sync_all().unwrap();
             fname.to_str().unwrap().to_string()
         }
     };

--- a/prusti-launch/src/bin/prusti-rustc.rs
+++ b/prusti-launch/src/bin/prusti-rustc.rs
@@ -113,6 +113,7 @@ fn process(mut args: Vec<String>) -> Result<(), i32> {
         for arg in cmd.get_args() {
             writeln!(file, "{}", arg.to_str().unwrap()).unwrap();
         }
+        file.sync_all().unwrap();
     }
     if let Ok(path) = env::var("PRUSTI_RUSTC_LOG_ENV") {
         let mut file = std::fs::File::create(path).unwrap();
@@ -125,6 +126,7 @@ fn process(mut args: Vec<String>) -> Result<(), i32> {
             )
             .unwrap();
         }
+        file.sync_all().unwrap();
     }
 
     let exit_status = cmd.status().unwrap_or_else(|e| {

--- a/prusti-viper/src/encoder/counterexamples/counterexample_translation_refactored.rs
+++ b/prusti-viper/src/encoder/counterexamples/counterexample_translation_refactored.rs
@@ -36,6 +36,7 @@ pub fn backtranslate(
         let label_markers = translator.get_label_markers(true);
         let mut file = std::fs::File::create(path).unwrap();
         serde_json::to_writer_pretty(&mut file, &label_markers).unwrap();
+        file.sync_all().unwrap();
     }
 
     let counterexample_entry_vec = translator.process_entries(position_manager, &label_markers);

--- a/smt-log-analyzer/src/state.rs
+++ b/smt-log-analyzer/src/state.rs
@@ -667,6 +667,7 @@ impl State {
                 self.traced_quantifier_triggers.as_ref().unwrap().as_bytes(),
             )
             .unwrap();
+            file.sync_all().unwrap();
         }
     }
 

--- a/viper-sys/build.rs
+++ b/viper-sys/build.rs
@@ -26,6 +26,7 @@ fn main() {
             let fname = deps_dir.path().join("asm.jar");
             let mut dest = File::create(fname.clone()).unwrap();
             copy(&mut response.into_reader(), &mut dest).unwrap();
+            dest.sync_all().unwrap();
             fname.to_str().unwrap().to_string()
         }
     };

--- a/viper/src/cache.rs
+++ b/viper/src/cache.rs
@@ -103,7 +103,8 @@ impl PersistentCache {
                     .unwrap_or_else(|e| error!("Failed to serialize the cache: {e}"));
                 match cache_buffer.into_inner() {
                     Err(e) => error!("Failed to flush the cache file: {e}"),
-                    Ok(f) => f.sync_all()
+                    Ok(f) => f
+                        .sync_all()
                         .unwrap_or_else(|e| error!("Failed to sync the cache file to disk: {e}")),
                 }
             }

--- a/viper/src/cache.rs
+++ b/viper/src/cache.rs
@@ -98,8 +98,14 @@ impl PersistentCache {
         match fs::File::create(cache_loc) {
             Ok(f) => {
                 info!("Saving cache to \"{}\"", cache_loc.display());
-                bincode::serialize_into(&mut io::BufWriter::new(f), &ResultCache::from(self))
-                    .unwrap_or_else(|e| error!("Failed to write cache: {e}"));
+                let mut cache_buffer = io::BufWriter::new(f);
+                bincode::serialize_into(&mut cache_buffer, &ResultCache::from(self))
+                    .unwrap_or_else(|e| error!("Failed to serialize the cache: {e}"));
+                match cache_buffer.into_inner() {
+                    Err(e) => error!("Failed to flush the cache file: {e}"),
+                    Ok(f) => f.sync_all()
+                        .unwrap_or_else(|e| error!("Failed to sync the cache file to disk: {e}")),
+                }
             }
             Err(e) => error!("Failed to create cache file: {e}"),
         }


### PR DESCRIPTION
Dropping a file will ignore errors in synchronizing in-memory (meta)data to disk. Calling `sync_all` gives instead a result on which to panic.