### PR TITLE
Try removing quotes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           # The following are necessary for profiling (see https://github.com/mozilla/grcov)
           echo "RUSTFLAGS=-Cinstrument-coverage" >> $GITHUB_ENV
-          echo "LLVM_PROFILE_FILE="${GITHUB_WORKSPACE}/target/coverage/gcov-%p-%m.profraw"" >> $GITHUB_ENV
+          echo "LLVM_PROFILE_FILE=${GITHUB_WORKSPACE}/target/coverage/gcov-%p-%m.profraw" >> $GITHUB_ENV
 
       - name: Build with cargo
         run: python x.py build --all


### PR DESCRIPTION
There is a chance that the coverage was being written to a relative path, where the first `"` is interpreted as being a folder name and the last `"` as being a suffix of the file name. Maybe this the reasons why the coverage jobs often fail, running out of space. A relative path might end up creating one file for each working directory instead of just a global one, and the tests might use many different working directories.