### PR TITLE
Make `ignore_deps_contracts` a "category B" flag

### DIFF
--- a/prusti-launch/src/bin/cargo-prusti.rs
+++ b/prusti-launch/src/bin/cargo-prusti.rs
@@ -58,6 +58,10 @@ where
             "PRUSTI_NO_VERIFY_DEPS",
             config::no_verify_deps().to_string(),
         )
+        .env(
+            "PRUSTI_IGNORE_DEPS_CONTRACTS",
+            config::ignore_deps_contracts().to_string(),
+        )
         // Category A* flags:
         .env("DEFAULT_PRUSTI_QUIET", "true")
         .env("DEFAULT_PRUSTI_FULL_COMPILATION", "true")


### PR DESCRIPTION
This way, the `ignore_deps_contracts` declared in a `Prusti.toml` will be passed to all the `prusti-rustc` runs that compile the dependencies of a project. Without this, the flag can only be set via the environment variable `PRUSTI_IGNORE_DEPS_CONTRACTS`.