### PR TITLE
Fix incorrect environment variable name

### DIFF
--- a/docs/user-guide/src/verify/counterexample.md
+++ b/docs/user-guide/src/verify/counterexample.md
@@ -1,7 +1,7 @@
 # Printing Counterexamples
 
 Prusti can print counterexamples for verification failures, i.e., values for variables that violate some assertion or pre-/postcondition.
-This can be enabled by setting [`counterexample = true`](https://viperproject.github.io/prusti-dev/dev-guide/config/flags.html#counterexample) in the `Prusti.toml` file, or with the `PRUSTI_COUNTEREXAMPLES=true` environment variable.
+This can be enabled by setting [`counterexample = true`](https://viperproject.github.io/prusti-dev/dev-guide/config/flags.html#counterexample) in the `Prusti.toml` file, or with the `PRUSTI_COUNTEREXAMPLE=true` environment variable.
 
 For example:
 ```rust,noplaypen


### PR DESCRIPTION
The docs currently describe the incorrect environment variables for finding counterexamples. The variable should be `PRUSTI_COUNTEREXAMPLE`, not `PRUSTI_COUNTEREXAMPLES`.