### PR TITLE
Fix purification

### DIFF
--- a/prusti-common/src/vir/optimizations/methods/purifier.rs
+++ b/prusti-common/src/vir/optimizations/methods/purifier.rs
@@ -261,7 +261,7 @@ impl ast::StmtWalker for VarCollector {
     fn walk_exhale(&mut self, ast::Exhale { expr, .. }: &ast::Exhale) {
         // When a field is fully exhaled, the purified encoding should havoc the purified variable.
         // This pass currently does not generate such havoc statement, which is why we mark the
-        // variables used in an havoc as non-purifiable.
+        // variables used in an exhale as non-purifiable.
         // See: https://github.com/viperproject/prusti-dev/pull/1464
         self.walk_expr(expr);
     }

--- a/prusti-common/src/vir/optimizations/methods/purifier.rs
+++ b/prusti-common/src/vir/optimizations/methods/purifier.rs
@@ -258,13 +258,7 @@ impl ast::StmtWalker for VarCollector {
         }
         self.is_pure_context = old_pure_context;
     }
-    fn walk_exhale(
-        &mut self,
-        ast::Exhale {
-            expr,
-            ..
-        }: &ast::Exhale,
-    ) {
+    fn walk_exhale(&mut self, ast::Exhale { expr, .. }: &ast::Exhale) {
         // When a field is fully exhaled, the purified encoding should havoc the purified variable.
         // This pass currently does not generate such havoc statement, which is why we mark the
         // variables used in an havoc as non-purifiable.

--- a/prusti-common/src/vir/optimizations/methods/purifier.rs
+++ b/prusti-common/src/vir/optimizations/methods/purifier.rs
@@ -258,6 +258,19 @@ impl ast::StmtWalker for VarCollector {
         }
         self.is_pure_context = old_pure_context;
     }
+    fn walk_exhale(
+        &mut self,
+        ast::Exhale {
+            expr,
+            ..
+        }: &ast::Exhale,
+    ) {
+        // When a field is fully exhaled, the purified encoding should havoc the purified variable.
+        // This pass currently does not generate such havoc statement, which is why we mark the
+        // variables used in an havoc as non-purifiable.
+        // See: https://github.com/viperproject/prusti-dev/pull/1464
+        self.walk_expr(expr);
+    }
 }
 
 struct VarPurifier {

--- a/prusti-tests/tests/verify/fail/loops/iter_range.rs
+++ b/prusti-tests/tests/verify/fail/loops/iter_range.rs
@@ -1,0 +1,35 @@
+use prusti_contracts::*;
+
+struct IterRange {
+    from: usize,
+    to: usize,
+}
+
+#[requires(iter.from < iter.to)] // WRONG, should be `<=`
+#[ensures(iter.to == old(iter.to))]
+#[ensures(old(iter.from < iter.to) ==> iter.from == old(iter.from) + 1)]
+#[ensures(old(iter.from < iter.to) == matches!(result, Some(_)))]
+#[ensures(old(iter.from == iter.to) == matches!(result, None))]
+fn next(iter: &mut IterRange) -> Option<usize> {
+    if iter.from < iter.to {
+        let v = iter.from;
+        iter.from = v + 1;
+        Some(v)
+    } else {
+        None
+    }
+}
+
+fn main() {
+    let mut iter = IterRange { from: 0, to: 10 };
+    let mut i = 0;
+    loop {
+        body_invariant!(i == iter.from && iter.from <= iter.to && iter.to == 10);
+        match next(&mut iter) { //~ ERROR: precondition might not hold
+            Some(_) => {}
+            None => break,
+        }
+        i += 1;
+    }
+    assert!(i == 10);
+}

--- a/prusti-tests/tests/verify_overflow/pass/loops/iter_range.rs
+++ b/prusti-tests/tests/verify_overflow/pass/loops/iter_range.rs
@@ -1,0 +1,35 @@
+use prusti_contracts::*;
+
+struct IterRange {
+    from: usize,
+    to: usize,
+}
+
+#[requires(iter.from <= iter.to)]
+#[ensures(iter.to == old(iter.to))]
+#[ensures(old(iter.from < iter.to) ==> iter.from == old(iter.from) + 1)]
+#[ensures(old(iter.from < iter.to) == matches!(result, Some(_)))]
+#[ensures(old(iter.from == iter.to) == matches!(result, None))]
+fn next(iter: &mut IterRange) -> Option<usize> {
+    if iter.from < iter.to {
+        let v = iter.from;
+        iter.from = v + 1;
+        Some(v)
+    } else {
+        None
+    }
+}
+
+fn main() {
+    let mut iter = IterRange { from: 0, to: 10 };
+    let mut i = 0;
+    loop {
+        body_invariant!(i == iter.from && iter.from <= iter.to && iter.to == 10);
+        match next(&mut iter) {
+            Some(_) => {}
+            None => break,
+        }
+        i += 1;
+    }
+    assert!(i == 10);
+}


### PR DESCRIPTION
The `purify_vars` pass does not correctly havoc the variables that it purified in a loop. That is, while replacing a `usize(_2)` with `_2: Int` it removes `acc(usize(_2), write)` from `exhale` statements without generating an havoc statement. The `encode_unsigned_num_constraint=true` and `check_overflows=false` combination is required to expose this encoding bug.

In the following example, the bug hides that the precondition of `next` might fail:
```rust
use prusti_contracts::*;

struct IterRange {
    from: usize,
    to: usize,
}

#[requires(iter.from < iter.to)] // Wrong, should be `<=`
#[ensures(iter.to == old(iter.to))]
#[ensures(old(iter.from < iter.to) ==> iter.from == old(iter.from) + 1)]
#[ensures(old(iter.from < iter.to) == matches!(result, Some(_)))]
#[ensures(old(iter.from == iter.to) == matches!(result, None))]
fn next(iter: &mut IterRange) -> Option<usize> {
    assert!(iter.from < iter.to);
    if iter.from < iter.to {
        let v = iter.from;
        iter.from = v + 1;
        Some(v)
    } else {
        None
    }
}

fn main() {
    let mut iter = IterRange { from: 0, to: 10 };
    let mut i = 0;
    loop {
        body_invariant!(i == iter.from && iter.from <= iter.to && iter.to == 10);
        match next(&mut iter) { // Expected: precondition might not hold
            Some(_) => {}
            None => break,
        }
        i += 1;
    }
    assert!(i == 10);
}
```