### PR TITLE
Updated snapshot injectivity axiom. 

### DIFF
--- a/prusti-tests/tests/verify/pass/pure-fn/pure_taking_self.rs
+++ b/prusti-tests/tests/verify/pass/pure-fn/pure_taking_self.rs
@@ -1,0 +1,18 @@
+use prusti_contracts::*;
+
+#[derive(Clone, Copy)]
+struct MyWrapper(u32);
+
+impl MyWrapper {
+    #[pure]
+    #[ensures(self === MyWrapper(result))]
+    fn unwrap(self) -> u32 {
+        self.0
+    }
+}
+
+fn test(x: MyWrapper) -> u32 {
+    x.unwrap()
+}
+
+fn main() { }

--- a/prusti-viper/src/encoder/definition_collector.rs
+++ b/prusti-viper/src/encoder/definition_collector.rs
@@ -250,7 +250,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> Collector<'p, 'v, 'tcx> {
                         // on an axiom, then we should also retain the axiom.
                         let mut used_snap_domain_function_prefixes = vec![];
                         let mut used_snap_domain_constructor = false;
-                        domain.functions.retain(|function| {
+                        for function in domain.functions.iter() {
                             let function_name = function.get_identifier();
                             let prefix = function_name.split("__").next().map(String::from);
                             let is_constructor = function_name.starts_with("cons");
@@ -260,11 +260,8 @@ impl<'p, 'v: 'p, 'tcx: 'v> Collector<'p, 'v, 'tcx> {
                             {
                                 used_snap_domain_function_prefixes.extend(prefix);
                                 used_snap_domain_constructor |= is_constructor;
-                                true
-                            } else {
-                                false
                             }
-                        });
+                        }
                         domain.axioms.retain(|axiom| {
                             let used = used_snap_domain_function_prefixes
                                 .iter()
@@ -272,9 +269,34 @@ impl<'p, 'v: 'p, 'tcx: 'v> Collector<'p, 'v, 'tcx> {
                             let retain_type_invariant = axiom.name.ends_with("$valid") && used;
                             let retain_injectivity = used_snap_domain_constructor
                                 && axiom.name.ends_with("$injectivity");
-                            let retain_field_axiom = used_snap_domain_constructor && used;
+                            let retain_field_axiom = used_snap_domain_constructor
+                                && axiom.name.ends_with("$axiom");
 
                             retain_type_invariant || retain_injectivity || retain_field_axiom
+                        });
+                        struct Walker {
+                            function_names: FxHashSet<String>
+                        }
+
+                        impl ExprWalker for Walker {
+                            fn walk_domain_func_app(&mut self, function_call: &vir::DomainFuncApp) {
+                                self.function_names.insert(function_call.domain_function.get_identifier());
+                            }
+                        }
+                        let mut functions_in_axioms: FxHashSet<String> = Default::default();
+                        for axiom in domain.axioms.iter() {
+                            let mut walker = Walker {
+                                function_names: Default::default()
+                            };
+                            walker.walk(&axiom.expr);
+                            functions_in_axioms.extend(walker.function_names);
+                        }
+                        domain.functions.retain(|function| {
+                            let function_name = function.get_identifier();
+                            self
+                                .used_snap_domain_functions
+                                .contains(&function_name.clone().into())
+                            || functions_in_axioms.contains(&function_name)
                         });
                     }
                 }

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -1841,7 +1841,7 @@ impl SnapshotEncoder {
                     .map(|f| {
                         let field_access_func = field_access_funcs
                             .get(&f.name)
-                            .expect(&format!("No accessor for field {}", f.name));
+                            .unwrap_or_else(|| panic!("No accessor for field {}", f.name));
                         field_access_func.apply(vec![self_expr.clone()])
                     })
                     .collect();

--- a/prusti-viper/src/encoder/snapshot/encoder.rs
+++ b/prusti-viper/src/encoder/snapshot/encoder.rs
@@ -1745,36 +1745,6 @@ impl SnapshotEncoder {
                 constructor.apply(args.iter().cloned().map(Expr::local).collect())
             };
 
-            if has_args {
-                // encode injectivity axiom of constructor
-                let lhs_args = encode_prefixed_args("_l");
-                let rhs_args = encode_prefixed_args("_r");
-
-                let lhs_call = encode_constructor_call(&lhs_args);
-                let rhs_call = encode_constructor_call(&rhs_args);
-
-                let mut forall_vars = vec![];
-                forall_vars.extend(lhs_args.iter().cloned());
-                forall_vars.extend(rhs_args.iter().cloned());
-
-                let conjunction = lhs_args
-                    .iter()
-                    .cloned()
-                    .zip(rhs_args.iter().cloned())
-                    .map(|(l, r)| Expr::eq_cmp(Expr::local(l), Expr::local(r)))
-                    .conjoin();
-
-                domain_axioms.push(vir::DomainAxiom {
-                    comment: None,
-                    name: format!("{domain_name}${variant_idx}$injectivity"),
-                    expr: forall_or_body(
-                        forall_vars,
-                        vec![vir::Trigger::new(vec![lhs_call.clone(), rhs_call.clone()])],
-                        Expr::implies(Expr::eq_cmp(lhs_call, rhs_call), conjunction),
-                    ),
-                    domain_name: domain_name.to_string(),
-                });
-            }
 
             if has_multiple_variants {
                 // encode discriminant axiom
@@ -1799,12 +1769,15 @@ impl SnapshotEncoder {
 
             let mut field_access_funcs = FxHashMap::default();
 
+            let self_local = vir::LocalVar::new("self", snapshot_type.clone());
+            let self_expr = Expr::local(self_local.clone());
+
             for (field_idx, field) in variant.fields.iter().enumerate() {
                 // encode field access function
                 let field_access_func = vir::DomainFunc {
                     name: format!("{}${}$field${}", domain_name, variant_idx, field.name),
                     type_arguments: Vec::new(), // FIXME: This is most likely wrong.
-                    formal_args: vec![vir::LocalVar::new("self", snapshot_type.clone())],
+                    formal_args: vec![self_local.clone()],
                     return_type: field.typ.clone(),
                     unique: false,
                     domain_name: domain_name.to_string(),
@@ -1823,7 +1796,7 @@ impl SnapshotEncoder {
                         name: format!("{}${}$field${}$axiom", domain_name, variant_idx, field.name),
                         expr: forall_or_body(
                             args.clone(),
-                            vec![vir::Trigger::new(vec![field_of_cons.clone()])],
+                            vec![vir::Trigger::new(vec![call.clone()])],
                             Expr::eq_cmp(
                                 field_of_cons.clone(),
                                 Expr::local(args[field_idx].clone()),
@@ -1840,8 +1813,6 @@ impl SnapshotEncoder {
                     | ty::TyKind::Uint(_)
                     | ty::TyKind::Float(_)
                     | ty::TyKind::Char => domain_axioms.push({
-                        let self_local = vir::LocalVar::new("self", snapshot_type.clone());
-                        let self_expr = Expr::local(self_local.clone());
                         let field_of_self = field_access_func.apply(vec![self_expr.clone()]);
 
                         vir::DomainAxiom {
@@ -1864,6 +1835,33 @@ impl SnapshotEncoder {
 
                     _ => {}
                 }
+            }
+
+            if has_args {
+                let field_access_apps: Vec<_> = variant.fields.iter().map(
+                    |f| {
+                        let field_access_func = field_access_funcs.get(&f.name).expect(&format!("No accessor for field {}", f.name));
+                        field_access_func.apply(vec![self_expr.clone()])
+                    }
+                ).collect();
+                let expr = Expr::forall(
+                    vec![self_local.clone()],
+                    field_access_apps.iter().map(|e|
+                        vir::Trigger::new(
+                            vec![e.clone()]
+                        )).collect(),
+                    Expr::eq_cmp(
+                        self_expr.clone(),
+                        constructor.apply(field_access_apps)
+                    )
+                );
+
+                domain_axioms.push(vir::DomainAxiom {
+                    comment: None,
+                    name: format!("{domain_name}${variant_idx}$injectivity"),
+                    expr,
+                    domain_name: domain_name.to_string(),
+                });
             }
 
             variant_domain_funcs.push((constructor.clone(), field_access_funcs));


### PR DESCRIPTION
The snapshot domain axioms do not currently ensure that a snapshot for a variant must correspond to a constructor invocation. As a consequence, given snapshots `s1` and `s2` that return the same values for all field access functions, we cannot prove `s1 == s2` (see the included test).

This PR introduces a new injectivity axiom, asserting that each variant snapshot corresponds to a constructor invocation:
```
forall this: Variant :: 
  {field1(this), field2(this), ...}
  this == cons(field1(this), field2(this), ...)
```

The replaces the current injectivity axiom:
```
forall _l_args..., _r_args... :: {cons(_l_args...), cons(_r_args)}
    cons(_l_args...) == cons(_r_args) ==> _l_args... == _r_args...
```

The trigger on field access axioms is also made more permissive. This is necessary because the new injectivity axiom is only triggered on field access (and not on snapshot construction).

Previous: `forall args... :: {field(cons(arg_field, other_args...))} field(cons(arg_field, other_args...)) == arg_field`
New: `forall args... :: {cons(arg_field, other_args...)} field(cons(arg_field, other_args...)) == arg_field`

Finally, `DefinitionCollector` is updated to ensure that functions used in the triggers of domain axioms are always preserved.