### PR TITLE
Fix `get_target_dir` and build.py to make packaging work properly with new prusti_contracts dir

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,10 +36,10 @@ jobs:
         run: python x.py setup
 
       - name: Build with cargo --release
-        run: python x.py build --release --all
+        run: python x.py build --release --all --jobs 1
 
       - name: Run cargo tests --release
-        run: python x.py test --release --all
+        run: python x.py test --release --all --jobs 1
 
       - name: Package Prusti artifact
         run: python x.py package release prusti_artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,7 +255,7 @@ jobs:
         run: python x.py test --all --jobs 1
       - name: Run a subset of tests with Carbon
         run: |
-            python x.py test pass/no-annotation --all --verbose
+            python x.py test pass/no-annotation --all --verbose --jobs 1
         env:
           PRUSTI_VIPER_BACKEND: carbon
       - name: Check prusti-contracts

--- a/prusti-utils/src/launch/mod.rs
+++ b/prusti-utils/src/launch/mod.rs
@@ -55,10 +55,11 @@ pub fn get_prusti_contracts_build_target_dir(target_dir: &Path) -> PathBuf {
 pub fn get_prusti_contracts_dir(exe_dir: &Path) -> Option<PathBuf> {
     let a_prusti_contracts_file = format!("lib{}.rlib", PRUSTI_LIBS[0].replace('-', "_"));
 
-    // Libraries in the Prusti artifact will show up here
     if exe_dir.join(&a_prusti_contracts_file).exists() {
+        // If this branch is entered, then this is the Prusti Artifact
         return Some(exe_dir.to_path_buf());
     } else if let Some(target_dir) = get_target_dir(exe_dir) {
+        // If this branch is entered, then we're building Prusti
         let candidate = get_prusti_contracts_build_target_dir(&target_dir)
             .join("verify")
             .join(BUILD_MODE);

--- a/x.py
+++ b/x.py
@@ -233,17 +233,17 @@ def package(mode: str, package_path: str):
         (f"target/{mode}/prusti-server*", "."),
         (f"target/{mode}/prusti-rustc*", "."),
         (f"target/{mode}/cargo-prusti*", "."),
-        (f"target/verify/{mode}/libprusti_contracts.*", "."),
-        (f"target/verify/{mode}/deps/libprusti_contracts_proc_macros-*", "deps"),
-        (f"target/verify/{mode}/deps/prusti_contracts_proc_macros-*.dll", "deps"),
-        (f"target/verify/{mode}/libprusti_std.*", "."),
-        (f"target/verify/{mode}/deps/libprusti_contracts-*", "deps"),
-        (f"target/verify/{mode}/deps/prusti_contracts-*.dll", "deps"),
+        (f"target/prusti-contracts/{mode}/verify/{mode}/libprusti_contracts.*", "."),
+        (f"target/prusti-contracts/{mode}/verify/{mode}/deps/libprusti_contracts_proc_macros-*", "deps"),
+        (f"target/prusti-contracts/{mode}/verify/{mode}/deps/prusti_contracts_proc_macros-*.dll", "deps"),
+        (f"target/prusti-contracts/{mode}/verify/{mode}/libprusti_std.*", "."),
+        (f"target/prusti-contracts/{mode}/verify/{mode}/deps/libprusti_contracts-*", "deps"),
+        (f"target/prusti-contracts/{mode}/verify/{mode}/deps/prusti_contracts-*.dll", "deps"),
     ]
     exclude_paths = [
         f"target/{mode}/*.d",
-        f"target/verify/{mode}/*.d",
-        f"target/verify/{mode}/deps/*.d",
+        f"target/prusti-contracts/{mode}/verify/{mode}/*.d",
+        f"target/prusti-contracts/{mode}/verify/{mode}/deps/*.d",
     ]
     actual_exclude_set = set(path for pattern in exclude_paths for path in glob.glob(pattern))
     logging.debug(f"The number of excluded paths is: {len(actual_exclude_set)}")


### PR DESCRIPTION
PR https://github.com/viperproject/prusti-dev/pull/1476 did not update the build script to also package Prusti correctly.

This fixes the workflow by locating the files in the correct location, and also fixes some bugs related to finding the `prusti-contracts` library from the artifact.
