### PR TITLE
Raise an error if old() expressions are used in local vars outside of loops

### DIFF
--- a/prusti-tests/tests/verify/fail/fold-unfold/old-local.rs
+++ b/prusti-tests/tests/verify/fail/fold-unfold/old-local.rs
@@ -1,0 +1,10 @@
+extern crate prusti_contracts;
+use prusti_contracts::*;
+
+fn blah(y: i32){
+    let x = 1;
+    prusti_assert!(old(x) == 1); //~ ERROR local variables are not supported in old
+}
+
+fn main(){
+}

--- a/prusti-tests/tests/verify/fail/fold-unfold/old-local.rs
+++ b/prusti-tests/tests/verify/fail/fold-unfold/old-local.rs
@@ -3,7 +3,7 @@ use prusti_contracts::*;
 
 fn blah(y: i32){
     let x = 1;
-    prusti_assert!(old(x) == 1); //~ ERROR local variables are not supported in old
+    prusti_assert!(old(x) == 1); //~ ERROR old expressions should not contain local variables
 }
 
 fn main(){

--- a/prusti-tests/tests/verify/pass/quick/old-in-loop.rs
+++ b/prusti-tests/tests/verify/pass/quick/old-in-loop.rs
@@ -1,0 +1,20 @@
+use prusti_contracts::*;
+
+pub struct Wrapper(u32);
+
+impl Wrapper {
+    #[pure]
+    pub fn get(&self) -> u32 {
+        self.0
+    }
+
+}
+
+fn capitalize(vec: &mut Wrapper) {
+    while true {
+        body_invariant!(vec.get() == old(vec.get()));
+    }
+}
+
+fn main(){
+}

--- a/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
+++ b/prusti-viper/src/encoder/mir/pure/interpreter/interpreter_poly.rs
@@ -35,8 +35,8 @@ use prusti_rustc_interface::{
     middle::{mir, span_bug, ty},
 };
 use rustc_hash::FxHashMap;
-use std::{convert::TryInto, mem};
-use vir_crate::polymorphic::{self as vir};
+use std::{collections::HashSet, convert::TryInto, mem};
+use vir_crate::polymorphic::{self as vir, ExprWalker};
 
 pub(crate) struct PureFunctionBackwardInterpreter<'p, 'v: 'p, 'tcx: 'v> {
     encoder: &'p Encoder<'v, 'tcx>,
@@ -49,6 +49,7 @@ pub(crate) struct PureFunctionBackwardInterpreter<'p, 'v: 'p, 'tcx: 'v> {
     /// DefId of the caller. Used for error reporting.
     caller_def_id: DefId,
     def_id: DefId, // TODO(tymap): is this actually caller_def_id?
+    arg_var_names: HashSet<String>,
 }
 
 /// This encoding works backward, so there is the risk of generating expressions whose length
@@ -62,13 +63,19 @@ impl<'p, 'v: 'p, 'tcx: 'v> PureFunctionBackwardInterpreter<'p, 'v, 'tcx> {
         pure_encoding_context: PureEncodingContext,
         caller_def_id: DefId,
     ) -> Self {
+        let mir_encoder = MirEncoder::new(encoder, mir, def_id);
+        let arg_var_names = mir
+            .args_iter()
+            .map(|arg| mir_encoder.encode_local_var_name(arg))
+            .collect();
         PureFunctionBackwardInterpreter {
             encoder,
             mir,
-            mir_encoder: MirEncoder::new(encoder, mir, def_id),
+            mir_encoder,
             pure_encoding_context,
             caller_def_id,
             def_id,
+            arg_var_names,
         }
     }
 
@@ -430,6 +437,33 @@ impl<'p, 'v: 'p, 'tcx: 'v> BackwardMirInterpreter<'tcx>
                         match full_func_proc_name {
                             "prusti_contracts::old" => {
                                 assert_eq!(args.len(), 1);
+
+                                struct InvalidInOldFinder<'a> {
+                                    has_invalid: bool,
+                                    local_vars: &'a HashSet<String>,
+                                }
+
+                                impl<'a> vir::ExprWalker for InvalidInOldFinder<'a> {
+                                    fn walk_local_var(&mut self, expr: &vir::LocalVar) {
+                                        if !self.local_vars.contains(&expr.name) {
+                                            self.has_invalid = true;
+                                        }
+                                    }
+                                }
+
+                                let mut invalid_finder = InvalidInOldFinder {
+                                    has_invalid: false,
+                                    local_vars: &self.arg_var_names,
+                                };
+
+                                invalid_finder.walk(&encoded_args[0]);
+
+                                if invalid_finder.has_invalid {
+                                    return Err(SpannedEncodingError::unsupported(
+                                        "local variables are not supported in old() expressions",
+                                        span,
+                                    ));
+                                }
 
                                 // Return an error for unsupported old(..) types
 

--- a/prusti-viper/src/encoder/procedure_encoder.rs
+++ b/prusti-viper/src/encoder/procedure_encoder.rs
@@ -246,9 +246,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                 if self.encoder.get_prusti_assumption(cl_def_id).is_none() {
                     return Ok(false);
                 }
-                let assume_expr =
-                    self.encoder
-                        .encode_invariant(self.mir, bb, self.proc_def_id, cl_substs)?;
+                let assume_expr = self.encoder.encode_invariant(
+                    self.mir,
+                    bb,
+                    self.proc_def_id,
+                    cl_substs,
+                    false,
+                )?;
 
                 let assume_stmt = vir::Stmt::Inhale(vir::Inhale { expr: assume_expr });
 
@@ -281,9 +285,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     .encoder
                     .get_definition_span(assertion.assertion.to_def_id());
 
-                let assert_expr =
-                    self.encoder
-                        .encode_invariant(self.mir, bb, self.proc_def_id, cl_substs)?;
+                let assert_expr = self.encoder.encode_invariant(
+                    self.mir,
+                    bb,
+                    self.proc_def_id,
+                    cl_substs,
+                    false,
+                )?;
 
                 let assert_stmt = vir::Stmt::Assert(vir::Assert {
                     expr: assert_expr,
@@ -319,9 +327,13 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                     .encoder
                     .get_definition_span(refutation.refutation.to_def_id());
 
-                let refute_expr =
-                    self.encoder
-                        .encode_invariant(self.mir, bb, self.proc_def_id, cl_substs)?;
+                let refute_expr = self.encoder.encode_invariant(
+                    self.mir,
+                    bb,
+                    self.proc_def_id,
+                    cl_substs,
+                    false,
+                )?;
 
                 let refute_stmt = vir::Stmt::Refute(vir::Refute {
                     expr: refute_expr,
@@ -5566,6 +5578,7 @@ impl<'p, 'v: 'p, 'tcx: 'v> ProcedureEncoder<'p, 'v, 'tcx> {
                             bbi,
                             self.proc_def_id,
                             cl_substs,
+                            true,
                         )?);
                         let invariant = match spec {
                             prusti_interface::specs::typed::LoopSpecification::Invariant(inv) => {


### PR DESCRIPTION
If an expression `old(E)` is used within an `assert` statement, and `E` contains a local variable, then the fold-unfold algorithm will raise an error. This PR changes Prusti to detect such patterns and present a user-friendly error instead.