### PR TITLE
Raise an error when postconditions of pure functions contain old() expressions

### DIFF
--- a/prusti-tests/tests/verify/fail/incorrect/old_in_pure_postcondition.rs
+++ b/prusti-tests/tests/verify/fail/incorrect/old_in_pure_postcondition.rs
@@ -16,7 +16,7 @@ impl<T> std::option::Option<T> {
 #[requires(x.is_some())]
 fn test(x: Option<i32>) -> i32 {
     // Following error is due to stub encoding of invalid external spec for function `unwrap()`
-    x.unwrap() // ~ ERROR precondition of pure function call might not hold
+    x.unwrap() //~ ERROR precondition of pure function call might not hold
 }
 
 fn main() { }

--- a/prusti-tests/tests/verify/fail/incorrect/old_in_pure_postcondition.rs
+++ b/prusti-tests/tests/verify/fail/incorrect/old_in_pure_postcondition.rs
@@ -1,21 +1,17 @@
 use prusti_contracts::*;
 
-#[extern_spec]
-impl<T> std::option::Option<T> {
-    #[pure] // <=== Error triggered by this
-    #[requires(self.is_some())]
-    #[ensures(old(self) === Some(result))]
-    pub fn unwrap(self) -> T; //~ ERROR old expressions should not appear in the postconditions of pure functions
+struct MyWrapper(u32);
 
+impl MyWrapper {
     #[pure]
-    #[ensures(result == matches!(self, Some(_)))]
-    pub const fn is_some(&self) -> bool;
+    #[ensures(old(self.0) == self.0)]
+    fn unwrap(&self) -> u32 { //~ ERROR old expressions should not appear in the postconditions of pure functions
+        self.0
+    }
 }
 
-#[pure]
-#[requires(x.is_some())]
-fn test(x: Option<i32>) -> i32 {
-    // Following error is due to stub encoding of invalid external spec for function `unwrap()`
+fn test(x: &MyWrapper) -> u32 {
+    // Following error is due to stub encoding of invalid spec for function `unwrap()`
     x.unwrap() //~ ERROR precondition of pure function call might not hold
 }
 

--- a/prusti-tests/tests/verify/fail/incorrect/old_in_pure_postcondition.rs
+++ b/prusti-tests/tests/verify/fail/incorrect/old_in_pure_postcondition.rs
@@ -1,0 +1,22 @@
+use prusti_contracts::*;
+
+#[extern_spec]
+impl<T> std::option::Option<T> {
+    #[pure] // <=== Error triggered by this
+    #[requires(self.is_some())]
+    #[ensures(old(self) === Some(result))]
+    pub fn unwrap(self) -> T; //~ ERROR old expressions should not appear in the postconditions of pure functions
+
+    #[pure]
+    #[ensures(result == matches!(self, Some(_)))]
+    pub const fn is_some(&self) -> bool;
+}
+
+#[pure]
+#[requires(x.is_some())]
+fn test(x: Option<i32>) -> i32 {
+    // Following error is due to stub encoding of invalid external spec for function `unwrap()`
+    x.unwrap() // ~ ERROR precondition of pure function call might not hold
+}
+
+fn main() { }

--- a/prusti-tests/tests/verify/fail/incorrect/old_in_pure_postcondition_extern.rs
+++ b/prusti-tests/tests/verify/fail/incorrect/old_in_pure_postcondition_extern.rs
@@ -1,0 +1,22 @@
+use prusti_contracts::*;
+
+#[extern_spec]
+impl<T> std::option::Option<T> {
+    #[pure] // <=== Error triggered by this
+    #[requires(self.is_some())]
+    #[ensures(old(self) === Some(result))]
+    pub fn unwrap(self) -> T; //~ ERROR old expressions should not appear in the postconditions of pure functions
+
+    #[pure]
+    #[ensures(result == matches!(self, Some(_)))]
+    pub const fn is_some(&self) -> bool;
+}
+
+#[pure]
+#[requires(x.is_some())]
+fn test(x: Option<i32>) -> i32 {
+    // Following error is due to stub encoding of invalid external spec for function `unwrap()`
+    x.unwrap() //~ ERROR precondition of pure function call might not hold
+}
+
+fn main() { }

--- a/prusti-viper/src/encoder/interface.rs
+++ b/prusti-viper/src/encoder/interface.rs
@@ -1,25 +1,15 @@
 use crate::encoder::{
     errors::{SpannedEncodingResult, WithSpan},
-    mir::specifications::SpecificationsInterface,
     snapshot::interface::SnapshotEncoderInterface,
-    stub_function_encoder::StubFunctionEncoder,
     Encoder,
 };
-use log::{debug, trace};
-use prusti_common::config;
-use prusti_interface::data::ProcedureDefId;
+
 use prusti_rustc_interface::{
-    middle::{
-        mir, ty,
-        ty::{Binder, GenericArgsRef},
-    },
+    middle::{mir, ty, ty::Binder},
     span::Span,
 };
-use rustc_hash::{FxHashMap, FxHashSet};
 
-use prusti_interface::specs::typed::ProcedureSpecificationKind;
-use std::cell::RefCell;
-use vir_crate::{common::identifier::WithIdentifier, high as vir_high, polymorphic as vir_poly};
+use vir_crate::polymorphic as vir_poly;
 
 pub(crate) trait PureFunctionFormalArgsEncoderInterface<'p, 'v: 'p, 'tcx: 'v> {
     fn encoder(&self) -> &'p Encoder<'v, 'tcx>;

--- a/prusti-viper/src/encoder/interface.rs
+++ b/prusti-viper/src/encoder/interface.rs
@@ -1,0 +1,56 @@
+use crate::encoder::{
+    errors::{SpannedEncodingResult, WithSpan},
+    mir::specifications::SpecificationsInterface,
+    snapshot::interface::SnapshotEncoderInterface,
+    stub_function_encoder::StubFunctionEncoder,
+    Encoder,
+};
+use log::{debug, trace};
+use prusti_common::config;
+use prusti_interface::data::ProcedureDefId;
+use prusti_rustc_interface::{
+    middle::{
+        mir, ty,
+        ty::{Binder, GenericArgsRef},
+    },
+    span::Span,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use prusti_interface::specs::typed::ProcedureSpecificationKind;
+use std::cell::RefCell;
+use vir_crate::{common::identifier::WithIdentifier, high as vir_high, polymorphic as vir_poly};
+
+pub(crate) trait PureFunctionFormalArgsEncoderInterface<'p, 'v: 'p, 'tcx: 'v> {
+    fn encoder(&self) -> &'p Encoder<'v, 'tcx>;
+
+    fn check_type(
+        &self,
+        var_span: Span,
+        ty: Binder<'tcx, ty::Ty<'tcx>>,
+    ) -> SpannedEncodingResult<()>;
+
+    fn get_span(&self, local: mir::Local) -> Span;
+
+    fn encode_formal_args(
+        &self,
+        sig: ty::PolyFnSig<'tcx>,
+    ) -> SpannedEncodingResult<Vec<vir_poly::LocalVar>> {
+        let mut formal_args = vec![];
+        for local_idx in 0..sig.skip_binder().inputs().len() {
+            let local_ty = sig.input(local_idx);
+            let local = mir::Local::from_usize(local_idx + 1);
+            let var_name = format!("{local:?}");
+            let var_span = self.get_span(local);
+
+            self.check_type(var_span, local_ty)?;
+
+            let var_type = self
+                .encoder()
+                .encode_snapshot_type(local_ty.skip_binder())
+                .with_span(var_span)?;
+            formal_args.push(vir_poly::LocalVar::new(var_name, var_type))
+        }
+        Ok(formal_args)
+    }
+}

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
@@ -39,8 +39,6 @@ use vir_crate::{
     polymorphic::{self as vir, ExprIterator},
 };
 
-use super::PureFunctionEncoderInterface;
-
 pub(super) struct PureFunctionEncoder<'p, 'v: 'p, 'tcx: 'v> {
     encoder: &'p Encoder<'v, 'tcx>,
     /// The function to be encoded.

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/encoder_poly.rs
@@ -543,8 +543,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionEncoder<'p, 'v, 'tcx> {
         let encoded_return = self.encode_local(contract.returned_value.into())?;
         debug!("encoded_return: {:?}", encoded_return);
 
-        eprintln!("IN IT");
-
         for (assertion, assertion_substs) in
             contract.functional_postcondition(self.encoder.env(), self.substs)
         {

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -2,17 +2,19 @@
 
 use super::encoder_poly::{FunctionCallInfo, FunctionCallInfoHigh, PureFunctionEncoder};
 use crate::encoder::{
-    Encoder,
     errors::{SpannedEncodingResult, WithSpan},
     mir::specifications::SpecificationsInterface,
     snapshot::interface::SnapshotEncoderInterface,
     stub_function_encoder::StubFunctionEncoder,
+    Encoder,
 };
 use log::{debug, trace};
 use prusti_common::config;
 use prusti_interface::data::ProcedureDefId;
-use prusti_rustc_interface::middle::{mir, ty, ty::GenericArgsRef};
-use prusti_rustc_interface::span::Span;
+use prusti_rustc_interface::{
+    middle::{mir, ty, ty::GenericArgsRef},
+    span::Span,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use prusti_interface::specs::typed::ProcedureSpecificationKind;
@@ -397,11 +399,26 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                     self.register_encoding_error(error);
                     debug!("Error encoding pure function: {:?}", proc_def_id);
                     let function = if !is_bodyless {
-                        let pure_fn_body = self.env().body.get_pure_fn_body(proc_def_id, substs, parent_def_id);
-                        let encoder = StubFunctionEncoder::new(self, proc_def_id, Some(&pure_fn_body), substs, pure_function_encoder.sig);
+                        let pure_fn_body =
+                            self.env()
+                                .body
+                                .get_pure_fn_body(proc_def_id, substs, parent_def_id);
+                        let encoder = StubFunctionEncoder::new(
+                            self,
+                            proc_def_id,
+                            Some(&pure_fn_body),
+                            substs,
+                            pure_function_encoder.sig,
+                        );
                         encoder.encode_function()?
                     } else {
-                        let encoder = StubFunctionEncoder::new(self, proc_def_id, None, substs, pure_function_encoder.sig);
+                        let encoder = StubFunctionEncoder::new(
+                            self,
+                            proc_def_id,
+                            None,
+                            substs,
+                            pure_function_encoder.sig,
+                        );
                         encoder.encode_function()?
                     };
                     self.log_vir_program_before_viper(function.to_string());

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -6,15 +6,11 @@ use crate::encoder::{
     mir::specifications::SpecificationsInterface,
     snapshot::interface::SnapshotEncoderInterface,
     stub_function_encoder::StubFunctionEncoder,
-    Encoder,
 };
 use log::{debug, trace};
 use prusti_common::config;
 use prusti_interface::data::ProcedureDefId;
-use prusti_rustc_interface::{
-    middle::{mir, ty, ty::GenericArgsRef},
-    span::Span,
-};
+use prusti_rustc_interface::middle::{mir, ty, ty::GenericArgsRef};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use prusti_interface::specs::typed::ProcedureSpecificationKind;

--- a/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
+++ b/prusti-viper/src/encoder/mir/pure/pure_functions/interface.rs
@@ -2,6 +2,7 @@
 
 use super::encoder_poly::{FunctionCallInfo, FunctionCallInfoHigh, PureFunctionEncoder};
 use crate::encoder::{
+    Encoder,
     errors::{SpannedEncodingResult, WithSpan},
     mir::specifications::SpecificationsInterface,
     snapshot::interface::SnapshotEncoderInterface,
@@ -11,6 +12,7 @@ use log::{debug, trace};
 use prusti_common::config;
 use prusti_interface::data::ProcedureDefId;
 use prusti_rustc_interface::middle::{mir, ty, ty::GenericArgsRef};
+use prusti_rustc_interface::span::Span;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use prusti_interface::specs::typed::ProcedureSpecificationKind;
@@ -331,10 +333,11 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 substs,
             );
 
+            let is_bodyless = self.is_trusted(proc_def_id, Some(substs))
+                || !self.env().query.has_body(proc_def_id);
+
             let maybe_identifier: SpannedEncodingResult<vir_poly::FunctionIdentifier> = (|| {
                 let proc_kind = self.get_proc_kind(proc_def_id, Some(substs));
-                let is_bodyless = self.is_trusted(proc_def_id, Some(substs))
-                    || !self.env().query.has_body(proc_def_id);
                 let mut function = if is_bodyless {
                     pure_function_encoder.encode_bodyless_function()?
                 } else {
@@ -393,13 +396,14 @@ impl<'v, 'tcx: 'v> PureFunctionEncoderInterface<'v, 'tcx>
                 Err(error) => {
                     self.register_encoding_error(error);
                     debug!("Error encoding pure function: {:?}", proc_def_id);
-                    let body = self
-                        .env()
-                        .body
-                        .get_pure_fn_body(proc_def_id, substs, parent_def_id);
-                    // TODO(tymap): does stub encoder need substs?
-                    let stub_encoder = StubFunctionEncoder::new(self, proc_def_id, &body, substs);
-                    let function = stub_encoder.encode_function()?;
+                    let function = if !is_bodyless {
+                        let pure_fn_body = self.env().body.get_pure_fn_body(proc_def_id, substs, parent_def_id);
+                        let encoder = StubFunctionEncoder::new(self, proc_def_id, Some(&pure_fn_body), substs, pure_function_encoder.sig);
+                        encoder.encode_function()?
+                    } else {
+                        let encoder = StubFunctionEncoder::new(self, proc_def_id, None, substs, pure_function_encoder.sig);
+                        encoder.encode_function()?
+                    };
                     self.log_vir_program_before_viper(function.to_string());
                     let identifier = self.insert_function(function);
                     self.pure_function_encoder_state

--- a/prusti-viper/src/encoder/mod.rs
+++ b/prusti-viper/src/encoder/mod.rs
@@ -12,6 +12,7 @@ mod encoder;
 mod errors;
 mod foldunfold;
 mod initialisation;
+mod interface;
 mod loop_encoder;
 mod mir_encoder;
 mod mir_successor;

--- a/prusti-viper/src/encoder/stub_function_encoder.rs
+++ b/prusti-viper/src/encoder/stub_function_encoder.rs
@@ -8,7 +8,6 @@ use crate::encoder::{
     errors::{SpannedEncodingResult, WithSpan},
     high::generics::HighGenericsEncoderInterface,
     interface::PureFunctionFormalArgsEncoderInterface,
-    mir_encoder::{MirEncoder, PlaceEncoder},
     snapshot::interface::SnapshotEncoderInterface,
     Encoder,
 };
@@ -16,9 +15,7 @@ use log::debug;
 use prusti_rustc_interface::{
     hir::def_id::DefId,
     middle::{
-        mir,
-        mir::Local,
-        ty,
+        mir, ty,
         ty::{Binder, GenericArgsRef},
     },
     span::Span,
@@ -30,7 +27,6 @@ use super::mir::specifications::SpecificationsInterface;
 pub struct StubFunctionEncoder<'p, 'v: 'p, 'tcx: 'v> {
     encoder: &'p Encoder<'v, 'tcx>,
     mir: Option<&'p mir::Body<'tcx>>,
-    mir_encoder: Option<MirEncoder<'p, 'v, 'tcx>>,
     proc_def_id: DefId,
     substs: GenericArgsRef<'tcx>,
     sig: ty::PolyFnSig<'tcx>,
@@ -64,7 +60,6 @@ impl<'p, 'v: 'p, 'tcx: 'v> StubFunctionEncoder<'p, 'v, 'tcx> {
         StubFunctionEncoder {
             encoder,
             mir,
-            mir_encoder: mir.map(|m| MirEncoder::new(encoder, m, proc_def_id)),
             proc_def_id,
             substs,
             sig,

--- a/prusti-viper/src/encoder/stub_function_encoder.rs
+++ b/prusti-viper/src/encoder/stub_function_encoder.rs
@@ -4,10 +4,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::encoder::interface::PureFunctionFormalArgsEncoderInterface;
 use crate::encoder::{
     errors::{SpannedEncodingResult, WithSpan},
     high::generics::HighGenericsEncoderInterface,
+    interface::PureFunctionFormalArgsEncoderInterface,
     mir_encoder::{MirEncoder, PlaceEncoder},
     snapshot::interface::SnapshotEncoderInterface,
     Encoder,
@@ -15,7 +15,12 @@ use crate::encoder::{
 use log::debug;
 use prusti_rustc_interface::{
     hir::def_id::DefId,
-    middle::{mir, mir::Local, ty, ty::GenericArgsRef, ty::Binder},
+    middle::{
+        mir,
+        mir::Local,
+        ty,
+        ty::{Binder, GenericArgsRef},
+    },
     span::Span,
 };
 use vir_crate::polymorphic as vir;
@@ -28,11 +33,12 @@ pub struct StubFunctionEncoder<'p, 'v: 'p, 'tcx: 'v> {
     mir_encoder: Option<MirEncoder<'p, 'v, 'tcx>>,
     proc_def_id: DefId,
     substs: GenericArgsRef<'tcx>,
-    sig: ty::PolyFnSig<'tcx>
+    sig: ty::PolyFnSig<'tcx>,
 }
 
-impl <'p, 'v, 'tcx> PureFunctionFormalArgsEncoderInterface<'p, 'v, 'tcx> for StubFunctionEncoder<'p, 'v, 'tcx> {
-
+impl<'p, 'v, 'tcx> PureFunctionFormalArgsEncoderInterface<'p, 'v, 'tcx>
+    for StubFunctionEncoder<'p, 'v, 'tcx>
+{
     fn check_type(&self, _span: Span, _ty: Binder<ty::Ty<'tcx>>) -> SpannedEncodingResult<()> {
         Ok(())
     }
@@ -53,7 +59,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> StubFunctionEncoder<'p, 'v, 'tcx> {
         proc_def_id: DefId,
         mir: Option<&'p mir::Body<'tcx>>,
         substs: GenericArgsRef<'tcx>,
-        sig: ty::PolyFnSig<'tcx>
+        sig: ty::PolyFnSig<'tcx>,
     ) -> Self {
         StubFunctionEncoder {
             encoder,
@@ -61,12 +67,14 @@ impl<'p, 'v: 'p, 'tcx: 'v> StubFunctionEncoder<'p, 'v, 'tcx> {
             mir_encoder: mir.map(|m| MirEncoder::new(encoder, m, proc_def_id)),
             proc_def_id,
             substs,
-            sig
+            sig,
         }
     }
 
     fn default_span(&self) -> Span {
-        self.mir.map(|m| m.span).unwrap_or_else(|| self.encoder.get_spec_span(self.proc_def_id))
+        self.mir
+            .map(|m| m.span)
+            .unwrap_or_else(|| self.encoder.get_spec_span(self.proc_def_id))
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/vir/defs/polymorphic/ast/expr.rs
+++ b/vir/defs/polymorphic/ast/expr.rs
@@ -1454,6 +1454,20 @@ impl Expr {
         PlaceReplacer { replacements }.fold(self)
     }
 
+    pub fn has_old_expression(&self) -> bool {
+        struct OldFinder {
+            has_old: bool,
+        }
+        impl ExprWalker for OldFinder {
+            fn walk_labelled_old(&mut self, _labelled_old: &LabelledOld) {
+                self.has_old = true;
+            }
+        }
+        let mut walker = OldFinder { has_old: false };
+        walker.walk(self);
+        walker.has_old
+    }
+
     /// Replaces expressions like `old[l5](old[l5](_9.val_ref).foo.bar)`
     /// into `old[l5](_9.val_ref.foo.bar)`
     #[must_use]


### PR DESCRIPTION
It doesn't make sense to have `old()` expressions in postconditions of pure functions (since they don't modify the heap). Also, the `PureFunctionEncoder` can't handle them (resulting in internal/consistency errors).

This PR makes it an error to include `old()` in postconditions of pure functions. Resolves https://github.com/viperproject/prusti-dev/issues/1306

This PR also includes support for `StubFunctionEncoder` to handle bodyless functions (e.g. those from `#[extern_spec]`)